### PR TITLE
README and per-game documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,73 @@
-# React + TypeScript + Vite
+# Card table
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A **browser-only** card table built with **React**, **TypeScript**, and **Vite**. Games load **YAML** deck definitions and per-game manifests; each title is implemented as a TypeScript **game module** that drives table zones, legal actions, and optional **multi-round match** scoring (points or chip-style bankrolls).
 
-Currently, two official plugins are available:
+## Requirements
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+- **Node.js** (20+ or current LTS recommended)
+- **npm** (comes with Node)
 
-## React Compiler
+## Run locally
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+Install dependencies:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Start the dev server (hot reload):
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run dev
 ```
+
+Then open the URL Vite prints (usually `http://localhost:5173`).
+
+Production build and local preview of the built assets:
+
+```bash
+npm run build
+npm run preview
+```
+
+Lint:
+
+```bash
+npm run lint
+```
+
+## Available games
+
+Pick a game from the in-app **Game** menu. Each row links to a short note in [`docs/`](docs/).
+
+| Game id | Description | Doc |
+|--------|-------------|-----|
+| `war` | Compare high cards; winner takes the trick. | [War](docs/war.md) |
+| `demo-custom` | Simple duel using the small **example-custom** deck. | [Custom deck duel](docs/demo-custom.md) |
+| `go-fish` | Ask opponents for ranks and collect books (configurable AI count). | [Go Fish](docs/go-fish.md) |
+| `skyjo` | Flip/swap/dump on a numbered Skyjo deck; match play to a target score. | [Skyjo](docs/skyjo.md) |
+| `blackjack` | Heads-up blackjack vs dealer with chip match. | [Blackjack](docs/blackjack.md) |
+| `casino-blackjack` | Same rules as blackjack; different default stacks / match target. | [Casino Blackjack](docs/casino-blackjack.md) |
+| `baccarat` | Bet player or banker; two-card totals modulo 10. | [Baccarat](docs/baccarat.md) |
+| `mini-baccarat` | Same engine as baccarat; tuned manifest defaults. | [Mini Baccarat](docs/mini-baccarat.md) |
+| `crazy-eights` | Shed cards; match suit/rank or play an 8 and call suit. | [Crazy Eights](docs/crazy-eights.md) |
+| `switch` | Same engine as Crazy Eights (alternate manifest). | [Switch](docs/switch.md) |
+| `poker-draw` | Heads-up 5-card draw with ante and simplified showdown. | [Poker (5-card draw)](docs/poker-draw.md) |
+| `heads-up-poker` | Same module as poker-draw; alternate match settings. | [Heads-up poker](docs/heads-up-poker.md) |
+| `high-card-duel` | Higher single card wins the pot (5 or 10 chip bets). | [High-card duel](docs/high-card-duel.md) |
+| `red-dog` | Same engine as high-card duel (alternate manifest). | [Red Dog](docs/red-dog.md) |
+| `uno` | Uno-style shedding game on the custom **uno** deck (108 cards). | [Uno](docs/uno.md) |
+
+## Repository layout (overview)
+
+| Path | Role |
+|------|------|
+| [`src/decks/`](src/decks/) | Deck YAML (standard 52, Skyjo, Uno, examples). |
+| [`src/games/<name>/`](src/games/) | Manifest YAML + `index.ts` game module per title or family. |
+| [`src/core/`](src/core/) | Table model, deck parsing, match state, registry. |
+| [`src/data/manifests.ts`](src/data/manifests.ts) | Wires game and deck ids to bundled YAML. |
+| [`docs/`](docs/) | Per-game markdown notes (rules as implemented in-app). |
+
+## Contributing
+
+Add or change a game by extending the registry, deck, and module pattern used in `src/games/`. See the relevant file under [`docs/`](docs/) for behavior-specific notes.

--- a/docs/baccarat.md
+++ b/docs/baccarat.md
@@ -1,0 +1,9 @@
+# Baccarat
+
+**Id:** `baccarat` · **Module:** `baccarat` · **Deck:** standard 52-card
+
+Punto banco–style **two-card** hands for “player” and “banker” seats. Totals are taken **modulo 10** (face cards and tens count as zero). You place a chip bet on **Player** or **Banker** (same payoff in this implementation; commission is not modeled).
+
+**Chips / match:** bankrolls and round deltas feed the multi-round match — see [`src/games/baccarat/baccarat.yaml`](../src/games/baccarat/baccarat.yaml).
+
+**Also see:** [Mini Baccarat](mini-baccarat.md) (same engine).

--- a/docs/blackjack.md
+++ b/docs/blackjack.md
@@ -1,0 +1,9 @@
+# Blackjack
+
+**Id:** `blackjack` · **Module:** `blackjack` · **Deck:** standard 52-card
+
+Heads-up **blackjack** vs a dealer seat: place a bet, receive two cards, then **Hit** or **Stand**. Dealer hits to a fixed threshold. Natural blackjacks pay 3:2 where implemented; bust loses the bet.
+
+**Chips / match:** cumulative scores represent **chip stacks** (`scoringMode: chips`). Default manifest uses a starting stack and a target chip total to win the match — see [`src/games/blackjack/blackjack.yaml`](../src/games/blackjack/blackjack.yaml).
+
+**Also see:** [Casino Blackjack](casino-blackjack.md) (same module, different defaults).

--- a/docs/casino-blackjack.md
+++ b/docs/casino-blackjack.md
@@ -1,0 +1,7 @@
+# Casino Blackjack
+
+**Id:** `casino-blackjack` · **Module:** `blackjack` (shared with [Blackjack](blackjack.md))
+
+Same rules and UI actions as **Blackjack** — bet, hit, stand, round scoring, and **Next round (apply scores)** when a hand completes.
+
+**Difference:** manifest-only tweaks (e.g. larger starting stack and higher match target). See [`src/games/blackjack/casino-blackjack.yaml`](../src/games/blackjack/casino-blackjack.yaml).

--- a/docs/crazy-eights.md
+++ b/docs/crazy-eights.md
@@ -1,0 +1,9 @@
+# Crazy Eights
+
+**Id:** `crazy-eights` · **Module:** `crazy-eights` · **Deck:** standard 52-card
+
+Shedding game: play a card that matches the **current suit** or **rank** of the top discard, or play any **8** and declare the next suit. Draw from stock if you cannot play (house rules as implemented).
+
+**Players:** 2–4 (human + AIs). Match scoring can award a point to the player who goes out first — see manifest.
+
+**Also see:** [Switch](switch.md) (same module, alternate YAML).

--- a/docs/demo-custom.md
+++ b/docs/demo-custom.md
@@ -1,0 +1,11 @@
+# Custom deck duel (demo)
+
+**Id:** `demo-custom` · **Module:** `demo-custom` · **Deck:** `example-custom`
+
+A minimal sample game using the small custom symbol deck from [`src/decks/example-custom.yaml`](../src/decks/example-custom.yaml). Useful as a template for how custom templates and zones behave in the shell.
+
+**Players:** one human vs one AI.
+
+**Match:** none.
+
+Use **Play round** (or the game’s primary control) as indicated in the UI to advance the scripted duel.

--- a/docs/go-fish.md
+++ b/docs/go-fish.md
@@ -1,0 +1,9 @@
+# Go Fish
+
+**Id:** `go-fish` · **Module:** `go-fish` · **Deck:** standard 52-card
+
+Classic **Go Fish**: ask another player for a rank you hold; if they have any, you collect them; otherwise “go fish” from the stock. Completing a four-of-a-kind forms a **book**. The shell supports configurable **AI opponent count** (1–8) and per-seat **AI difficulty** when multiple AIs are enabled.
+
+**Interaction:** choose a rank from your hand, then click an opponent’s hand or books pile to ask. **Pass** appears when the rules allow skipping your turn.
+
+**Match:** optional in manifest; default play is table-focused with books and hand zones.

--- a/docs/heads-up-poker.md
+++ b/docs/heads-up-poker.md
@@ -1,0 +1,7 @@
+# Heads-up poker
+
+**Id:** `heads-up-poker` · **Module:** `poker-draw` (shared with [Poker (5-card draw)](poker-draw.md))
+
+Same heads-up draw poker flow: ante, draw round, showdown.
+
+**Difference:** manifest-only (stacks / targets). See [`src/games/poker-draw/heads-up-poker.yaml`](../src/games/poker-draw/heads-up-poker.yaml).

--- a/docs/high-card-duel.md
+++ b/docs/high-card-duel.md
@@ -1,0 +1,9 @@
+# High-card duel
+
+**Id:** `high-card-duel` · **Module:** `high-card-duel` · **Deck:** standard 52-card
+
+Each side antes **5** or **10** chips (when both can cover it), then one card is dealt to each hand; **higher rank wins** the pot (aces high). Ties refund the antes.
+
+**Chips / match:** see [`src/games/high-card-duel/high-card-duel.yaml`](../src/games/high-card-duel/high-card-duel.yaml).
+
+**Also see:** [Red Dog](red-dog.md) (same engine).

--- a/docs/mini-baccarat.md
+++ b/docs/mini-baccarat.md
@@ -1,0 +1,7 @@
+# Mini Baccarat
+
+**Id:** `mini-baccarat` · **Module:** `baccarat` (shared with [Baccarat](baccarat.md))
+
+Same flow as **Baccarat**: choose bet size and side, then the round resolves from the dealt hands.
+
+**Difference:** separate manifest entry (name / defaults). Compare [`src/games/baccarat/mini-baccarat.yaml`](../src/games/baccarat/mini-baccarat.yaml) with [`baccarat.yaml`](../src/games/baccarat/baccarat.yaml).

--- a/docs/poker-draw.md
+++ b/docs/poker-draw.md
@@ -1,0 +1,9 @@
+# Poker (5-card draw)
+
+**Id:** `poker-draw` · **Module:** `poker-draw` · **Deck:** standard 52-card
+
+Heads-up **five-card draw**: pay the **ante**, receive five cards, then choose how many cards to replace from the **front** of the hand (0–3; mirrored for the opponent). **Highest hand** wins the pot by simplified rank ordering.
+
+**Chips / match:** antes and pots adjust chip stacks; match ends at a chip target — see [`src/games/poker-draw/poker-draw.yaml`](../src/games/poker-draw/poker-draw.yaml).
+
+**Also see:** [Heads-up poker](heads-up-poker.md) (same module).

--- a/docs/red-dog.md
+++ b/docs/red-dog.md
@@ -1,0 +1,7 @@
+# Red Dog
+
+**Id:** `red-dog` · **Module:** `high-card-duel` (shared with [High-card duel](high-card-duel.md))
+
+Uses the same high-card duel flow and betting buttons.
+
+**Difference:** alternate manifest only — [`src/games/high-card-duel/red-dog.yaml`](../src/games/high-card-duel/red-dog.yaml).

--- a/docs/skyjo.md
+++ b/docs/skyjo.md
@@ -1,0 +1,11 @@
+# Skyjo
+
+**Id:** `skyjo` · **Module:** `skyjo` · **Deck:** Skyjo distribution (`src/decks/skyjo.yaml`)
+
+Skyjo-style round play: grid of face-down/face-up cards, draw pile, discard, and scoring toward a **match target** (manifest default: reach cumulative rules with **lowest** total winning the match when the threshold is met — see manifest for `targetScore` / `winnerIs`).
+
+**Players:** human vs one or more AIs; per-seat **AI difficulty** is supported.
+
+**UI:** follow the on-screen hints for dump & flip, swap, and discard flows.
+
+See [`src/games/skyjo/skyjo.yaml`](../src/games/skyjo/skyjo.yaml) for bundled match parameters.

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -1,0 +1,7 @@
+# Switch
+
+**Id:** `switch` · **Module:** `crazy-eights` (shared with [Crazy Eights](crazy-eights.md))
+
+**Switch** uses the same engine as Crazy Eights (discard matching, eights, draw). Pick this entry for an alternate packaged manifest / labeling.
+
+Compare [`src/games/crazy-eights/switch.yaml`](../src/games/crazy-eights/switch.yaml) with [`crazy-eights.yaml`](../src/games/crazy-eights/crazy-eights.yaml).

--- a/docs/uno.md
+++ b/docs/uno.md
@@ -1,0 +1,13 @@
+# Uno
+
+**Id:** `uno` · **Module:** `uno` · **Deck:** `uno` (108 cards in [`src/decks/uno.yaml`](../src/decks/uno.yaml))
+
+Uno-style shedding: match the **current color** or the **face** of the top discard, or play **Wild** / **Wild +4**. Action cards (**Skip**, **Reverse**, **Draw two**) follow the usual flow; two-player reverses/skips behave like common house rules (opponent may lose a turn).
+
+**Draw:** if you have no legal play, draw one card; you may play that card or end your turn, as implemented in the action list.
+
+**Match:** first to **500** points from round wins (opponents’ remaining cards scored) — see [`src/games/uno/uno.yaml`](../src/games/uno/uno.yaml).
+
+**Players:** 2–4 (human + AIs).
+
+*Uno® is a trademark of Mattel. This is an independent fan-style implementation for the table engine.*

--- a/docs/war.md
+++ b/docs/war.md
@@ -1,0 +1,11 @@
+# War
+
+**Id:** `war` · **Module:** `war` · **Deck:** standard 52-card
+
+Two players split the deck and reveal one card per round; higher rank wins both cards (standard rank order). Ties can trigger “war” sequences depending on implementation.
+
+**Players:** one human vs one AI (fixed).
+
+**Match:** none — single continuous session unless you use **New deal** / **End game**.
+
+See the in-app status line for the current phase and outcome text.


### PR DESCRIPTION
## Summary
- Replace the Vite template README with project-specific documentation: what the app is, how to install and run it locally, and how the repo is organized.
- Add `docs/` with one markdown file per selectable game id, including shared-engine variants (e.g. Switch vs Crazy Eights) with cross-links.

## Test plan
- [ ] Read README on branch; confirm npm commands match package.json
- [ ] Spot-check doc links from README table to `docs/*.md` on GitHub

Made with [Cursor](https://cursor.com)