### PR TITLE
Rules modal with per-game markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Then open the URL Vite prints (usually `http://localhost:5173`).
 
 Choosing another entry in the **Game** menu updates the selection only; press **Start deal** (or **New deal** when a hand is already on the table) to shuffle and play.
 
+Use **Rules** (next to **End game**) to open a modal with the in-app rules for the **currently selected** game (you can read them before **Start deal**).
+
 Production build and local preview of the built assets:
 
 ```bash
@@ -68,7 +70,8 @@ Pick a game from the in-app **Game** menu. Each row links to a short note in [`d
 | [`src/games/<name>/`](src/games/) | Manifest YAML + `index.ts` game module per title or family. |
 | [`src/core/`](src/core/) | Table model, deck parsing, match state, registry. |
 | [`src/data/manifests.ts`](src/data/manifests.ts) | Wires game and deck ids to bundled YAML. |
-| [`docs/`](docs/) | Per-game markdown notes (rules as implemented in-app). |
+| [`src/rules/`](src/rules/) | In-app rules copy (markdown) shown in the **Rules** modal; see [`src/data/rulesSources.ts`](src/data/rulesSources.ts). |
+| [`docs/`](docs/) | Longer per-game notes (repo docs; can diverge slightly from the modal text). |
 
 ## Contributing
 

--- a/src/App.css
+++ b/src/App.css
@@ -350,3 +350,66 @@
   font-family: var(--mono, ui-monospace, monospace);
   font-size: 0.85em;
 }
+
+/* Rules modal */
+.app__modalBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.55);
+  box-sizing: border-box;
+}
+
+.app__modal {
+  width: min(36rem, 100%);
+  max-height: min(85vh, 32rem);
+  display: flex;
+  flex-direction: column;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border, #2e303a);
+  background: var(--bg, #16171d);
+  color: var(--text-h, #f3f4f6);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+.app__modalHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border, #2e303a);
+}
+
+.app__modalTitle {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.app__modalBody {
+  padding: 0.85rem 1rem 1.1rem;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.app__rulesMarkdown {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.app__rulesParagraph {
+  margin: 0 0 0.75rem;
+}
+
+.app__rulesParagraph:last-child {
+  margin-bottom: 0;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { type MatchState } from './core/match'
 import { playerSeatLabel } from './core/playerLabels'
 import { createSession, startNextMatchRound, type CreateSessionOptions, type GameSession } from './session'
 import { GAME_IDS } from './data/manifests'
+import { rulesTextForGame } from './data/rulesSources'
 import {
   clampAiOpponentCount,
   gameSupportsConfigurableAi,
@@ -12,6 +13,7 @@ import {
   MAX_AI_OPPONENTS,
   normalizeAiDifficultiesForCount,
 } from './session/playerConfig'
+import { RulesModal } from './ui/RulesModal'
 import { TableView, type ActiveTurnHighlight, type TableIntent } from './ui/TableView'
 import { skyjoDumpUiStepShouldReset, type SkyjoDumpUiStep } from './ui/tableUiFlow'
 import type { GameAction } from './core/types'
@@ -162,6 +164,7 @@ function App() {
   const [gfAwaitingOpponent, setGfAwaitingOpponent] = useState(false)
   const [gfRank, setGfRank] = useState('A')
   const [skyjoDumpStep, setSkyjoDumpStep] = useState<SkyjoDumpUiStep>('idle')
+  const [rulesOpen, setRulesOpen] = useState(false)
 
   const makeDealOptions = useCallback(
     (
@@ -631,6 +634,13 @@ function App() {
                       <button type="button" className="app__btnToolbar app__btnSecondary" onClick={startOrNewDeal}>
                         {session ? 'New deal' : 'Start deal'}
                       </button>
+                      <button
+                        type="button"
+                        className="app__btnSecondary app__btnToolbar"
+                        onClick={() => setRulesOpen(true)}
+                      >
+                        Rules
+                      </button>
                       <button type="button" className="app__btnSecondary app__btnToolbar" onClick={endGame}>
                         End game
                       </button>
@@ -817,6 +827,8 @@ function App() {
           </footer>
         </>
       )}
+
+      <RulesModal open={rulesOpen} onClose={() => setRulesOpen(false)} markdown={rulesTextForGame(gameId)} />
     </div>
   )
 }

--- a/src/data/rulesSources.ts
+++ b/src/data/rulesSources.ts
@@ -1,0 +1,42 @@
+import { GAME_IDS } from './manifests'
+
+import war from '../rules/war.md?raw'
+import demoCustom from '../rules/demo-custom.md?raw'
+import goFish from '../rules/go-fish.md?raw'
+import skyjo from '../rules/skyjo.md?raw'
+import blackjack from '../rules/blackjack.md?raw'
+import casinoBlackjack from '../rules/casino-blackjack.md?raw'
+import baccarat from '../rules/baccarat.md?raw'
+import miniBaccarat from '../rules/mini-baccarat.md?raw'
+import crazyEights from '../rules/crazy-eights.md?raw'
+import switchGame from '../rules/switch.md?raw'
+import pokerDraw from '../rules/poker-draw.md?raw'
+import headsUpPoker from '../rules/heads-up-poker.md?raw'
+import highCardDuel from '../rules/high-card-duel.md?raw'
+import redDog from '../rules/red-dog.md?raw'
+import uno from '../rules/uno.md?raw'
+
+/** In-app rules copy (markdown), one file per selectable game id. */
+export const RULES_SOURCES = {
+  war,
+  'demo-custom': demoCustom,
+  'go-fish': goFish,
+  skyjo,
+  blackjack,
+  'casino-blackjack': casinoBlackjack,
+  baccarat,
+  'mini-baccarat': miniBaccarat,
+  'crazy-eights': crazyEights,
+  switch: switchGame,
+  'poker-draw': pokerDraw,
+  'heads-up-poker': headsUpPoker,
+  'high-card-duel': highCardDuel,
+  'red-dog': redDog,
+  uno,
+} as const satisfies Record<(typeof GAME_IDS)[number], string>
+
+export type RulesGameId = keyof typeof RULES_SOURCES
+
+export function rulesTextForGame(gameId: RulesGameId): string {
+  return RULES_SOURCES[gameId]
+}

--- a/src/rules/baccarat.md
+++ b/src/rules/baccarat.md
@@ -1,0 +1,7 @@
+# Baccarat
+
+Two hands — **Player** and **Banker** — each get two cards. Card values: aces = 1, tens and faces = 0, other cards = pip value. The hand **total is modulo 10** (only the ones digit counts).
+
+**In this app:** choose a **bet size**, then bet **Player** or **Banker**. The round resolves from the dealt hands. **Chips** and match totals work like other betting games (toolbar shows targets).
+
+**Players:** you vs one AI (banker hand is still simulated on the table).

--- a/src/rules/blackjack.md
+++ b/src/rules/blackjack.md
@@ -1,0 +1,7 @@
+# Blackjack
+
+Heads-up **21** vs the dealer seat: **place a bet**, get two cards, then **Hit** (draw) or **Stand**. The dealer hits until a fixed total (e.g. 17). **Natural blackjack** pays **3:2** where implemented; going over 21 **busts** your hand.
+
+**Chips:** cumulative scores are **chip stacks**. When a round finishes, use **Next round (apply scores)** to merge round deltas into the match totals. The toolbar shows the chip goal for this variant.
+
+**Players:** you vs dealer (one AI seat).

--- a/src/rules/casino-blackjack.md
+++ b/src/rules/casino-blackjack.md
@@ -1,0 +1,5 @@
+# Casino Blackjack
+
+Same rules and controls as **Blackjack** (bet, hit, stand, dealer rules, chip match scoring).
+
+This menu entry only changes **default stacks and match targets** in the manifest — compare the cumulative **Chips** goal in the toolbar after you **Start deal**.

--- a/src/rules/crazy-eights.md
+++ b/src/rules/crazy-eights.md
@@ -1,0 +1,7 @@
+# Crazy Eights
+
+**Shed** all your cards. Play a card that matches the **rank** or **suit** of the top discard, or play any **8** and **choose the next suit**. If you cannot play, **draw** from the stock (as implemented).
+
+**In this app:** use the action buttons for play / draw. With multiple opponents, turn order rotates; the match may award points when someone goes out.
+
+**Players:** 2–4 (you + AIs).

--- a/src/rules/demo-custom.md
+++ b/src/rules/demo-custom.md
@@ -1,0 +1,7 @@
+# Custom deck duel (demo)
+
+A tiny sample game using the **example-custom** deck (symbol cards, not French suits). It exists to show how custom templates and zones work in the engine.
+
+**In this app:** press **Play round** (or the primary action) when enabled to step through the scripted duel.
+
+**Players:** you vs one AI.

--- a/src/rules/go-fish.md
+++ b/src/rules/go-fish.md
@@ -1,0 +1,9 @@
+# Go Fish
+
+Collect **books** (four of a kind). On your turn, **ask** any other player for a rank; you must hold at least one card of that rank. If they have any, they give you all of them; if not, they say “go fish” and you **draw** from the stock.
+
+**In this app:**
+
+- Click a card in **your hand** to pick the rank, then click an opponent’s **hand** or **books** pile to ask.
+- Use **Pass turn** when the rules allow it.
+- AI count and per-seat difficulty can be set before **Start deal**.

--- a/src/rules/heads-up-poker.md
+++ b/src/rules/heads-up-poker.md
@@ -1,0 +1,5 @@
+# Heads-up poker
+
+Same **5-card draw** flow as **Poker (5-card draw)**: ante, draw phase, showdown.
+
+This menu entry only changes manifest defaults (starting stacks, match target). Rules on the table are identical.

--- a/src/rules/high-card-duel.md
+++ b/src/rules/high-card-duel.md
@@ -1,0 +1,7 @@
+# High-card duel
+
+Each side antes **5** or **10** chips (when both can cover it). One card each; **higher rank wins** the pot (**aces high**). **Tie** refunds the antes.
+
+**Chips:** use **Next round (apply scores)** when the match module finishes a scoring round. Toolbar shows this variant’s chip goal.
+
+**Players:** you vs one AI.

--- a/src/rules/mini-baccarat.md
+++ b/src/rules/mini-baccarat.md
@@ -1,0 +1,5 @@
+# Mini Baccarat
+
+Same flow as **Baccarat**: bet amount, pick **Player** or **Banker**, then the hands are dealt and scored modulo 10.
+
+This entry is a separate manifest preset (name / default match settings), not a different rules engine.

--- a/src/rules/poker-draw.md
+++ b/src/rules/poker-draw.md
@@ -1,0 +1,7 @@
+# Poker (5-card draw)
+
+Heads-up **draw poker**: pay the **ante**, receive five cards face-up for you (opponent’s hand may be hidden). Choose how many cards to **replace** from the **front** of your hand — **0 to 3**; the same count is applied to both hands. **Highest hand** wins the pot by the app’s simplified rank ordering.
+
+**Chips:** antes and showdown move stacks; advance the **match** with **Next round** when a round completes.
+
+**Players:** you vs one AI.

--- a/src/rules/red-dog.md
+++ b/src/rules/red-dog.md
@@ -1,0 +1,5 @@
+# Red Dog
+
+Same **high-card duel** rules as **High-card duel** (pick 5 or 10 chip bet, one card each, high card wins, tie pushes).
+
+This entry is an alternate manifest only; gameplay is unchanged.

--- a/src/rules/skyjo.md
+++ b/src/rules/skyjo.md
@@ -1,0 +1,5 @@
+# Skyjo
+
+Play on a personal **grid** of face-down and face-up numbered cards, with a **draw pile** and **discard**. Rounds score the sum of visible values on your grid; the **match** typically ends when someone’s cumulative total crosses a threshold (see toolbar caption for this table’s goal — often **lowest** total wins the match).
+
+**In this app:** follow the on-screen hints for drawing, dump & flip, swapping with a pending card, and taking the visible discard. Per-seat **AI difficulty** applies to computer players.

--- a/src/rules/switch.md
+++ b/src/rules/switch.md
@@ -1,0 +1,5 @@
+# Switch
+
+**Switch** uses the **same rules as Crazy Eights** in this app (match rank or suit, eights change suit, draw when needed).
+
+Pick this menu item for an alternate packaged preset. See **Crazy Eights** for how to play on the table.

--- a/src/rules/uno.md
+++ b/src/rules/uno.md
@@ -1,0 +1,11 @@
+# Uno
+
+Match the **current color** or the **face** of the top discard, or play a **Wild** / **Wild +4**. **Skip**, **Reverse**, and **Draw two** affect turn order; with **two players**, reverse and skip behave like “opponent loses a turn” (you may play again).
+
+**Drawing:** if you have no legal play, **draw** one card. You may then **play that card** or **end your turn** without playing it.
+
+**Wilds:** when you play a wild, **pick the next color** (R / Y / G / B). **Wild +4** makes the next player draw four and lose their turn.
+
+**Scoring rounds:** when someone **goes out**, they score the sum of card points left in opponents’ hands; **match** is typically first to **500** (see toolbar).
+
+*Uno® is a trademark of Mattel. This table is an independent fan-style implementation.*

--- a/src/rules/war.md
+++ b/src/rules/war.md
@@ -1,0 +1,7 @@
+# War
+
+You and the opponent each have a pile. Each turn both sides reveal one card; **higher rank wins** both cards (standard ace-high ordering unless the module specifies otherwise). Ties may trigger extra “war” flips depending on the deal.
+
+**In this app:** use **Start deal** / **New deal** to shuffle. The status line describes what happened each round.
+
+**Players:** you vs one AI.

--- a/src/ui/RulesModal.tsx
+++ b/src/ui/RulesModal.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useId } from 'react'
+
+export interface RulesModalProps {
+  open: boolean
+  onClose: () => void
+  markdown: string
+}
+
+/** Split leading `# Title` from body for dialog chrome. */
+function parseRulesHeading(markdown: string): { title: string; body: string } {
+  const trimmed = markdown.trim()
+  const lines = trimmed.split('\n')
+  const first = lines[0] ?? ''
+  const m = /^#\s+(.+)$/.exec(first)
+  if (!m) {
+    return { title: 'Rules', body: trimmed }
+  }
+  const body = lines.slice(1).join('\n').trim()
+  return { title: m[1]!.trim(), body }
+}
+
+export function RulesModal({ open, onClose, markdown }: RulesModalProps) {
+  const titleId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const { title, body } = parseRulesHeading(markdown)
+
+  return (
+    <div className="app__modalBackdrop" role="presentation" onClick={onClose}>
+      <div
+        className="app__modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="app__modalHeader">
+          <h2 id={titleId} className="app__modalTitle">
+            {title}
+          </h2>
+          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <div className="app__modalBody">
+          <div className="app__rulesMarkdown">
+            {body
+              .split(/\n\n+/)
+              .map((p) => p.trim())
+              .filter(Boolean)
+              .map((para, i) => (
+                <p key={i} className="app__rulesParagraph">
+                  {para}
+                </p>
+              ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,3 +4,8 @@ declare module '*.yaml?raw' {
   const src: string
   export default src
 }
+
+declare module '*.md?raw' {
+  const src: string
+  export default src
+}


### PR DESCRIPTION
## Summary
- **Rules** button next to **End game** opens a modal with rules for the **selected** game.
- Rules live in `src/rules/*.md` and are bundled via `src/data/rulesSources.ts`.
- README documents the flow and `src/rules/` layout.

## Test plan
- [ ] `npm run build`
- [ ] Open **Rules** before/after **Start deal**; switch games and confirm text updates.
- [ ] **Escape** and backdrop click close the modal.

Made with [Cursor](https://cursor.com)