### PR TITLE
UI: card flip and enter motion

### DIFF
--- a/src/ui/CardView.css
+++ b/src/ui/CardView.css
@@ -108,3 +108,51 @@
   box-shadow: none;
   min-height: 5rem;
 }
+
+/* --- 3D flip (CardView wrapper) --- */
+.cardFlip {
+  width: 4.75rem;
+  height: 6.75rem;
+  flex-shrink: 0;
+  perspective: 720px;
+}
+
+.cardFlip__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: none;
+}
+
+.cardFlip--ready .cardFlip__inner {
+  transition: transform 0.52s cubic-bezier(0.4, 0.2, 0.2, 1);
+}
+
+.cardFlip__inner--front {
+  transform: rotateY(180deg);
+}
+
+.cardFlip__face {
+  position: absolute;
+  inset: 0;
+  border-radius: 0.45rem;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+.cardFlip__face--front {
+  transform: rotateY(180deg);
+}
+
+.cardFlip__face .card {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cardFlip--ready .cardFlip__inner {
+    transition: none;
+  }
+}

--- a/src/ui/CardView.tsx
+++ b/src/ui/CardView.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import type { CardInstance, CardTemplate } from '../core/types'
 import './CardView.css'
 
@@ -17,6 +18,10 @@ export interface CardViewProps {
   template: CardTemplate | undefined
   /** When false, show card back (hidden) */
   showFace: boolean
+  /**
+   * When true, hide this subtree from assistive tech (parent supplies the name, e.g. grid card button).
+   */
+  presentationOnly?: boolean
 }
 
 function skyjoTierClass(value: number): string {
@@ -27,26 +32,29 @@ function skyjoTierClass(value: number): string {
   return 'card--skyjoRed'
 }
 
-export function CardView({ card, template, showFace }: CardViewProps) {
-  if (template?.id === '__slot__') {
-    return <div className="card card--skyjoSlot" aria-hidden="true" />
-  }
+function CardBackShell() {
+  return (
+    <div className="card card--back">
+      <div className="card__backPattern" />
+    </div>
+  )
+}
 
-  if (!showFace || !card.faceUp) {
-    return (
-      <div className="card card--back" aria-label="Hidden card">
-        <div className="card__backPattern" />
-      </div>
-    )
-  }
+function cardFaceAriaLabel(template: CardTemplate | undefined, card: CardInstance, showFace: boolean): string {
+  if (!showFace || !card.faceUp) return 'Hidden card'
+  if (template?.skyjo === true && typeof template.value === 'number') return `Skyjo ${template.value}`
+  const rank = template?.rank
+  const suit = template?.suit
+  const label = template?.label
+  if (label !== undefined || !suit) return String(label ?? template?.id ?? 'Card')
+  return `${String(rank)} ${String(suit)}`
+}
 
+function CardFaceFront({ template }: { template: CardTemplate | undefined }) {
   if (template?.skyjo === true && typeof template.value === 'number') {
     const v = template.value
     return (
-      <div
-        className={`card card--skyjo ${skyjoTierClass(v)}`}
-        aria-label={`Skyjo ${v}`}
-      >
+      <div className={`card card--skyjo ${skyjoTierClass(v)}`}>
         <span className="card__skyjoValue">{v}</span>
       </div>
     )
@@ -62,12 +70,9 @@ export function CardView({ card, template, showFace }: CardViewProps) {
       <div
         className="card card--custom"
         style={color ? { color, borderColor: color } : undefined}
-        aria-label={template?.id}
       >
         <span className="card__customLabel">{String(label ?? template?.id ?? '?')}</span>
-        {template?.value !== undefined && (
-          <span className="card__customValue">{template.value}</span>
-        )}
+        {template?.value !== undefined && <span className="card__customValue">{template.value}</span>}
       </div>
     )
   }
@@ -76,12 +81,50 @@ export function CardView({ card, template, showFace }: CardViewProps) {
   const red = isRedSuit(typeof suit === 'string' ? suit : undefined)
 
   return (
-    <div
-      className={`card card--standard${red ? ' card--red' : ''}`}
-      aria-label={`${String(rank)} ${String(suit)}`}
-    >
+    <div className={`card card--standard${red ? ' card--red' : ''}`}>
       <span className="card__rank">{String(rank)}</span>
       <span className="card__suit">{sym}</span>
+    </div>
+  )
+}
+
+export function CardView({ card, template, showFace, presentationOnly }: CardViewProps) {
+  const [motionReady, setMotionReady] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const id = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!cancelled) setMotionReady(true)
+      })
+    })
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(id)
+    }
+  }, [])
+
+  if (template?.id === '__slot__') {
+    return <div className="card card--skyjoSlot" aria-hidden="true" />
+  }
+
+  const faceVisible = showFace && card.faceUp
+  const label = cardFaceAriaLabel(template, card, showFace)
+
+  return (
+    <div
+      className={`cardFlip${motionReady ? ' cardFlip--ready' : ''}`}
+      aria-hidden={presentationOnly ? true : undefined}
+      aria-label={presentationOnly ? undefined : label}
+    >
+      <div className={`cardFlip__inner${faceVisible ? ' cardFlip__inner--front' : ''}`}>
+        <div className="cardFlip__face cardFlip__face--back">
+          <CardBackShell />
+        </div>
+        <div className="cardFlip__face cardFlip__face--front">
+          <CardFaceFront template={template} />
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/ui/TableView.css
+++ b/src/ui/TableView.css
@@ -163,6 +163,13 @@
   flex-shrink: 0;
 }
 
+.tableView__cards--pendingSlot .cardFlip {
+  width: 4.75rem;
+  height: 6.75rem;
+  box-sizing: border-box;
+  flex-shrink: 0;
+}
+
 .tableView__pendingEmpty {
   opacity: 0.4;
   font-size: 1.35rem;
@@ -333,6 +340,14 @@
   flex-shrink: 1;
 }
 
+.tableView__cards--grid .tableView__cardSlot .cardFlip {
+  box-sizing: border-box;
+  width: min(4.75rem, 100%);
+  height: auto;
+  aspect-ratio: 4.75 / 6.75;
+  flex-shrink: 1;
+}
+
 .tableView__cards--grid .tableView__cardSlot .card--skyjoSlot {
   width: min(4.75rem, 100%);
   height: auto;
@@ -348,8 +363,39 @@
   position: relative;
 }
 
+.tableView__cardSlotPose {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .tableView__cards--stack .tableView__cardSlot {
   position: absolute;
   left: 0;
   top: 0;
+}
+
+/* Subtle enter / zone-change motion (runs on mount; flip handled in CardView) */
+.tableView__cardSlot--enter {
+  animation: tableViewCardArrive 0.44s cubic-bezier(0.34, 1.2, 0.64, 1) both;
+}
+
+@keyframes tableViewCardArrive {
+  from {
+    opacity: 0.55;
+    transform: translateY(12px) scale(0.93);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tableView__cardSlot--enter {
+    animation: none;
+  }
 }

--- a/src/ui/TableView.tsx
+++ b/src/ui/TableView.tsx
@@ -148,7 +148,7 @@ export function TableView({
 }: TableViewProps) {
   const order = table.zoneOrder.length ? table.zoneOrder : Object.keys(table.zones)
   const layoutGroups = useMemo(() => buildLayoutGroups(order, table.zones), [order, table.zones])
-  const intentsEnabled = typeof onTableIntent === 'function' && intentZoneAllowlist?.length
+  const intentsEnabled = typeof onTableIntent === 'function' && !!intentZoneAllowlist?.length
 
   const emitCard = (zoneId: string, cardIndex: number, e: MouseEvent<HTMLButtonElement>) => {
     if (!intentsEnabled || !zoneAllowsIntent(zoneId, intentZoneAllowlist)) return
@@ -203,15 +203,16 @@ export function TableView({
           const tmpl = table.templates[card.templateId]
           const inner = <CardView card={card} template={tmpl} showFace={showFace} />
           return (
-            <div
-              key={card.instanceId}
-              className="tableView__cardSlot"
-              style={{
-                zIndex: idx,
-                transform: `translate(${Math.min(idx, 5) * 2}px, ${Math.min(idx, 5) * -1}px)`,
-              }}
-            >
-              {inner}
+            <div key={card.instanceId} className="tableView__cardSlot tableView__cardSlot--enter">
+              <div
+                className="tableView__cardSlotPose"
+                style={{
+                  zIndex: idx,
+                  transform: `translate(${Math.min(idx, 5) * 2}px, ${Math.min(idx, 5) * -1}px)`,
+                }}
+              >
+                {inner}
+              </div>
             </div>
           )
         })}
@@ -291,29 +292,29 @@ export function TableView({
               const showFace = shouldShowFaceForViewer(zone, card, idx, humanPlayerIndex)
               const tmpl = table.templates[card.templateId]
               const cardInteractive = zoneInteractive && zone.kind !== 'stack'
-              const inner = <CardView card={card} template={tmpl} showFace={showFace} />
+              const inner = (
+                <CardView card={card} template={tmpl} showFace={showFace} presentationOnly={cardInteractive} />
+              )
+              const poseStyle =
+                zone.kind === 'grid'
+                  ? undefined
+                  : { transform: `rotate(${-12 + idx * 8}deg) translateY(${idx * 2}px)` }
               return (
-                <div
-                  key={card.instanceId}
-                  className="tableView__cardSlot"
-                  style={
-                    zone.kind === 'grid'
-                      ? undefined
-                      : { transform: `rotate(${-12 + idx * 8}deg) translateY(${idx * 2}px)` }
-                  }
-                >
-                  {cardInteractive ? (
-                    <button
-                      type="button"
-                      className="tableView__cardHit"
-                      aria-label={`${label} card ${idx + 1}`}
-                      onClick={(e) => emitCard(zid, idx, e)}
-                    >
-                      {inner}
-                    </button>
-                  ) : (
-                    inner
-                  )}
+                <div key={card.instanceId} className="tableView__cardSlot tableView__cardSlot--enter">
+                  <div className="tableView__cardSlotPose" style={poseStyle}>
+                    {cardInteractive ? (
+                      <button
+                        type="button"
+                        className="tableView__cardHit"
+                        aria-label={`${label} card ${idx + 1}`}
+                        onClick={(e) => emitCard(zid, idx, e)}
+                      >
+                        {inner}
+                      </button>
+                    ) : (
+                      inner
+                    )}
+                  </div>
                 </div>
               )
             })
@@ -340,8 +341,10 @@ export function TableView({
           </header>
           <div className="tableView__cards tableView__cards--pendingSlot">
             {c ? (
-              <div className="tableView__cardSlot">
-                <CardView card={c} template={tmpl} showFace />
+              <div className="tableView__cardSlot tableView__cardSlot--enter">
+                <div className="tableView__cardSlotPose">
+                  <CardView card={c} template={tmpl} showFace />
+                </div>
               </div>
             ) : (
               <div className="tableView__pendingEmpty">—</div>


### PR DESCRIPTION
## Summary

- **CardView:** 3D `rotateY` flip when a card goes between face-down and face-up (or when the viewer can’t see the face). Transitions start only after mount so the initial deal doesn’t animate every card.
- **TableView:** Short enter animation on card slot mount (helpful when cards move between zones and remount). Stack/spread offsets live on an inner `.tableView__cardSlotPose` so they don’t clash with the motion layer.
- **A11y:** Optional `presentationOnly` on `CardView` so grid card buttons don’t duplicate labels.
- **Fix:** `intentsEnabled` is now a boolean (`!!allowlist?.length`).
- **prefers-reduced-motion:** Disables flip transition and arrive keyframes.

## Testing

- `npm run build`

Made with [Cursor](https://cursor.com)