### PR TITLE
UI: Skyjo draw pile, match scoreboard, rules modal, house rules

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -65,7 +65,8 @@
 .app__toolbarScores {
   flex: 0 0 auto;
   align-self: flex-start;
-  min-width: min(100%, 17rem);
+  min-width: 0;
+  max-width: min(100%, 36rem);
   text-align: right;
 }
 
@@ -201,59 +202,121 @@
   line-height: 1.4;
 }
 
-/* Borderless cumulative scoreboard (toolbar when match active) */
+/* Cumulative scoreboard: theme tokens from index.css (light + dark readable) */
 .matchCumulative {
   font-size: 0.82rem;
   line-height: 1.35;
-  color: var(--text-h, #f3f4f6);
+  color: var(--match-cumulative-cell);
+  padding: 0.55rem 0.65rem 0.5rem;
+  border-radius: 0.65rem;
+  background: var(--match-cumulative-surface);
+  border: none;
+  box-shadow: var(--shadow);
+}
+
+.matchCumulative__scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0 -0.15rem;
+  padding: 0 0.15rem;
 }
 
 .matchCumulative__table {
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   margin: 0;
   text-align: right;
+  width: 100%;
+  min-width: min(100%, 12rem);
 }
 
 .matchCumulative__table caption {
   caption-side: top;
   text-align: inherit;
-  font-weight: 600;
+  font-weight: 700;
   font-size: 0.78rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  opacity: 0.8;
-  padding: 0 0 0.35rem;
+  padding: 0 0 0.45rem;
+  color: var(--match-cumulative-caption);
 }
 
 .matchCumulative__table th,
 .matchCumulative__table td {
   border: none;
-  padding: 0.15rem 0 0.15rem 0.65rem;
+  padding: 0.22rem 0.45rem;
   font-weight: 400;
+  vertical-align: middle;
 }
 
-.matchCumulative__table th:first-child,
-.matchCumulative__table td:first-child {
-  padding-left: 0;
+.matchCumulative__thPlayer,
+.matchCumulative__playerCell {
+  padding-left: 0.35rem !important;
   text-align: left;
+  font-weight: 600;
+}
+
+.matchCumulative__playerCell {
+  font-weight: 600;
+  color: var(--match-cumulative-caption);
 }
 
 .matchCumulative__table thead th {
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: 0.68rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  opacity: 0.75;
-  padding-bottom: 0.25rem;
+  letter-spacing: 0.05em;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid var(--match-cumulative-head-rule);
+}
+
+.matchCumulative__thRound--a {
+  background: var(--match-cumulative-round-a-bg);
+  color: var(--match-cumulative-round-a-fg);
+}
+
+.matchCumulative__thRound--b {
+  background: var(--match-cumulative-round-b-bg);
+  color: var(--match-cumulative-round-b-fg);
+}
+
+.matchCumulative__thTotal {
+  background: var(--match-cumulative-total-bg);
+  color: var(--match-cumulative-total-fg);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.matchCumulative__roundCell--a {
+  background: var(--match-cumulative-round-a-bg);
+  color: var(--match-cumulative-round-a-fg);
+}
+
+.matchCumulative__roundCell--b {
+  background: var(--match-cumulative-round-b-bg);
+  color: var(--match-cumulative-round-b-fg);
+}
+
+.matchCumulative__roundCell--a,
+.matchCumulative__roundCell--b {
+  font-variant-numeric: tabular-nums;
+}
+
+.matchCumulative__totalCell {
+  background: var(--match-cumulative-total-bg);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--match-cumulative-total-fg);
 }
 
 .matchCumulative__meta {
-  margin: 0.4rem 0 0;
+  margin: 0.45rem 0 0;
   font-size: 0.75rem;
-  line-height: 1.4;
-  opacity: 0.82;
-  max-width: 16rem;
+  line-height: 1.45;
+  max-width: 28rem;
   text-align: right;
+  margin-left: auto;
+  color: var(--match-cumulative-meta);
 }
 
 .matchCumulative--toolbar {
@@ -262,25 +325,24 @@
 
 .matchCumulative--toolbar .matchCumulative__table caption {
   font-size: 0.68rem;
-  padding-bottom: 0.28rem;
+  padding-bottom: 0.32rem;
 }
 
 .matchCumulative--toolbar .matchCumulative__table th,
 .matchCumulative--toolbar .matchCumulative__table td {
-  padding: 0.08rem 0 0.08rem 0.5rem;
+  padding: 0.12rem 0.4rem;
 }
 
 .matchCumulative--toolbar .matchCumulative__meta {
-  margin-top: 0.3rem;
+  margin-top: 0.32rem;
   font-size: 0.68rem;
-  max-width: 20rem;
-  margin-left: auto;
+  max-width: none;
 }
 
 @media (max-width: 52rem) {
   .matchCumulative--toolbar .matchCumulative__meta {
     margin-left: 0;
-    max-width: none;
+    text-align: left;
   }
 }
 
@@ -436,19 +498,24 @@
   border: 1px solid var(--border, #2e303a);
   border-radius: 0.45rem;
   background: rgba(15, 23, 42, 0.35);
+  box-sizing: border-box;
+  min-width: 0;
 }
 
 .app__houseRulesLegend {
-  padding: 0 0.25rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
   font-size: 0.82rem;
   font-weight: 700;
+  font-family: inherit;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-muted, #9ca3af);
+  line-height: 1.3;
 }
 
 .app__houseRulesHint {
-  margin: 0.35rem 0 0.65rem;
+  margin: 0 0 0.65rem;
   font-size: 0.82rem;
   opacity: 0.88;
   line-height: 1.4;
@@ -500,6 +567,15 @@
 
 .app__rulesSubhead:first-child {
   margin-top: 0;
+}
+
+.app__rulesSubhead--title {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.app__rulesStrong {
+  font-weight: 650;
 }
 
 .app__rulesOl,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,33 +29,78 @@ function MatchCumulativePanel({
   scoreColumnLabel = 'Total',
   caption = 'Cumulative scores',
   scoringMode = 'points',
+  pendingRoundScores,
 }: {
   match: MatchState
   toolbar?: boolean
   scoreColumnLabel?: string
   caption?: string
   scoringMode?: 'points' | 'chips'
+  /** Round scored in game state but not yet merged — updates Total column only (no layout change). */
+  pendingRoundScores?: number[] | null
 }) {
   const unit = scoringMode === 'chips' ? 'chips' : 'points'
+  const history = match.completedRoundScores ?? []
+  const n = match.cumulativeScores.length
+  const pending =
+    pendingRoundScores && pendingRoundScores.length === n ? pendingRoundScores : null
+  const displayTotals = pending
+    ? match.cumulativeScores.map((c, i) => c + (pending[i] ?? 0))
+    : match.cumulativeScores
+
   return (
     <div className={`matchCumulative${toolbar ? ' matchCumulative--toolbar' : ''}`}>
-      <table className="matchCumulative__table">
-        <caption>{caption}</caption>
-        <thead>
-          <tr>
-            <th scope="col">Player</th>
-            <th scope="col">{scoreColumnLabel}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {match.cumulativeScores.map((s, i) => (
-            <tr key={i}>
-              <td>{playerSeatLabel(i)}</td>
-              <td>{s}</td>
+      <div className="matchCumulative__scroll">
+        <table
+          className="matchCumulative__table"
+          title={
+            pending
+              ? `${scoreColumnLabel} shows the result after merging this round (before you click Next round).`
+              : undefined
+          }
+        >
+          <caption>{caption}</caption>
+          <thead>
+            <tr>
+              <th scope="col" className="matchCumulative__thPlayer">
+                Player
+              </th>
+              {history.map((_, ri) => (
+                <th
+                  key={`r-${ri}`}
+                  scope="col"
+                  className={`matchCumulative__thRound matchCumulative__thRound--${ri % 2 === 0 ? 'a' : 'b'}`}
+                >
+                  R{ri + 1}
+                </th>
+              ))}
+              <th scope="col" className="matchCumulative__thTotal">
+                {scoreColumnLabel}
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {match.cumulativeScores.map((_, pi) => (
+              <tr key={pi}>
+                <th scope="row" className="matchCumulative__playerCell">
+                  {playerSeatLabel(pi)}
+                </th>
+                {history.map((roundVec, ri) => (
+                  <td
+                    key={`${pi}-${ri}`}
+                    className={`matchCumulative__roundCell matchCumulative__roundCell--${ri % 2 === 0 ? 'a' : 'b'}`}
+                  >
+                    {roundVec[pi] ?? '—'}
+                  </td>
+                ))}
+                <td className="matchCumulative__totalCell">
+                  {displayTotals[pi] ?? '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       <p className="matchCumulative__meta">
         Round {match.round}
         {' · '}
@@ -311,7 +356,7 @@ function App() {
     )
   }, [session])
 
-  const matchPreviewTotals = useMemo(() => {
+  const pendingMergeRoundScores = useMemo(() => {
     if (!session) return null
     const m = session.match
     if (!m?.config || m.complete) return null
@@ -319,8 +364,15 @@ function App() {
     if (!mod.isMatchRoundFinished?.(session.gameState)) return null
     const rs = mod.extractMatchRoundScores?.(session.gameState)
     if (!rs?.length) return null
-    return m.cumulativeScores.map((c, i) => c + (rs[i] ?? 0))
+    return rs
   }, [session])
+
+  const matchPreviewTotals = useMemo(() => {
+    if (!session || !pendingMergeRoundScores) return null
+    const m = session.match
+    if (!m?.config || m.complete) return null
+    return m.cumulativeScores.map((c, i) => c + (pendingMergeRoundScores[i] ?? 0))
+  }, [session, pendingMergeRoundScores])
 
   const primaryLabel = gameId === 'demo-custom' ? 'Reveal winner' : 'Play round'
 
@@ -806,6 +858,7 @@ function App() {
                     session.manifest.match?.scoringMode === 'chips' ? 'Cumulative chips' : 'Cumulative scores'
                   }
                   scoringMode={session.manifest.match?.scoringMode === 'chips' ? 'chips' : 'points'}
+                  pendingRoundScores={pendingMergeRoundScores}
                 />
               </div>
             )}

--- a/src/core/match.ts
+++ b/src/core/match.ts
@@ -16,6 +16,11 @@ export interface MatchState {
   /** 1-based round number for the deal currently in play (or just finished). */
   round: number
   cumulativeScores: number[]
+  /**
+   * Each entry is one completed round’s per-player scores (same length as {@link cumulativeScores}),
+   * in order. Used for the cumulative scoreboard UI. Omitted in older in-memory state — treat as [].
+   */
+  completedRoundScores?: number[][]
   config: MatchConfig
   /** Set when a player’s cumulative score crosses the threshold. */
   complete: boolean
@@ -45,6 +50,7 @@ export function createInitialMatchState(manifest: GameManifestYaml): MatchState 
   return {
     round: 1,
     cumulativeScores,
+    completedRoundScores: [],
     config,
     complete: false,
     matchWinnerIndex: null,
@@ -84,12 +90,15 @@ export function applyFinishedRound(
 ): MatchState {
   const next = match.cumulativeScores.map((c, i) => c + (roundScores[i] ?? 0))
   const { targetScore, winnerIs, endCondition } = match.config
+  const prevRounds = match.completedRoundScores ?? []
+  const completedRoundScores = [...prevRounds, roundScores.map((_, i) => roundScores[i] ?? 0)]
 
   if (endCondition === 'anyAtOrAbove' && next.some((s) => s >= targetScore)) {
     const win = indexOfExtreme(next, winnerIs)
     return {
       ...match,
       cumulativeScores: next,
+      completedRoundScores,
       complete: true,
       matchWinnerIndex: win,
     }
@@ -98,6 +107,7 @@ export function applyFinishedRound(
   return {
     ...match,
     cumulativeScores: next,
+    completedRoundScores,
     round: match.round + 1,
     complete: false,
     matchWinnerIndex: null,

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,24 @@
   --shadow:
     rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 
+  --text-muted: #5c566a;
+
+  /* Cumulative score panel (toolbar + table; light mode = high contrast on white) */
+  --match-cumulative-surface: color-mix(in srgb, var(--text-h) 4.5%, var(--bg));
+  --match-cumulative-border: color-mix(in srgb, var(--text-h) 14%, var(--border));
+  --match-cumulative-inset: color-mix(in srgb, var(--bg) 70%, var(--text-h) 30%);
+  --match-cumulative-caption: var(--text-h);
+  --match-cumulative-cell: var(--text-h);
+  --match-cumulative-head-rule: color-mix(in srgb, var(--text-h) 16%, var(--border));
+  --match-cumulative-round-a-bg: #e0e7ff;
+  --match-cumulative-round-a-fg: #1e3a8a;
+  --match-cumulative-round-b-bg: #ede9fe;
+  --match-cumulative-round-b-fg: #4c1d95;
+  --match-cumulative-total-bg: #d1fae5;
+  --match-cumulative-total-fg: #065f46;
+  --match-cumulative-total-border: #059669;
+  --match-cumulative-meta: var(--text-muted);
+
   --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
   --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
   --mono: ui-monospace, Consolas, monospace;
@@ -36,6 +54,22 @@
     --text-h: #f3f4f6;
     --bg: #16171d;
     --border: #2e303a;
+    --text-muted: #9ca3af;
+
+    --match-cumulative-surface: color-mix(in srgb, var(--text-h) 7%, var(--bg));
+    --match-cumulative-border: color-mix(in srgb, var(--text-h) 22%, var(--border));
+    --match-cumulative-inset: color-mix(in srgb, var(--text-h) 8%, transparent);
+    --match-cumulative-caption: var(--text-h);
+    --match-cumulative-cell: #e5e7eb;
+    --match-cumulative-head-rule: color-mix(in srgb, var(--text-h) 28%, var(--border));
+    --match-cumulative-round-a-bg: color-mix(in srgb, #3b82f6 22%, var(--bg));
+    --match-cumulative-round-a-fg: #dbeafe;
+    --match-cumulative-round-b-bg: color-mix(in srgb, #8b5cf6 18%, var(--bg));
+    --match-cumulative-round-b-fg: #ede9fe;
+    --match-cumulative-total-bg: color-mix(in srgb, #10b981 20%, var(--bg));
+    --match-cumulative-total-fg: #a7f3d0;
+    --match-cumulative-total-border: #34d399;
+    --match-cumulative-meta: #a1a1aa;
     --code-bg: #1f2028;
     --accent: #c084fc;
     --accent-bg: rgba(192, 132, 252, 0.15);

--- a/src/ui/GameHouseRulesPanel.tsx
+++ b/src/ui/GameHouseRulesPanel.tsx
@@ -49,10 +49,10 @@ export function GameHouseRulesPanel({ gameId, manifest }: GameHouseRulesPanelPro
   }
 
   return (
-    <fieldset className="app__houseRules" aria-labelledby={legendId}>
-      <legend id={legendId} className="app__houseRulesLegend">
+    <div className="app__houseRules" role="group" aria-labelledby={legendId}>
+      <h3 id={legendId} className="app__houseRulesLegend">
         Options for this game
-      </legend>
+      </h3>
       <p className="app__houseRulesHint">
         Saved in your browser. Start a <strong>new deal</strong> (or next match round) for changes to apply.
       </p>
@@ -140,6 +140,6 @@ export function GameHouseRulesPanel({ gameId, manifest }: GameHouseRulesPanelPro
             variants to see examples).
           </p>
         )}
-    </fieldset>
+    </div>
   )
 }

--- a/src/ui/RulesModal.tsx
+++ b/src/ui/RulesModal.tsx
@@ -10,19 +10,45 @@ export interface RulesModalProps {
 
 /** Split leading `# Title` from body for dialog chrome. */
 function parseRulesHeading(markdown: string): { title: string; body: string } {
-  const trimmed = markdown.trim()
-  const lines = trimmed.split('\n')
-  const first = lines[0] ?? ''
+  const trimmed = markdown.trim().replace(/^\uFEFF/, '')
+  const lines = trimmed.split(/\r?\n/)
+  const first = (lines[0] ?? '').trim()
   const m = /^#\s+(.+)$/.exec(first)
   if (!m) {
     return { title: 'Rules', body: trimmed }
   }
+  const title = m[1]!.trim()
   const body = lines.slice(1).join('\n').trim()
-  return { title: m[1]!.trim(), body }
+  return { title, body }
+}
+
+/** Inline `**bold**` (non-greedy); leaves unmatched `**` as text. */
+function renderInlineMarkdown(text: string, keyPrefix: string): ReactNode {
+  const out: ReactNode[] = []
+  let last = 0
+  const re = /\*\*(.+?)\*\*/g
+  let m: RegExpExecArray | null
+  let k = 0
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) {
+      out.push(text.slice(last, m.index))
+    }
+    out.push(
+      <strong key={`${keyPrefix}-${k++}`} className="app__rulesStrong">
+        {m[1]}
+      </strong>,
+    )
+    last = m.index + m[0].length
+  }
+  if (last < text.length) {
+    out.push(text.slice(last))
+  }
+  if (out.length === 0) return text
+  return <>{out}</>
 }
 
 function RulesMarkdownBody({ text }: { text: string }) {
-  const lines = text.split('\n')
+  const lines = text.split(/\r?\n/)
   const blocks: ReactNode[] = []
   let i = 0
   while (i < lines.length) {
@@ -34,7 +60,16 @@ function RulesMarkdownBody({ text }: { text: string }) {
     if (/^##\s+/.test(trimmed)) {
       blocks.push(
         <h3 key={`h-${i}`} className="app__rulesSubhead">
-          {trimmed.replace(/^##\s+/, '')}
+          {renderInlineMarkdown(trimmed.replace(/^##\s+/, ''), `h-${i}`)}
+        </h3>,
+      )
+      i++
+      continue
+    }
+    if (/^#\s+/.test(trimmed)) {
+      blocks.push(
+        <h3 key={`h1-${i}`} className="app__rulesSubhead app__rulesSubhead--title">
+          {renderInlineMarkdown(trimmed.replace(/^#\s+/, ''), `h1-${i}`)}
         </h3>,
       )
       i++
@@ -60,7 +95,7 @@ function RulesMarkdownBody({ text }: { text: string }) {
         blocks.push(
           <ol key={`ol-${i}`} className="app__rulesOl">
             {items.map((t, j) => (
-              <li key={j}>{t}</li>
+              <li key={j}>{renderInlineMarkdown(t, `ol-${i}-${j}`)}</li>
             ))}
           </ol>,
         )
@@ -68,7 +103,7 @@ function RulesMarkdownBody({ text }: { text: string }) {
         blocks.push(
           <ul key={`ul-${i}`} className="app__rulesUl">
             {items.map((t, j) => (
-              <li key={j}>{t}</li>
+              <li key={j}>{renderInlineMarkdown(t, `ul-${i}-${j}`)}</li>
             ))}
           </ul>,
         )
@@ -80,14 +115,15 @@ function RulesMarkdownBody({ text }: { text: string }) {
       const raw = lines[i] ?? ''
       const t = raw.trim()
       if (!t) break
-      if (/^##\s/.test(t) || /^\d+\.\s/.test(t) || /^[-*]\s/.test(t)) break
+      if (/^##\s/.test(t) || /^#\s/.test(t) || /^\d+\.\s/.test(t) || /^[-*]\s/.test(t)) break
       paraLines.push(raw.trimEnd())
       i++
     }
     if (paraLines.length) {
+      const para = paraLines.join(' ')
       blocks.push(
         <p key={`p-${i}`} className="app__rulesParagraph">
-          {paraLines.join(' ')}
+          {renderInlineMarkdown(para, `p-${i}`)}
         </p>,
       )
     }

--- a/src/ui/TableView.css
+++ b/src/ui/TableView.css
@@ -90,41 +90,6 @@
   flex-direction: column;
 }
 
-.tableView__zone--drawSplit .tableView__drawSplitBody {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.5rem;
-  align-items: stretch;
-  min-height: 0;
-}
-
-.tableView__drawSplitHalf--meta {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.5rem;
-  border: 1px dashed var(--border, #2e303a);
-  min-height: 5.5rem;
-  background: rgba(15, 23, 42, 0.25);
-}
-
-.tableView__drawSplitHalfLabel {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  opacity: 0.75;
-}
-
-.tableView__drawSplitHalf--pile {
-  min-width: 0;
-}
-
-.tableView__drawSplitHalf--pile .tableView__cards--stack {
-  min-height: 8.75rem;
-}
-
 .tableView__zone--pendingSlot {
   flex: 1 1 auto;
   display: flex;
@@ -185,7 +150,7 @@
   flex-wrap: wrap;
   gap: 1rem 1.25rem;
   align-items: flex-start;
-  justify-content: flex-start;
+  justify-content: center;
   width: 100%;
 }
 

--- a/src/ui/TableView.tsx
+++ b/src/ui/TableView.tsx
@@ -31,8 +31,7 @@ export interface TableViewProps {
    */
   intentZoneAllowlist?: readonly string[]
   /**
-   * When both `draw` and `discard` exist, set this to show a middle “Pending” column (e.g. Skyjo drawn card)
-   * and split the draw pile into two columns (deck label | cards).
+   * When both `draw` and `discard` exist, set this to show a middle “Pending” column (e.g. Skyjo drawn card).
    */
   pendingStacksColumn?: {
     card: CardInstance | null
@@ -220,36 +219,12 @@ export function TableView({
     )
   }
 
-  const renderZone = (zid: string, variant?: 'drawSplit') => {
+  const renderZone = (zid: string) => {
     const zone = table.zones[zid]
     if (!zone) return null
     const cards = zone.cards
     const label = zoneLabel(zone, humanPlayerIndex)
     const zoneInteractive = intentsEnabled && zoneAllowsIntent(zid, intentZoneAllowlist)
-
-    if (zid === 'draw' && variant === 'drawSplit') {
-      return (
-        <section
-          key={zid}
-          className={`tableView__zone tableView__zone--drawSplit${zoneInteractive ? ' tableView__zone--interactive' : ''}`}
-          data-zone-kind={zone.kind}
-          data-zone-id={zid}
-        >
-          <header className="tableView__zoneTitle">
-            <span>{label}</span>
-            {cards.length > 0 && <span className="tableView__count">{cards.length} cards</span>}
-          </header>
-          <div className="tableView__drawSplitBody">
-            <div className="tableView__drawSplitHalf tableView__drawSplitHalf--meta">
-              <span className="tableView__drawSplitHalfLabel">Deck</span>
-            </div>
-            <div className="tableView__drawSplitHalf tableView__drawSplitHalf--pile">
-              <div className="tableView__cards tableView__cards--stack">{renderStackCardsInner('draw')}</div>
-            </div>
-          </div>
-        </section>
-      )
-    }
 
     const activeTurn =
       activeTurnHighlight != null && zid === `${activeTurnHighlight.zoneIdPrefix}:${activeTurnHighlight.playerIndex}`
@@ -362,7 +337,7 @@ export function TableView({
           if (pendingStacksColumn) {
             return (
               <div key="__draw_pending_discard__" className="tableView__stacksRow tableView__stacksRow--tri">
-                <div className="tableView__stackCol tableView__stackCol--draw">{renderZone('draw', 'drawSplit')}</div>
+                <div className="tableView__stackCol tableView__stackCol--draw">{renderZone('draw')}</div>
                 {renderPendingStacksColumn()}
                 <div className="tableView__stackCol tableView__stackCol--discardColumn">
                   <div className="tableView__discardZoneStretch">{renderZone('discard')}</div>


### PR DESCRIPTION
## Summary

- **Skyjo table:** Remove the split "Deck" column so the draw pile matches the discard layout; center-align the grid row below the stacks.
- **Match scoring:** Store `completedRoundScores` for per-round columns; theme-aware cumulative panel (light/dark); only a header underline for rules; no layout shift when a round is waiting to merge (totals preview only).
- **Rules modal:** Reliable `# Title` parsing (line endings/BOM); render `**bold**` in paragraphs and lists; handle stray `# ` lines in body.
- **House rules:** Replace fieldset/legend with `role="group"` + `h3` so the options label aligns inside the shaded box.

## Test plan

- [x] Skyjo: draw/discard/pending row and grids look correct in light and dark mode.
- [x] Multi-round match: score table shows R1, R2, and total; totals update before "Next round" without extra columns.
- [x] Rules: Skyjo copy shows bold and headings correctly.
- [x] Rules → Options: label no longer overlaps the border.
