### PR TITLE
House rule: recycle discard into draw when draw pile is empty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,15 +19,16 @@ This document summarizes how the **card-game** repository is structured, how gam
 | `src/session.ts` | **`createSession`**, **`startNextMatchRound`**, **`continuationOptionsFromSession`** (preserve house rules between match rounds). |
 | `src/session/playerConfig.ts` | **`CreateSessionOptions`** (AI count/difficulties, `skipMatch`, house-rule fields), **`gameSupportsConfigurableAi`**, **`clampAiOpponentCount`**, manifest AI count normalization. |
 | `src/core/` | **`GameModule`** contract, **`TableState`**, **`GameAction`**, **`MatchState`**, deck/build helpers, **`registerGameModule`**, shuffle, YAML parsing entry points. |
+| `src/core/discardRecycle.ts` | When the draw pile is empty, optionally **shuffle the discard pile into a new draw pile**; **`isDeckDrawAvailableAfterOptionalRecycle`** for legal-action checks without mutating the table. Used by games with both **`draw`** and **`discard`** when **`reshuffleDiscardWhenDrawEmpty`** is on. |
 | `src/core/types.ts` | Shared types: **`CardInstance`**, **`CardTemplate`**, zones, **`GameManifestYaml`**, **`MatchManifestYaml`**, **`GameAction`** variants. |
-| `src/core/gameModule.ts` | **`GameModuleContext`** (manifest, templates, rng, `matchCumulativeScores`, optional house-rule flags for modules). |
+| `src/core/gameModule.ts` | **`GameModuleContext`** (manifest, templates, rng, `matchCumulativeScores`, optional **`reshuffleDiscardWhenDrawEmpty`**, other house-rule flags for modules). |
 | `src/core/match.ts` | **`MatchState`**, **`applyFinishedRound`**, **`createInitialMatchState`**, end condition **`anyAtOrAbove`**, **`winnerIs`**: `lowest` \| `highest`. |
 | `src/core/table.ts` | **`createEmptyTable`**, **`cloneTable`**, **`moveTop`**, zone helpers. |
 | `src/core/registry.ts` | **`registerGameModule`** / **`getGameModule`** — modules self-register on import. |
 | `src/core/aiContext.ts` | **`AiDifficulty`**: `easy` \| `medium` \| `hard`; **`SelectAiContext`** (difficulty + optional match fields for Skyjo AI). |
 | `src/data/manifests.ts` | **`GAME_SOURCES`**, **`DECK_SOURCES`**, **`GAME_IDS`** — Vite `?raw` imports wiring ids to YAML strings. |
 | `src/data/rulesSources.ts` | **`RULES_SOURCES`**, **`rulesTextForGame`**, **`RulesGameId`** — maps each **`GAME_IDS`** entry to `src/rules/*.md` raw markdown. |
-| `src/data/houseRules.ts` | **`localStorage`** persistence for per-game **house rules**; **`createSessionOptionsHouseRules`** merges into **`CreateSessionOptions`**. |
+| `src/data/houseRules.ts` | **`localStorage`** persistence for per-game **house rules**; **`createSessionOptionsHouseRules`** merges into **`CreateSessionOptions`**; **`GAMES_WITH_DISCARD_RECYCLE_OPTION`** controls which games show the “reshuffle discard when draw empty” toggle; **`effectiveReshuffleDiscardWhenDrawEmpty`** resolves manifest default + stored preference + session options. |
 | `src/decks/*.yaml` | Deck definitions: `standard-52`, `skyjo`, `uno`, `thirty-one-32`, `euchre-24`, `durak-36`, `pinochle-24`, `canasta-108`, `sequence-race-112`, `example-custom`. |
 | `src/games/<id>/` | Per-title **`*.yaml` manifest** + **`index.ts`** module (some **game ids** share one **`module`** id). |
 | `src/games/*/index.ts` | Implements **`GameModule`**: **`setup`**, **`getLegalActions`**, **`applyAction`**, **`selectAiAction`**, **`statusText`**, optional **`extractMatchRoundScores`** / **`isMatchRoundFinished`**. |
@@ -49,7 +50,7 @@ This document summarizes how the **card-game** repository is structured, how gam
    - Parses manifest from **`GAME_SOURCES[gameId]`** (and may override **`match.targetScore`** from house rules when **not** continuing a match).
    - Applies **`manifestWithAiOpponents`** when **`CreateSessionOptions.aiCount`** is set.
    - Builds **`MatchState`** from manifest when **`match.enabled`** and not **`skipMatch`**, unless **`carryMatch`** is passed (next round).
-   - Loads deck YAML, **`buildDeckInstances`**, calls **`module.setup(ctx, instances)`** with **`GameModuleContext`** (including house-rule flags).
+   - Loads deck YAML, **`buildDeckInstances`**, calls **`module.setup(ctx, instances)`** with **`GameModuleContext`** (including house-rule flags and optional **`reshuffleDiscardWhenDrawEmpty`** for draw+discard games).
 3. **`GameSession`** holds **`manifest`**, **`module`**, **`table`**, **`gameState`**, optional **`match`**, optional **`aiPlayerConfig`**.
 4. **`App`** dispatches **`module.applyAction`** for button or intent-driven actions; **`TableView`** may call **`onTableIntent`** when zones are allowlisted.
 5. When a module implements **`isMatchRoundFinished`** + **`extractMatchRoundScores`**, **`startNextMatchRound`** merges scores via **`applyFinishedRound`** and either ends the match or **`createSession`** again with updated **`carryMatch`** and **`continuationOptionsFromSession`** so house rules persist.
@@ -63,6 +64,7 @@ Parsed as **`GameManifestYaml`** (`src/core/types.ts`). Important fields:
 - **`id`**, **`name`**, **`module`** (registry key — must match **`GameModule.moduleId`** in the TS file), **`deck`** (key into **`DECK_SOURCES`**).
 - **`players.human`**, **`players.ai`** — shell often fixes **`human: 1`** and varies AI count via **`manifestWithAiOpponents`**.
 - **`match`** (optional): **`enabled`**, **`targetScore`**, **`winnerIs`**, **`endCondition`**, **`startingStack`**, **`scoringMode`**, **`scoreLabel`**, etc.
+- **`discardRecycleWhenDrawEmpty`** (optional boolean): default for whether an **empty draw pile** should recycle the **discard** (shuffled) back into **draw** when the game uses both zones. Titles where an empty stock normally **ends** the round (e.g. **thirty-one**) should set **`false`**; casual “keep playing” defaults can set **`true`**. The Rules panel can override per player via **`reshuffleDiscardWhenDrawEmpty`** in **`houseRules`**.
 
 The **game id** in the menu is the manifest **`id`** (e.g. `casino-blackjack`), not always the same string as **`module`** (e.g. `blackjack`).
 
@@ -140,8 +142,8 @@ Keep **`RulesGameId`** in sync with **`GAME_IDS`** in **`rulesSources.ts`**.
 ## House rules (optional table options)
 
 - **`src/data/houseRules.ts`**: **`localStorage`** key **`card-game:house-rules:v1`**, per **`RulesGameId`**.
-- **`GameHouseRulesPanel`** (in Rules modal) edits: **match target**, Skyjo **discard-on-face-up-only**, blackjack **dealer hits soft 17**, War **tie pile size** (1 vs 3).
-- **`createSessionOptionsHouseRules`** merges into **`createSession`**; **`GameModuleContext`** passes module-specific flags into **`setup`**.
+- **`GameHouseRulesPanel`** (in Rules modal) edits: **match target**, Skyjo **discard-on-face-up-only**, blackjack **dealer hits soft 17**, War **tie pile size** (1 vs 3), and for games in **`GAMES_WITH_DISCARD_RECYCLE_OPTION`** (**skyjo**, **uno**, **crazy-eights**, **canasta**, **poker-draw**, **thirty-one**): **reshuffle discard into draw when the draw pile is empty** (stored as **`reshuffleDiscardWhenDrawEmpty`**).
+- **`createSessionOptionsHouseRules`** merges into **`createSession`**; **`continuationOptionsFromSession`** spreads those options so house rules persist across **next match round**. **`GameModuleContext`** passes **`reshuffleDiscardWhenDrawEmpty`** (and other flags) into **`setup`**; modules that implement recycle call **`recycleDiscardIntoDrawWhenEmpty`** / **`isDeckDrawAvailableAfterOptionalRecycle`** from **`src/core/discardRecycle.ts`**.
 
 Agents changing rules behavior should update **both** the module logic and **`src/rules/*.md`** (and optionally **`docs/`**).
 
@@ -154,23 +156,23 @@ Agents changing rules behavior should update **both** the module logic and **`sr
 | `war` | `war` | Step-driven skirmish; **`tieDownCards`** house rule. |
 | `demo-custom` | `demo-custom` | Sample custom deck. |
 | `go-fish` | `go-fish` | Asks, books, draw pile; per-seat AI difficulty. |
-| `skyjo` | `skyjo` | Grid, draw/discard, match play; rich AI; **`discardSwapFaceUpOnly`**. |
+| `skyjo` | `skyjo` | Grid, draw/discard, match play; rich AI; **`discardSwapFaceUpOnly`**; optional **discard→draw recycle** when stock empty (**`discardRecycleWhenDrawEmpty`** / Rules toggle). |
 | `blackjack` | `blackjack` | Chips, bet/hit/stand; **`dealerHitsSoft17`**. |
 | `casino-blackjack` | `blackjack` | Alternate manifest (stacks/target/scoring labels). |
 | `baccarat` | `baccarat` | Player/banker bets. |
 | `mini-baccarat` | `baccarat` | Alternate manifest. |
-| `crazy-eights` | `crazy-eights` | Shedding + eights wild. |
+| `crazy-eights` | `crazy-eights` | Shedding + eights wild; optional **discard recycle** when draw empty. |
 | `switch` | `crazy-eights` | Alternate manifest. |
-| `poker-draw` | `poker-draw` | Draw poker style. |
+| `poker-draw` | `poker-draw` | Draw poker style; optional **discard recycle** when deck empty. |
 | `heads-up-poker` | `poker-draw` | Alternate manifest. |
 | `high-card-duel` | `high-card-duel` | Single-card compare. |
 | `red-dog` | `high-card-duel` | Alternate manifest. |
-| `uno` | `uno` | Custom **uno** deck. |
-| `thirty-one` | `thirty-one` | 32-card Scat-style draw/discard; optional match. |
+| `uno` | `uno` | Custom **uno** deck; optional **discard recycle** when draw empty. |
+| `thirty-one` | `thirty-one` | 32-card Scat-style draw/discard; optional match; **discard recycle** defaults **off** (empty stock often ends the round). |
 | `euchre` | `euchre` | 24-card simplified trick race (four seats, fixed AI count). |
 | `durak` | `durak` | 36-card two-player attack/defend. |
 | `pinochle` | `pinochle` | Double 48-card trick race; templates doubled in `setup`. |
-| `canasta` | `canasta` | 108-card draw-two/discard-one drill (not full canasta). |
+| `canasta` | `canasta` | 108-card draw-two/discard-one drill (not full canasta); optional **discard recycle** when draw empty. |
 | `sequence-race` | `sequence-race` | Custom 112-card “Skip-Bo–style” builder. |
 
 ---
@@ -179,7 +181,7 @@ Agents changing rules behavior should update **both** the module logic and **`sr
 
 1. Add **`src/games/<id>/<id>.yaml`** and **`src/games/<id>/index.ts`** implementing **`GameModule`** + **`registerGameModule`**.
 2. Wire **`GAME_SOURCES`** and (if new) **`DECK_SOURCES`** in **`src/data/manifests.ts`** with `?raw` imports.
-3. Add **`src/rules/<id>.md`** and an entry in **`RULES_SOURCES`** (`src/data/rulesSources.ts`); extend **`GameHouseRules`** / panel only if new options are needed.
+3. Add **`src/rules/<id>.md`** and an entry in **`RULES_SOURCES`** (`src/data/rulesSources.ts`); extend **`GameHouseRules`** / panel only if new options are needed. For **draw + discard** games that should support “shuffle discard into draw when draw is empty,” wire **`src/core/discardRecycle.ts`**, set **`discardRecycleWhenDrawEmpty`** on the manifest, register the id in **`GAMES_WITH_DISCARD_RECYCLE_OPTION`**, and mirror the **`GameHouseRulesPanel`** + **`createSession`** pattern used by Skyjo / Uno.
 4. Update **`App.tsx`** if the shell must handle intents, custom buttons, or special UI (copy patterns from similar games).
 5. Add **`docs/<id>.md`** and a **README** table row if you want public doc parity.
 6. Run **`npm run build`** and **`npm run lint`**.

--- a/src/core/discardRecycle.ts
+++ b/src/core/discardRecycle.ts
@@ -1,0 +1,64 @@
+import { shuffleInPlace } from './shuffle'
+import type { TableState } from './types'
+
+export interface RecycleDiscardIntoDrawOptions {
+  /** When false, no-op. */
+  enabled: boolean
+  /**
+   * When true, keep the current top discard visible and shuffle the rest into the draw pile (Uno / Skyjo style).
+   * When false, move all discard cards into the draw pile and shuffle (discard becomes empty).
+   */
+  preserveTopDiscard: boolean
+}
+
+/**
+ * When the draw pile is empty and the discard pile has cards, shuffle discard into draw.
+ * @returns true if the table was modified.
+ */
+export function recycleDiscardIntoDrawWhenEmpty(
+  table: TableState,
+  rng: () => number,
+  opts: RecycleDiscardIntoDrawOptions,
+): boolean {
+  if (!opts.enabled) return false
+  const draw = table.zones.draw?.cards
+  const disc = table.zones.discard?.cards
+  if (!draw || !disc) return false
+  if (draw.length > 0) return false
+  if (disc.length === 0) return false
+
+  if (opts.preserveTopDiscard) {
+    if (disc.length <= 1) return false
+    const top = disc.pop()!
+    const rest = disc.splice(0, disc.length)
+    shuffleInPlace(rest, rng)
+    draw.push(...rest)
+    disc.length = 0
+    disc.push(top)
+    return true
+  }
+
+  const all = disc.splice(0, disc.length)
+  shuffleInPlace(all, rng)
+  draw.push(...all)
+  return true
+}
+
+/**
+ * True if the player could draw from the deck: either stock has cards, or recycling discard into draw
+ * would refill it (used for legal actions without mutating the table).
+ */
+export function isDeckDrawAvailableAfterOptionalRecycle(
+  table: TableState,
+  recycleEnabled: boolean,
+  preserveTopDiscard: boolean,
+): boolean {
+  const draw = table.zones.draw?.cards
+  if (!draw) return false
+  if (draw.length > 0) return true
+  if (!recycleEnabled) return false
+  const disc = table.zones.discard?.cards
+  if (!disc?.length) return false
+  if (preserveTopDiscard) return disc.length > 1
+  return true
+}

--- a/src/core/gameModule.ts
+++ b/src/core/gameModule.ts
@@ -13,6 +13,11 @@ export interface GameModuleContext {
   dealerHitsSoft17?: boolean
   warTieDownCards?: 1 | 3
   skyjoDiscardSwapFaceUpOnly?: boolean
+  /**
+   * When true, an empty draw pile is refilled by shuffling the discard pile into it (rules vary by game).
+   * Games without both `draw` and `discard` zones ignore this. Omitted or false = no recycle.
+   */
+  reshuffleDiscardWhenDrawEmpty?: boolean
 }
 
 export interface ApplyResult<TGame> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -107,6 +107,11 @@ export interface GameManifestYaml {
   ai?: Record<string, unknown>
   /** When set, session may track cumulative scores across rounds (see core/match.ts). */
   match?: MatchManifestYaml
+  /**
+   * When both draw and discard piles exist: default for “shuffle discard into draw when draw is empty”.
+   * House rule can override; see `data/houseRules.ts` per-game defaults.
+   */
+  discardRecycleWhenDrawEmpty?: boolean
 }
 
 export type GameAction =

--- a/src/data/houseRules.ts
+++ b/src/data/houseRules.ts
@@ -1,3 +1,4 @@
+import type { GameManifestYaml } from '../core/types'
 import type { CreateSessionOptions } from '../session/playerConfig'
 import type { RulesGameId } from './rulesSources'
 
@@ -13,6 +14,31 @@ export interface GameHouseRules {
   dealerHitsSoft17?: boolean
   /** War: face-down cards placed before each tie-break flip (1 = quick, 3 = classic). */
   warTieDownCards?: 1 | 3
+  /**
+   * When true, empty draw pile is refilled by shuffling the discard pile (games with draw + discard only).
+   * Omitted = use manifest default or built-in per-game default.
+   */
+  reshuffleDiscardWhenDrawEmpty?: boolean
+}
+
+/** Games that expose the discard→draw recycle toggle in Rules → Options. */
+export const GAMES_WITH_DISCARD_RECYCLE_OPTION: ReadonlySet<RulesGameId> = new Set([
+  'skyjo',
+  'uno',
+  'crazy-eights',
+  'canasta',
+  'poker-draw',
+  'thirty-one',
+])
+
+/** Built-in default when manifest + house rule do not set a preference. */
+const DISCARD_RECYCLE_DEFAULT_BY_GAME: Partial<Record<RulesGameId, boolean>> = {
+  skyjo: true,
+  uno: true,
+  'crazy-eights': true,
+  canasta: true,
+  'poker-draw': true,
+  'thirty-one': false,
 }
 
 export type HouseRulesStore = Partial<Record<RulesGameId, GameHouseRules>>
@@ -63,6 +89,25 @@ export function patchHouseRulesForGame(gameId: RulesGameId, patch: HouseRulesPat
   return next
 }
 
+/** Manifest + built-in default only (no saved house rule). */
+export function defaultReshuffleDiscardWhenDrawEmpty(gameId: RulesGameId, manifest: GameManifestYaml): boolean {
+  if (typeof manifest.discardRecycleWhenDrawEmpty === 'boolean') return manifest.discardRecycleWhenDrawEmpty
+  return DISCARD_RECYCLE_DEFAULT_BY_GAME[gameId] ?? false
+}
+
+export function effectiveReshuffleDiscardWhenDrawEmpty(
+  gameId: RulesGameId,
+  manifest: GameManifestYaml,
+  options?: CreateSessionOptions,
+): boolean {
+  if (options?.reshuffleDiscardWhenDrawEmpty === true) return true
+  if (options?.reshuffleDiscardWhenDrawEmpty === false) return false
+  const hr = getHouseRulesForGame(gameId)
+  if (hr.reshuffleDiscardWhenDrawEmpty === true) return true
+  if (hr.reshuffleDiscardWhenDrawEmpty === false) return false
+  return defaultReshuffleDiscardWhenDrawEmpty(gameId, manifest)
+}
+
 export function clampMatchTargetScore(n: number, fallback: number): number {
   const x = Math.floor(Number(n))
   if (!Number.isFinite(x)) return fallback
@@ -77,5 +122,7 @@ export function createSessionOptionsHouseRules(gameId: RulesGameId): Partial<Cre
   if (hr.skyjoDiscardSwapFaceUpOnly) o.skyjoDiscardSwapFaceUpOnly = true
   if (hr.dealerHitsSoft17) o.dealerHitsSoft17 = true
   if (hr.warTieDownCards === 1 || hr.warTieDownCards === 3) o.warTieDownCards = hr.warTieDownCards
+  if (hr.reshuffleDiscardWhenDrawEmpty === true) o.reshuffleDiscardWhenDrawEmpty = true
+  if (hr.reshuffleDiscardWhenDrawEmpty === false) o.reshuffleDiscardWhenDrawEmpty = false
   return o
 }

--- a/src/games/canasta/index.ts
+++ b/src/games/canasta/index.ts
@@ -1,3 +1,4 @@
+import { recycleDiscardIntoDrawWhenEmpty, isDeckDrawAvailableAfterOptionalRecycle } from '../../core/discardRecycle'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import { newInstanceId } from '../../core/deck'
 import type { CardInstance, GameAction, GameManifestYaml } from '../../core/types'
@@ -27,6 +28,7 @@ export interface CanastaGameState {
   drewThisTurn: boolean
   message: string
   roundScores: number[] | null
+  reshuffleDiscardWhenDrawEmpty: boolean
 }
 
 const canastaModule: GameModule<CanastaGameState> = {
@@ -75,15 +77,15 @@ const canastaModule: GameModule<CanastaGameState> = {
         drewThisTurn: false,
         message: 'Draw two from stock, then discard one to end your turn. Empty your hand to win the round.',
         roundScores: null,
+        reshuffleDiscardWhenDrawEmpty: ctx.reshuffleDiscardWhenDrawEmpty ?? false,
       },
     }
   },
 
   getLegalActions(table, gs) {
     if (gs.phase !== 'play' || gs.currentPlayer !== 0) return []
-    const stock = table.zones.draw!.cards.length
     if (!gs.drewThisTurn) {
-      if (stock === 0) {
+      if (!isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
         const hz = table.zones['hand:0']!.cards
         return hz.map((_, i) => ({ type: 'custom', payload: { cmd: 'cnsDiscard', index: i } }) as GameAction)
       }
@@ -120,6 +122,10 @@ const canastaModule: GameModule<CanastaGameState> = {
     if (command === 'cnsDrawTwo') {
       if (cur !== gs.currentPlayer) return { table: t, gameState: gs, error: 'Not your turn.' }
       if (gs.drewThisTurn) return { table: t, gameState: gs, error: 'Already drew.' }
+      recycleDiscardIntoDrawWhenEmpty(t, () => Math.random(), {
+        enabled: gs.reshuffleDiscardWhenDrawEmpty,
+        preserveTopDiscard: true,
+      })
       const stock = t.zones.draw!.cards.length
       if (stock === 0) return { table: t, gameState: gs, error: 'Stock empty — discard only.' }
       const n = Math.min(2, stock)
@@ -168,9 +174,10 @@ const canastaModule: GameModule<CanastaGameState> = {
   selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext) {
     void context
     if (gs.phase !== 'play' || playerIndex !== gs.currentPlayer) return null
-    const stock = table.zones.draw!.cards.length
     if (!gs.drewThisTurn) {
-      if (stock > 0) return { type: 'custom', payload: { cmd: 'cnsDrawTwo' } }
+      if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
+        return { type: 'custom', payload: { cmd: 'cnsDrawTwo' } }
+      }
     }
     const hand = table.zones[handId(playerIndex)]!.cards
     if (!hand.length) return null

--- a/src/games/crazy-eights/index.ts
+++ b/src/games/crazy-eights/index.ts
@@ -1,6 +1,7 @@
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
+import { recycleDiscardIntoDrawWhenEmpty, isDeckDrawAvailableAfterOptionalRecycle } from '../../core/discardRecycle'
 import { mulberry32, shuffleInPlace } from '../../core/shuffle'
 import { cloneTable, createEmptyTable, moveTop } from '../../core/table'
 import type { TableState } from '../../core/types'
@@ -23,6 +24,7 @@ export interface Crazy8sGameState {
   currentSuit: string
   message: string
   roundScores: number[] | null
+  reshuffleDiscardWhenDrawEmpty: boolean
 }
 
 function topDiscard(table: TableState): { templateId: string } | null {
@@ -95,6 +97,7 @@ const crazy8sModule: GameModule<Crazy8sGameState> = {
         currentSuit: suit,
         message: 'Play a card matching rank or suit, or an 8.',
         roundScores: null,
+        reshuffleDiscardWhenDrawEmpty: ctx.reshuffleDiscardWhenDrawEmpty ?? false,
       },
     }
   },
@@ -117,7 +120,7 @@ const crazy8sModule: GameModule<Crazy8sGameState> = {
         }
       }
     })
-    if (table.zones.draw!.cards.length > 0) {
+    if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
       out.push({ type: 'custom', payload: { cmd: 'c8Draw' } })
     }
     return out
@@ -134,6 +137,11 @@ const crazy8sModule: GameModule<Crazy8sGameState> = {
     const hz = t.zones[hid]!.cards
 
     if (c === 'c8Draw') {
+      const rng = () => Math.random()
+      recycleDiscardIntoDrawWhenEmpty(t, rng, {
+        enabled: gs.reshuffleDiscardWhenDrawEmpty,
+        preserveTopDiscard: true,
+      })
       if (t.zones.draw!.cards.length === 0) return { table: t, gameState: gs, error: 'Deck empty.' }
       moveTop(t, 'draw', hid, cp === 0)
       return {
@@ -175,6 +183,7 @@ const crazy8sModule: GameModule<Crazy8sGameState> = {
             currentSuit: suit,
             roundScores: scores,
             message: `Player ${cp} went out!`,
+            reshuffleDiscardWhenDrawEmpty: gs.reshuffleDiscardWhenDrawEmpty,
           },
         }
       }
@@ -211,7 +220,9 @@ const crazy8sModule: GameModule<Crazy8sGameState> = {
       }
       return { type: 'custom', payload: { cmd: 'c8Play', index: pick } }
     }
-    if (table.zones.draw!.cards.length > 0) return { type: 'custom', payload: { cmd: 'c8Draw' } }
+    if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
+      return { type: 'custom', payload: { cmd: 'c8Draw' } }
+    }
     return null
   },
 

--- a/src/games/poker-draw/index.ts
+++ b/src/games/poker-draw/index.ts
@@ -1,3 +1,4 @@
+import { recycleDiscardIntoDrawWhenEmpty } from '../../core/discardRecycle'
 import type { ApplyResult, GameModule, GameModuleContext } from '../../core/gameModule'
 import type { CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
@@ -38,6 +39,7 @@ export interface PokerDrawGameState {
   ante: number
   roundDelta: [number, number] | null
   message: string
+  reshuffleDiscardWhenDrawEmpty: boolean
 }
 
 const pokerDrawModule: GameModule<PokerDrawGameState> = {
@@ -67,6 +69,7 @@ const pokerDrawModule: GameModule<PokerDrawGameState> = {
         ante: 10,
         roundDelta: null,
         message: 'Ante 10 chips. Then replace 0–3 cards from the front of your hand (same count for both). Highest rank wins the pot.',
+        reshuffleDiscardWhenDrawEmpty: ctx.reshuffleDiscardWhenDrawEmpty ?? false,
       },
     }
   },
@@ -114,12 +117,17 @@ const pokerDrawModule: GameModule<PokerDrawGameState> = {
           phase: 'draw',
           stacks: afterAnte,
           message: 'How many cards to replace (0–3)? Same count is applied to both hands.',
+          reshuffleDiscardWhenDrawEmpty: gs.reshuffleDiscardWhenDrawEmpty,
         },
       }
     }
 
     if (gs.phase === 'draw' && c === 'p5Draw') {
       const count = Math.min(3, Math.max(0, Number((action.payload as { count?: number }).count)))
+      recycleDiscardIntoDrawWhenEmpty(t, () => Math.random(), {
+        enabled: gs.reshuffleDiscardWhenDrawEmpty,
+        preserveTopDiscard: true,
+      })
       const drawPile = t.zones.draw!.cards
       if (count * 2 > drawPile.length) {
         return { table: t, gameState: gs, error: 'Not enough cards to replace that many.' }
@@ -169,6 +177,7 @@ const pokerDrawModule: GameModule<PokerDrawGameState> = {
           ante: gs.ante,
           roundDelta: [s0 - preAnte0, s1 - preAnte1],
           message,
+          reshuffleDiscardWhenDrawEmpty: gs.reshuffleDiscardWhenDrawEmpty,
         },
       }
     }

--- a/src/games/skyjo/index.ts
+++ b/src/games/skyjo/index.ts
@@ -3,6 +3,7 @@ import type { CardInstance, GameAction, GameManifestYaml } from '../../core/type
 import type { CardTemplate } from '../../core/types'
 import { playerSeatLabel } from '../../core/playerLabels'
 import { registerGameModule } from '../../core/registry'
+import { recycleDiscardIntoDrawWhenEmpty, isDeckDrawAvailableAfterOptionalRecycle } from '../../core/discardRecycle'
 import { mulberry32, shuffleInPlace } from '../../core/shuffle'
 import { cloneTable, createEmptyTable } from '../../core/table'
 import type { TableState } from '../../core/types'
@@ -51,17 +52,8 @@ function pushDiscard(table: TableState, card: CardInstance): void {
   table.zones.discard!.cards.push(card)
 }
 
-function recycleDiscardIfDrawEmpty(table: TableState, rng: () => number): void {
-  const draw = table.zones.draw!.cards
-  if (draw.length > 0) return
-  const disc = table.zones.discard!.cards
-  if (disc.length <= 1) return
-  const top = disc.pop()!
-  const rest = disc.splice(0, disc.length)
-  shuffleInPlace(rest, rng)
-  draw.push(...rest)
-  disc.length = 0
-  disc.push(top)
+function recycleDiscardIfDrawEmpty(table: TableState, rng: () => number, enabled: boolean): void {
+  recycleDiscardIntoDrawWhenEmpty(table, rng, { enabled, preserveTopDiscard: true })
 }
 
 function columnIndices(c: number): [number, number, number] {
@@ -408,6 +400,8 @@ export interface SkyjoGameState {
    * (face-down cells accept deck draws only).
    */
   discardSwapFaceUpOnly: boolean
+  /** House rule: shuffle discard into draw when draw is empty (except visible top discard). */
+  reshuffleDiscardWhenDrawEmpty: boolean
 }
 
 function buildLegalActions(table: TableState, gs: SkyjoGameState): GameAction[] {
@@ -437,7 +431,7 @@ function buildLegalActions(table: TableState, gs: SkyjoGameState): GameAction[] 
   }
 
   const actions: GameAction[] = []
-  if (table.zones.draw!.cards.length > 0) {
+  if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
     actions.push({ type: 'skyjoDraw', from: 'deck' })
   }
   if (table.zones.discard!.cards.length > 0) {
@@ -788,6 +782,7 @@ const skyjoModule: GameModule<SkyjoGameState> = {
   setup(ctx: GameModuleContext, instances: CardInstance[]) {
     const { manifest, templates, rng } = ctx
     const discardSwapFaceUpOnly = ctx.skyjoDiscardSwapFaceUpOnly ?? false
+    const reshuffleDiscardWhenDrawEmpty = ctx.reshuffleDiscardWhenDrawEmpty ?? false
     const pCount = totalPlayers(manifest)
     const rngFn = mulberry32(Math.floor(rng() * 0xffffffff))
 
@@ -853,6 +848,7 @@ const skyjoModule: GameModule<SkyjoGameState> = {
         roundScores: null,
         finisherDoubled: false,
         discardSwapFaceUpOnly,
+        reshuffleDiscardWhenDrawEmpty,
       },
     }
   },
@@ -877,12 +873,12 @@ const skyjoModule: GameModule<SkyjoGameState> = {
       return { table, gameState, error: 'Wait for the correct final-turn player.' }
     }
 
-    recycleDiscardIfDrawEmpty(t, rngFn)
+    recycleDiscardIfDrawEmpty(t, rngFn, gameState.reshuffleDiscardWhenDrawEmpty)
 
     const gs = gameState
 
     const endTurn = (next: Partial<SkyjoGameState>, finished: number): ApplyResult<SkyjoGameState> => {
-      recycleDiscardIfDrawEmpty(t, rngFn)
+      recycleDiscardIfDrawEmpty(t, rngFn, gs.reshuffleDiscardWhenDrawEmpty)
       if (gs.phase === 'final' && gs.finalQueue.length > 0) {
         const q = [...gs.finalQueue]
         if (q[0] === finished) {
@@ -1020,10 +1016,10 @@ const skyjoModule: GameModule<SkyjoGameState> = {
     }
 
     if (action.type === 'skyjoDraw' && action.from === 'deck') {
-      recycleDiscardIfDrawEmpty(t, rngFn)
+      recycleDiscardIfDrawEmpty(t, rngFn, gs.reshuffleDiscardWhenDrawEmpty)
       const drawn = popTopDraw(t)
       if (!drawn) {
-        recycleDiscardIfDrawEmpty(t, rngFn)
+        recycleDiscardIfDrawEmpty(t, rngFn, gs.reshuffleDiscardWhenDrawEmpty)
         const d2 = popTopDraw(t)
         if (!d2) return { table, gameState, error: 'Draw pile is empty.' }
         d2.faceUp = true

--- a/src/games/skyjo/skyjo.yaml
+++ b/src/games/skyjo/skyjo.yaml
@@ -12,3 +12,5 @@ match:
   endCondition: anyAtOrAbove
 ai:
   strategy: simple
+# Default for house rule “recycle discard into draw” (overridable in Rules → Options)
+discardRecycleWhenDrawEmpty: true

--- a/src/games/thirty-one/index.ts
+++ b/src/games/thirty-one/index.ts
@@ -1,3 +1,4 @@
+import { recycleDiscardIntoDrawWhenEmpty, isDeckDrawAvailableAfterOptionalRecycle } from '../../core/discardRecycle'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
@@ -61,7 +62,7 @@ function legalForSeat(table: TableState, gs: ThirtyOneGameState, cur: number): G
   if (hz.length !== 3) return []
   const out: GameAction[] = []
   out.push({ type: 'custom', payload: { cmd: 't31Knock' } })
-  if (table.zones.draw!.cards.length > 0) {
+  if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
     for (let i = 0; i < hz.length; i++) {
       out.push({ type: 'custom', payload: { cmd: 't31DrawStock', discardIndex: i } })
     }
@@ -80,6 +81,7 @@ export interface ThirtyOneGameState {
   currentPlayer: number
   message: string
   roundScores: number[] | null
+  reshuffleDiscardWhenDrawEmpty: boolean
 }
 
 const thirtyOneModule: GameModule<ThirtyOneGameState> = {
@@ -119,6 +121,7 @@ const thirtyOneModule: GameModule<ThirtyOneGameState> = {
         currentPlayer: 0,
         message: 'Draw or take discard, then discard. Knock to end the round now.',
         roundScores: null,
+        reshuffleDiscardWhenDrawEmpty: ctx.reshuffleDiscardWhenDrawEmpty ?? false,
       },
     }
   },
@@ -160,6 +163,10 @@ const thirtyOneModule: GameModule<ThirtyOneGameState> = {
       if (c === 't31DrawStock') {
         const di = Number((action.payload as { discardIndex?: unknown }).discardIndex)
         if (!Number.isInteger(di) || di < 0 || di >= hz.length) return { table: t, gameState: gs, error: 'Bad discard index.' }
+        recycleDiscardIntoDrawWhenEmpty(t, () => Math.random(), {
+          enabled: gs.reshuffleDiscardWhenDrawEmpty,
+          preserveTopDiscard: true,
+        })
         if (t.zones.draw!.cards.length === 0) return { table: t, gameState: gs, error: 'Deck empty.' }
         const drawn = moveTop(t, 'draw', handId(cur), cur === 0)
         if (!drawn) return { table: t, gameState: gs, error: 'Draw failed.' }
@@ -172,6 +179,10 @@ const thirtyOneModule: GameModule<ThirtyOneGameState> = {
           currentPlayer: (cur + 1) % pc,
           message: 'Next player’s turn.',
         }
+        recycleDiscardIntoDrawWhenEmpty(t, () => Math.random(), {
+          enabled: gs.reshuffleDiscardWhenDrawEmpty,
+          preserveTopDiscard: true,
+        })
         if (t.zones.draw!.cards.length === 0) {
           const { winner } = showdownScores(t, pc)
           return finishRound(next, winner)
@@ -194,6 +205,10 @@ const thirtyOneModule: GameModule<ThirtyOneGameState> = {
           currentPlayer: (cur + 1) % pc,
           message: 'Next player’s turn.',
         }
+        recycleDiscardIntoDrawWhenEmpty(t, () => Math.random(), {
+          enabled: gs.reshuffleDiscardWhenDrawEmpty,
+          preserveTopDiscard: true,
+        })
         if (t.zones.draw!.cards.length === 0) {
           const { winner } = showdownScores(t, pc)
           return finishRound(next, winner)

--- a/src/games/thirty-one/thirty-one.yaml
+++ b/src/games/thirty-one/thirty-one.yaml
@@ -1,6 +1,8 @@
 id: thirty-one
 name: Thirty-One (Scat)
 module: thirty-one
+# Typical 31: round ends when the deck is exhausted; recycle off by default (toggle in Rules → Options)
+discardRecycleWhenDrawEmpty: false
 deck: thirty-one-32
 players:
   human: 1

--- a/src/games/uno/index.ts
+++ b/src/games/uno/index.ts
@@ -1,6 +1,7 @@
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
+import { recycleDiscardIntoDrawWhenEmpty } from '../../core/discardRecycle'
 import { mulberry32, shuffleInPlace } from '../../core/shuffle'
 import { cloneTable, createEmptyTable, moveTop } from '../../core/table'
 import type { TableState } from '../../core/types'
@@ -64,22 +65,8 @@ function step(cur: number, direction: number, n: number): number {
   return (cur + direction + n * 100) % n
 }
 
-function reshuffleDrawFromDiscard(table: TableState, rng: () => number): void {
-  const draw = table.zones.draw!
-  const disc = table.zones.discard!
-  if (draw.cards.length > 0 || disc.cards.length <= 1) return
-  const top = disc.cards.pop()!
-  const rest = [...disc.cards]
-  disc.cards.length = 0
-  disc.cards.push(top)
-  shuffleInPlace(rest, rng)
-  for (const c of rest) {
-    draw.cards.push(c)
-  }
-}
-
-function ensureDraw(table: TableState, rng: () => number): void {
-  reshuffleDrawFromDiscard(table, rng)
+function ensureDraw(table: TableState, rng: () => number, reshuffleEnabled: boolean): void {
+  recycleDiscardIntoDrawWhenEmpty(table, rng, { enabled: reshuffleEnabled, preserveTopDiscard: true })
 }
 
 function handValue(templates: Record<string, CardTemplate>, cards: CardInstance[]): number {
@@ -107,6 +94,7 @@ export interface UnoGameState {
   drawSlot: number | null
   message: string
   roundScores: number[] | null
+  reshuffleDiscardWhenDrawEmpty: boolean
 }
 
 function roundOverScores(
@@ -132,7 +120,7 @@ function computeLegalActions(
   rng: () => number,
 ): GameAction[] {
   if (gs.phase !== 'play' || gs.currentPlayer !== playerIndex) return []
-  ensureDraw(table, rng)
+  ensureDraw(table, rng, gs.reshuffleDiscardWhenDrawEmpty)
   const top = topDiscard(table)
   if (!top) return []
   const templates = table.templates
@@ -240,6 +228,7 @@ const unoModule: GameModule<UnoGameState> = {
         drawSlot: null,
         message: 'Match color or number — Wilds are always playable.',
         roundScores: null,
+        reshuffleDiscardWhenDrawEmpty: ctx.reshuffleDiscardWhenDrawEmpty ?? false,
       },
     }
   },
@@ -278,7 +267,7 @@ const unoModule: GameModule<UnoGameState> = {
 
     if (c === 'unoPass') {
       if (gs.drewThisTurn) return { table: t, gameState: gs, error: 'Finish draw step.' }
-      ensureDraw(t, rng)
+      ensureDraw(t, rng, gs.reshuffleDiscardWhenDrawEmpty)
       if (t.zones.draw!.cards.length > 0) return { table: t, gameState: gs, error: 'Must draw.' }
       const next = step(cp, gs.direction, pCount)
       return {
@@ -298,7 +287,7 @@ const unoModule: GameModule<UnoGameState> = {
       const topTpl = templates[top.templateId]!
       const hasPlay = hz.some((card) => canPlay(templates[card.templateId]!, topTpl, gs.currentColor))
       if (hasPlay) return { table: t, gameState: gs, error: 'You have a playable card.' }
-      ensureDraw(t, rng)
+      ensureDraw(t, rng, gs.reshuffleDiscardWhenDrawEmpty)
       if (t.zones.draw!.cards.length === 0) return { table: t, gameState: gs, error: 'Cannot draw.' }
       moveTop(t, 'draw', hid, cp === 0)
       const newSlot = hz.length - 1
@@ -361,6 +350,7 @@ const unoModule: GameModule<UnoGameState> = {
           drawSlot: null,
           message: `Player ${cp} went out!`,
           roundScores: scores,
+          reshuffleDiscardWhenDrawEmpty: gs.reshuffleDiscardWhenDrawEmpty,
         },
       }
     }
@@ -371,7 +361,7 @@ const unoModule: GameModule<UnoGameState> = {
 
     const victimDraw = (victim: number, count: number) => {
       for (let i = 0; i < count; i++) {
-        ensureDraw(t, rng)
+        ensureDraw(t, rng, gs.reshuffleDiscardWhenDrawEmpty)
         if (t.zones.draw!.cards.length === 0) break
         moveTop(t, 'draw', handId(victim), victim === 0)
       }

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,7 +12,8 @@ import {
   normalizeAiDifficultiesForCount,
   type CreateSessionOptions,
 } from './session/playerConfig'
-import { clampMatchTargetScore } from './data/houseRules'
+import { clampMatchTargetScore, createSessionOptionsHouseRules, effectiveReshuffleDiscardWhenDrawEmpty } from './data/houseRules'
+import type { RulesGameId } from './data/rulesSources'
 
 export type { MatchState } from './core/match'
 export type { CreateSessionOptions } from './session/playerConfig'
@@ -70,6 +71,12 @@ export function createSession(
   const match: MatchState | undefined =
     options?.skipMatch === true ? undefined : carryMatch ?? createInitialMatchState(manifest)
 
+  const reshuffleDiscardWhenDrawEmpty = effectiveReshuffleDiscardWhenDrawEmpty(
+    gameId as RulesGameId,
+    manifest,
+    options,
+  )
+
   const { table, gameState } = mod.setup(
     {
       manifest,
@@ -79,6 +86,7 @@ export function createSession(
       dealerHitsSoft17: options?.dealerHitsSoft17,
       warTieDownCards: options?.warTieDownCards,
       skyjoDiscardSwapFaceUpOnly: options?.skyjoDiscardSwapFaceUpOnly,
+      reshuffleDiscardWhenDrawEmpty,
     },
     instances,
   )
@@ -120,9 +128,11 @@ export function startNextMatchRound(
 
 /** Preserve house rules and match threshold when dealing the next round. */
 export function continuationOptionsFromSession(prev: GameSession): CreateSessionOptions {
+  const gameId = prev.manifest.id as RulesGameId
   const base: CreateSessionOptions = {
     aiCount: prev.manifest.players.ai,
     aiDifficulties: prev.aiPlayerConfig?.difficulties,
+    ...createSessionOptionsHouseRules(gameId),
   }
   if (prev.match) {
     base.matchTargetScore = prev.match.config.targetScore

--- a/src/session/playerConfig.ts
+++ b/src/session/playerConfig.ts
@@ -26,6 +26,10 @@ export interface CreateSessionOptions {
   dealerHitsSoft17?: boolean
   /** War: face-down cards per player before tie-break flip (1 quick, 3 classic). */
   warTieDownCards?: 1 | 3
+  /**
+   * Override “shuffle discard into draw when draw is empty” for games that support it (see house rules).
+   */
+  reshuffleDiscardWhenDrawEmpty?: boolean
 }
 
 const CONFIGURABLE_AI_GAME_IDS = new Set([

--- a/src/ui/GameHouseRulesPanel.tsx
+++ b/src/ui/GameHouseRulesPanel.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useId, useState } from 'react'
+import { useEffect, useId, useMemo, useReducer, useState } from 'react'
 import type { GameManifestYaml } from '../core/types'
 import {
   clampMatchTargetScore,
+  defaultReshuffleDiscardWhenDrawEmpty,
+  GAMES_WITH_DISCARD_RECYCLE_OPTION,
   getHouseRulesForGame,
   patchHouseRulesForGame,
 } from '../data/houseRules'
@@ -29,6 +31,13 @@ export function GameHouseRulesPanel({ gameId, manifest }: GameHouseRulesPanelPro
   const [warTie, setWarTie] = useState<'1' | '3'>(() =>
     getHouseRulesForGame(gameId).warTieDownCards === 1 ? '1' : '3',
   )
+  const [houseRulesGen, bumpHouseRules] = useReducer((x: number) => x + 1, 0)
+  const houseRules = useMemo(() => {
+    void houseRulesGen
+    return getHouseRulesForGame(gameId)
+  }, [gameId, houseRulesGen])
+  const reshuffleDiscard =
+    houseRules.reshuffleDiscardWhenDrawEmpty ?? defaultReshuffleDiscardWhenDrawEmpty(gameId, manifest)
 
   useEffect(() => {
     const h = getHouseRulesForGame(gameId)
@@ -73,6 +82,23 @@ export function GameHouseRulesPanel({ gameId, manifest }: GameHouseRulesPanelPro
             }}
           />
           <span>{unit} ({manifest.match?.winnerIs === 'highest' ? 'highest' : 'lowest'} total wins)</span>
+        </label>
+      )}
+
+      {GAMES_WITH_DISCARD_RECYCLE_OPTION.has(gameId) && (
+        <label className="app__houseRulesCheck">
+          <input
+            type="checkbox"
+            checked={reshuffleDiscard}
+            onChange={(e) => {
+              patchHouseRulesForGame(gameId, { reshuffleDiscardWhenDrawEmpty: e.target.checked })
+              bumpHouseRules()
+            }}
+          />
+          <span>
+            When the <strong>draw pile</strong> is empty, shuffle the <strong>discard pile</strong> into a new draw pile
+            (top discard stays face-up).
+          </span>
         </label>
       )}
 
@@ -134,7 +160,8 @@ export function GameHouseRulesPanel({ gameId, manifest }: GameHouseRulesPanelPro
         gameId !== 'skyjo' &&
         gameId !== 'war' &&
         gameId !== 'blackjack' &&
-        gameId !== 'casino-blackjack' && (
+        gameId !== 'casino-blackjack' &&
+        !GAMES_WITH_DISCARD_RECYCLE_OPTION.has(gameId) && (
           <p className="app__houseRulesNone">
             No optional table rules are configurable in the app for this game yet (open Rules on Skyjo, War, or Blackjack
             variants to see examples).


### PR DESCRIPTION
## Summary

Adds a framework-level house rule: when the **draw pile is empty**, optionally **shuffle the discard pile into a new draw pile** (typical casual table behavior). Games that treat an empty deck as round/game over can leave this off via manifest defaults or the Rules panel.

## Changes

- **Core:** \src/core/discardRecycle.ts\ — recycle helper + \isDeckDrawAvailableAfterOptionalRecycle\ for legal-action checks without mutating state in \getLegalActions\.
- **Config:** \GameManifestYaml.discardRecycleWhenDrawEmpty\, session/options wiring, \houseRules\ defaults and \GAMES_WITH_DISCARD_RECYCLE_OPTION\ (Skyjo, Uno, Crazy Eights, Canasta, Poker-draw, Thirty-one).
- **Defaults:** Most listed games default **on**; **Thirty-one** defaults **off** (empty stock often ends the round).
- **UI:** Rules panel checkbox when the game exposes both draw and discard piles.
- **Games:** Skyjo, Uno, Crazy Eights, Canasta, Thirty-one, Poker-draw wired to the flag.

## Notes

- \GameHouseRulesPanel\ still has a pre-existing \set-state-in-effect\ lint on the legacy sync effect; not introduced by this PR.

Made with [Cursor](https://cursor.com)