### PR TITLE
docs: link game docs to rules sources and project wiki

### DIFF
--- a/docs/baccarat.md
+++ b/docs/baccarat.md
@@ -7,3 +7,8 @@ Punto banco–style **two-card** hands for “player” and “banker” seats. 
 **Chips / match:** bankrolls and round deltas feed the multi-round match — see [`src/games/baccarat/baccarat.yaml`](../src/games/baccarat/baccarat.yaml).
 
 **Also see:** [Mini Baccarat](mini-baccarat.md) (same engine).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/baccarat.md`](../src/rules/baccarat.md)
+- **Project wiki:** [Baccarat](https://github.com/MichaelJ43/card-game/wiki/Baccarat)

--- a/docs/blackjack.md
+++ b/docs/blackjack.md
@@ -7,3 +7,8 @@ Heads-up **blackjack** vs a dealer seat: place a bet, receive two cards, then **
 **Chips / match:** cumulative scores represent **chip stacks** (`scoringMode: chips`). Default manifest uses a starting stack and a target chip total to win the match — see [`src/games/blackjack/blackjack.yaml`](../src/games/blackjack/blackjack.yaml).
 
 **Also see:** [Casino Blackjack](casino-blackjack.md) (same module, different defaults).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/blackjack.md`](../src/rules/blackjack.md)
+- **Project wiki:** [Blackjack](https://github.com/MichaelJ43/card-game/wiki/Blackjack)

--- a/docs/canasta.md
+++ b/docs/canasta.md
@@ -4,4 +4,7 @@
 2. This is a shedding drill, not tournament canasta (no melds or piles).
 3. Draw two, discard one, first to empty hand wins the round.
 
-See [`src/rules/canasta.md`](../src/rules/canasta.md).
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/canasta.md`](../src/rules/canasta.md)
+- **Project wiki:** [Canasta](https://github.com/MichaelJ43/card-game/wiki/Canasta)

--- a/docs/casino-blackjack.md
+++ b/docs/casino-blackjack.md
@@ -5,3 +5,8 @@
 Same rules and UI actions as **Blackjack** — bet, hit, stand, round scoring, and **Next round (apply scores)** when a hand completes.
 
 **Difference:** manifest-only tweaks (e.g. larger starting stack and higher match target). See [`src/games/blackjack/casino-blackjack.yaml`](../src/games/blackjack/casino-blackjack.yaml).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/casino-blackjack.md`](../src/rules/casino-blackjack.md)
+- **Project wiki:** [Casino-blackjack](https://github.com/MichaelJ43/card-game/wiki/Casino-blackjack)

--- a/docs/crazy-eights.md
+++ b/docs/crazy-eights.md
@@ -7,3 +7,8 @@ Shedding game: play a card that matches the **current suit** or **rank** of the 
 **Players:** 2–4 (human + AIs). Match scoring can award a point to the player who goes out first — see manifest.
 
 **Also see:** [Switch](switch.md) (same module, alternate YAML).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/crazy-eights.md`](../src/rules/crazy-eights.md)
+- **Project wiki:** [Crazy-Eights](https://github.com/MichaelJ43/card-game/wiki/Crazy-Eights)

--- a/docs/demo-custom.md
+++ b/docs/demo-custom.md
@@ -9,3 +9,8 @@ A minimal sample game using the small custom symbol deck from [`src/decks/exampl
 **Match:** none.
 
 Use **Play round** (or the game’s primary control) as indicated in the UI to advance the scripted duel.
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/demo-custom.md`](../src/rules/demo-custom.md)
+- **Project wiki:** [Demo-custom](https://github.com/MichaelJ43/card-game/wiki/Demo-custom)

--- a/docs/durak.md
+++ b/docs/durak.md
@@ -4,4 +4,7 @@
 2. Attack/defend flow with trump and refill toward six cards.
 3. Round ends when the stock is empty and one player sheds all cards.
 
-See [`src/rules/durak.md`](../src/rules/durak.md).
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/durak.md`](../src/rules/durak.md)
+- **Project wiki:** [Durak](https://github.com/MichaelJ43/card-game/wiki/Durak)

--- a/docs/euchre.md
+++ b/docs/euchre.md
@@ -4,4 +4,7 @@
 2. Four seats with fixed AI count from the manifest (three computer opponents).
 3. Free-for-all tricks; trump from a turned card; no bowers or bidding.
 
-See [`src/rules/euchre.md`](../src/rules/euchre.md) for the full modal text.
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/euchre.md`](../src/rules/euchre.md)
+- **Project wiki:** [Euchre](https://github.com/MichaelJ43/card-game/wiki/Euchre)

--- a/docs/go-fish.md
+++ b/docs/go-fish.md
@@ -7,3 +7,8 @@ Classic **Go Fish**: ask another player for a rank you hold; if they have any, y
 **Interaction:** choose a rank from your hand, then click an opponent’s hand or books pile to ask. **Pass** appears when the rules allow skipping your turn.
 
 **Match:** optional in manifest; default play is table-focused with books and hand zones.
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/go-fish.md`](../src/rules/go-fish.md)
+- **Project wiki:** [Go-Fish](https://github.com/MichaelJ43/card-game/wiki/Go-Fish)

--- a/docs/heads-up-poker.md
+++ b/docs/heads-up-poker.md
@@ -5,3 +5,8 @@
 Same heads-up draw poker flow: ante, draw round, showdown.
 
 **Difference:** manifest-only (stacks / targets). See [`src/games/poker-draw/heads-up-poker.yaml`](../src/games/poker-draw/heads-up-poker.yaml).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/heads-up-poker.md`](../src/rules/heads-up-poker.md)
+- **Project wiki:** [Heads-up-poker](https://github.com/MichaelJ43/card-game/wiki/Heads-up-poker)

--- a/docs/high-card-duel.md
+++ b/docs/high-card-duel.md
@@ -7,3 +7,8 @@ Each side antes **5** or **10** chips (when both can cover it), then one card is
 **Chips / match:** see [`src/games/high-card-duel/high-card-duel.yaml`](../src/games/high-card-duel/high-card-duel.yaml).
 
 **Also see:** [Red Dog](red-dog.md) (same engine).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/high-card-duel.md`](../src/rules/high-card-duel.md)
+- **Project wiki:** [High-card-duel](https://github.com/MichaelJ43/card-game/wiki/High-card-duel)

--- a/docs/mini-baccarat.md
+++ b/docs/mini-baccarat.md
@@ -5,3 +5,8 @@
 Same flow as **Baccarat**: choose bet size and side, then the round resolves from the dealt hands.
 
 **Difference:** separate manifest entry (name / defaults). Compare [`src/games/baccarat/mini-baccarat.yaml`](../src/games/baccarat/mini-baccarat.yaml) with [`baccarat.yaml`](../src/games/baccarat/baccarat.yaml).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/mini-baccarat.md`](../src/rules/mini-baccarat.md)
+- **Project wiki:** [Mini-baccarat](https://github.com/MichaelJ43/card-game/wiki/Mini-baccarat)

--- a/docs/pinochle.md
+++ b/docs/pinochle.md
@@ -4,4 +4,7 @@
 2. Twelve tricks, fixed trump, simplified in-suit ordering.
 3. Match scoring accumulates tricks per hand toward a configurable goal.
 
-See [`src/rules/pinochle.md`](../src/rules/pinochle.md).
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/pinochle.md`](../src/rules/pinochle.md)
+- **Project wiki:** [Pinochle](https://github.com/MichaelJ43/card-game/wiki/Pinochle)

--- a/docs/poker-draw.md
+++ b/docs/poker-draw.md
@@ -7,3 +7,8 @@ Heads-up **five-card draw**: pay the **ante**, receive five cards, then choose h
 **Chips / match:** antes and pots adjust chip stacks; match ends at a chip target — see [`src/games/poker-draw/poker-draw.yaml`](../src/games/poker-draw/poker-draw.yaml).
 
 **Also see:** [Heads-up poker](heads-up-poker.md) (same module).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/poker-draw.md`](../src/rules/poker-draw.md)
+- **Project wiki:** [Poker-draw](https://github.com/MichaelJ43/card-game/wiki/Poker-draw)

--- a/docs/red-dog.md
+++ b/docs/red-dog.md
@@ -5,3 +5,8 @@
 Uses the same high-card duel flow and betting buttons.
 
 **Difference:** alternate manifest only — [`src/games/high-card-duel/red-dog.yaml`](../src/games/high-card-duel/red-dog.yaml).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/red-dog.md`](../src/rules/red-dog.md)
+- **Project wiki:** [Red-dog](https://github.com/MichaelJ43/card-game/wiki/Red-dog)

--- a/docs/sequence-race.md
+++ b/docs/sequence-race.md
@@ -4,4 +4,7 @@
 2. Four shared piles advance 1→…→12→1; Wild cards match the current need.
 3. End turn draws up to five from stock; first empty hand wins the round.
 
-See [`src/rules/sequence-race.md`](../src/rules/sequence-race.md).
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/sequence-race.md`](../src/rules/sequence-race.md)
+- **Project wiki:** [Sequence-race](https://github.com/MichaelJ43/card-game/wiki/Sequence-race)

--- a/docs/skyjo.md
+++ b/docs/skyjo.md
@@ -9,3 +9,8 @@ Skyjo-style round play: grid of face-down/face-up cards, draw pile, discard, and
 **UI:** follow the on-screen hints for dump & flip, swap, and discard flows.
 
 See [`src/games/skyjo/skyjo.yaml`](../src/games/skyjo/skyjo.yaml) for bundled match parameters.
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/skyjo.md`](../src/rules/skyjo.md)
+- **Project wiki:** [Skyjo](https://github.com/MichaelJ43/card-game/wiki/Skyjo)

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -5,3 +5,8 @@
 **Switch** uses the same engine as Crazy Eights (discard matching, eights, draw). Pick this entry for an alternate packaged manifest / labeling.
 
 Compare [`src/games/crazy-eights/switch.yaml`](../src/games/crazy-eights/switch.yaml) with [`crazy-eights.yaml`](../src/games/crazy-eights/crazy-eights.yaml).
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/switch.md`](../src/rules/switch.md)
+- **Project wiki:** [Switch](https://github.com/MichaelJ43/card-game/wiki/Switch)

--- a/docs/thirty-one.md
+++ b/docs/thirty-one.md
@@ -1,7 +1,12 @@
 # Thirty-One (Scat)
 
-Browser table notes for the `thirty-one` game id. Authoritative in-app copy lives in [`src/rules/thirty-one.md`](../src/rules/thirty-one.md).
+Browser table notes for the `thirty-one` game id.
 
 1. Uses deck id `thirty-one-32` (32 cards: 7–A).
 2. Module id `thirty-one`; optional match play to 5 round wins by default.
 3. House rules storage can adjust match target when the manifest enables a match.
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/thirty-one.md`](../src/rules/thirty-one.md)
+- **Project wiki:** [Thirty-one](https://github.com/MichaelJ43/card-game/wiki/Thirty-one)

--- a/docs/uno.md
+++ b/docs/uno.md
@@ -11,3 +11,8 @@ Uno-style shedding: match the **current color** or the **face** of the top disca
 **Players:** 2–4 (human + AIs).
 
 *Uno® is a trademark of Mattel. This is an independent fan-style implementation for the table engine.*
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/uno.md`](../src/rules/uno.md)
+- **Project wiki:** [Uno](https://github.com/MichaelJ43/card-game/wiki/Uno)

--- a/docs/war.md
+++ b/docs/war.md
@@ -9,3 +9,8 @@ Two players split the deck and reveal one card per round; higher rank wins both 
 **Match:** none — single continuous session unless you use **New deal** / **End game**.
 
 See the in-app status line for the current phase and outcome text.
+
+## See also
+
+- **In-app rules** (modal text bundled in the app): [`src/rules/war.md`](../src/rules/war.md)
+- **Project wiki:** [War](https://github.com/MichaelJ43/card-game/wiki/War)


### PR DESCRIPTION
## Summary

Updates every `docs/<game>.md` with a **See also** section that:

1. Links to the corresponding **in-app rules** markdown (`src/rules/<gameId>.md`) — the same copy bundled for the Rules modal.
2. Links to the **[project GitHub wiki](https://github.com/MichaelJ43/card-game/wiki)** with one page slug per game id (e.g. `/wiki/Skyjo`, `/wiki/Go-Fish`). Create wiki pages as needed; URLs follow the usual GitHub wiki naming.

## Notes

- Replaces inline "see `src/rules/...`" sentences in a few docs with the shared section for consistency.
- Wiki links resolve once matching wiki pages exist; until then GitHub shows the wiki home or create flow.
