### PR TITLE
docs: point game docs to Wikipedia instead of project wiki

### DIFF
--- a/docs/baccarat.md
+++ b/docs/baccarat.md
@@ -11,4 +11,4 @@ Punto banco–style **two-card** hands for “player” and “banker” seats. 
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/baccarat.md`](../src/rules/baccarat.md)
-- **Project wiki:** [Baccarat](https://github.com/MichaelJ43/card-game/wiki/Baccarat)
+- **Wikipedia:** [Baccarat](https://en.wikipedia.org/wiki/Baccarat)

--- a/docs/blackjack.md
+++ b/docs/blackjack.md
@@ -11,4 +11,4 @@ Heads-up **blackjack** vs a dealer seat: place a bet, receive two cards, then **
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/blackjack.md`](../src/rules/blackjack.md)
-- **Project wiki:** [Blackjack](https://github.com/MichaelJ43/card-game/wiki/Blackjack)
+- **Wikipedia:** [Blackjack](https://en.wikipedia.org/wiki/Blackjack)

--- a/docs/canasta.md
+++ b/docs/canasta.md
@@ -7,4 +7,4 @@
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/canasta.md`](../src/rules/canasta.md)
-- **Project wiki:** [Canasta](https://github.com/MichaelJ43/card-game/wiki/Canasta)
+- **Wikipedia:** [Canasta](https://en.wikipedia.org/wiki/Canasta)

--- a/docs/casino-blackjack.md
+++ b/docs/casino-blackjack.md
@@ -9,4 +9,4 @@ Same rules and UI actions as **Blackjack** — bet, hit, stand, round scoring, a
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/casino-blackjack.md`](../src/rules/casino-blackjack.md)
-- **Project wiki:** [Casino-blackjack](https://github.com/MichaelJ43/card-game/wiki/Casino-blackjack)
+- **Wikipedia:** [Blackjack](https://en.wikipedia.org/wiki/Blackjack)

--- a/docs/crazy-eights.md
+++ b/docs/crazy-eights.md
@@ -11,4 +11,4 @@ Shedding game: play a card that matches the **current suit** or **rank** of the 
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/crazy-eights.md`](../src/rules/crazy-eights.md)
-- **Project wiki:** [Crazy-Eights](https://github.com/MichaelJ43/card-game/wiki/Crazy-Eights)
+- **Wikipedia:** [Crazy Eights](https://en.wikipedia.org/wiki/Crazy_Eights)

--- a/docs/demo-custom.md
+++ b/docs/demo-custom.md
@@ -13,4 +13,4 @@ Use **Play round** (or the game’s primary control) as indicated in the UI to a
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/demo-custom.md`](../src/rules/demo-custom.md)
-- **Project wiki:** [Demo-custom](https://github.com/MichaelJ43/card-game/wiki/Demo-custom)
+- **Wikipedia:** [Card game](https://en.wikipedia.org/wiki/Card_game) (no article for this sample deck; general overview)

--- a/docs/durak.md
+++ b/docs/durak.md
@@ -7,4 +7,4 @@
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/durak.md`](../src/rules/durak.md)
-- **Project wiki:** [Durak](https://github.com/MichaelJ43/card-game/wiki/Durak)
+- **Wikipedia:** [Durak](https://en.wikipedia.org/wiki/Durak)

--- a/docs/euchre.md
+++ b/docs/euchre.md
@@ -7,4 +7,4 @@
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/euchre.md`](../src/rules/euchre.md)
-- **Project wiki:** [Euchre](https://github.com/MichaelJ43/card-game/wiki/Euchre)
+- **Wikipedia:** [Euchre](https://en.wikipedia.org/wiki/Euchre)

--- a/docs/go-fish.md
+++ b/docs/go-fish.md
@@ -11,4 +11,4 @@ Classic **Go Fish**: ask another player for a rank you hold; if they have any, y
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/go-fish.md`](../src/rules/go-fish.md)
-- **Project wiki:** [Go-Fish](https://github.com/MichaelJ43/card-game/wiki/Go-Fish)
+- **Wikipedia:** [Go Fish](https://en.wikipedia.org/wiki/Go_Fish)

--- a/docs/heads-up-poker.md
+++ b/docs/heads-up-poker.md
@@ -9,4 +9,4 @@ Same heads-up draw poker flow: ante, draw round, showdown.
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/heads-up-poker.md`](../src/rules/heads-up-poker.md)
-- **Project wiki:** [Heads-up-poker](https://github.com/MichaelJ43/card-game/wiki/Heads-up-poker)
+- **Wikipedia:** [Heads-up poker](https://en.wikipedia.org/wiki/Heads-up_poker)

--- a/docs/high-card-duel.md
+++ b/docs/high-card-duel.md
@@ -11,4 +11,4 @@ Each side antes **5** or **10** chips (when both can cover it), then one card is
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/high-card-duel.md`](../src/rules/high-card-duel.md)
-- **Project wiki:** [High-card-duel](https://github.com/MichaelJ43/card-game/wiki/High-card-duel)
+- **Wikipedia:** [War (card game)](https://en.wikipedia.org/wiki/War_(card_game)) (same high-card comparison idea)

--- a/docs/mini-baccarat.md
+++ b/docs/mini-baccarat.md
@@ -9,4 +9,4 @@ Same flow as **Baccarat**: choose bet size and side, then the round resolves fro
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/mini-baccarat.md`](../src/rules/mini-baccarat.md)
-- **Project wiki:** [Mini-baccarat](https://github.com/MichaelJ43/card-game/wiki/Mini-baccarat)
+- **Wikipedia:** [Baccarat](https://en.wikipedia.org/wiki/Baccarat)

--- a/docs/pinochle.md
+++ b/docs/pinochle.md
@@ -7,4 +7,4 @@
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/pinochle.md`](../src/rules/pinochle.md)
-- **Project wiki:** [Pinochle](https://github.com/MichaelJ43/card-game/wiki/Pinochle)
+- **Wikipedia:** [Pinochle](https://en.wikipedia.org/wiki/Pinochle)

--- a/docs/poker-draw.md
+++ b/docs/poker-draw.md
@@ -11,4 +11,4 @@ Heads-up **five-card draw**: pay the **ante**, receive five cards, then choose h
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/poker-draw.md`](../src/rules/poker-draw.md)
-- **Project wiki:** [Poker-draw](https://github.com/MichaelJ43/card-game/wiki/Poker-draw)
+- **Wikipedia:** [Five-card draw](https://en.wikipedia.org/wiki/Five-card_draw)

--- a/docs/red-dog.md
+++ b/docs/red-dog.md
@@ -9,4 +9,4 @@ Uses the same high-card duel flow and betting buttons.
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/red-dog.md`](../src/rules/red-dog.md)
-- **Project wiki:** [Red-dog](https://github.com/MichaelJ43/card-game/wiki/Red-dog)
+- **Wikipedia:** [Red dog (card game)](https://en.wikipedia.org/wiki/Red_dog_(card_game))

--- a/docs/sequence-race.md
+++ b/docs/sequence-race.md
@@ -7,4 +7,4 @@
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/sequence-race.md`](../src/rules/sequence-race.md)
-- **Project wiki:** [Sequence-race](https://github.com/MichaelJ43/card-game/wiki/Sequence-race)
+- **Wikipedia:** [Skip-Bo](https://en.wikipedia.org/wiki/Skip-Bo) (similar commercial sequence-builder)

--- a/docs/skyjo.md
+++ b/docs/skyjo.md
@@ -13,4 +13,4 @@ See [`src/games/skyjo/skyjo.yaml`](../src/games/skyjo/skyjo.yaml) for bundled ma
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/skyjo.md`](../src/rules/skyjo.md)
-- **Project wiki:** [Skyjo](https://github.com/MichaelJ43/card-game/wiki/Skyjo)
+- **Wikipedia:** [Skyjo](https://de.wikipedia.org/wiki/Skyjo) (English Wikipedia has no article yet; German article)

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -9,4 +9,4 @@ Compare [`src/games/crazy-eights/switch.yaml`](../src/games/crazy-eights/switch.
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/switch.md`](../src/rules/switch.md)
-- **Project wiki:** [Switch](https://github.com/MichaelJ43/card-game/wiki/Switch)
+- **Wikipedia:** [Switch (card game)](https://en.wikipedia.org/wiki/Switch_(card_game))

--- a/docs/thirty-one.md
+++ b/docs/thirty-one.md
@@ -9,4 +9,4 @@ Browser table notes for the `thirty-one` game id.
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/thirty-one.md`](../src/rules/thirty-one.md)
-- **Project wiki:** [Thirty-one](https://github.com/MichaelJ43/card-game/wiki/Thirty-one)
+- **Wikipedia:** [Thirty-one (card game)](https://en.wikipedia.org/wiki/Thirty-one_(card_game))

--- a/docs/uno.md
+++ b/docs/uno.md
@@ -15,4 +15,4 @@ Uno-style shedding: match the **current color** or the **face** of the top disca
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/uno.md`](../src/rules/uno.md)
-- **Project wiki:** [Uno](https://github.com/MichaelJ43/card-game/wiki/Uno)
+- **Wikipedia:** [Uno (card game)](https://en.wikipedia.org/wiki/Uno_(card_game))

--- a/docs/war.md
+++ b/docs/war.md
@@ -13,4 +13,4 @@ See the in-app status line for the current phase and outcome text.
 ## See also
 
 - **In-app rules** (modal text bundled in the app): [`src/rules/war.md`](../src/rules/war.md)
-- **Project wiki:** [War](https://github.com/MichaelJ43/card-game/wiki/War)
+- **Wikipedia:** [War (card game)](https://en.wikipedia.org/wiki/War_(card_game))


### PR DESCRIPTION
## Summary

Replaces **project GitHub wiki** links in `docs/<game>.md` with **Wikipedia** URLs (`en.wikipedia.org` where an English article exists).

## Notes

- **Skyjo:** no English Wikipedia article; links to the **German** article (`de.wikipedia.org/wiki/Skyjo`).
- **demo-custom:** sample deck — links to the general **[Card game](https://en.wikipedia.org/wiki/Card_game)** article.
- **high-card-duel:** links to **[War (card game)](https://en.wikipedia.org/wiki/War_(card_game))** as the closest well-known “compare high cards” game.
- **sequence-race:** links to **[Skip-Bo](https://en.wikipedia.org/wiki/Skip-Bo)** as a similar commercial sequence-builder.
- See also lines relabeled from **Project wiki** to **Wikipedia**.
