### PR TITLE
build: multiplayer Vite URLs from Variables or Terraform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy to `.env.local` (gitignored via `*.local`) for `npm run dev` / local builds.
+# Values come from your deployed stack — see README “Online multiplayer” or
+# GitHub Deploy workflow summary (HTTP API / WS API lines).
+
+# Required for Host / Join UI (no trailing slash on HTTP URL).
+# VITE_MULTIPLAYER_HTTP_URL=https://xxxxxxxx.execute-api.us-east-1.amazonaws.com
+# VITE_MULTIPLAYER_WS_URL=wss://yyyyyyyy.execute-api.us-east-1.amazonaws.com/prod
+
+# Optional: comma-separated STUN URLs (defaults to Google public STUN).
+# VITE_MULTIPLAYER_STUN_URLS=stun:stun.l.google.com:19302

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
         run: npm run test:ci
 
       - name: Build
+        env:
+          # Optional: set repository Variables so CI builds match production URLs.
+          VITE_MULTIPLAYER_HTTP_URL: ${{ vars.VITE_MULTIPLAYER_HTTP_URL }}
+          VITE_MULTIPLAYER_WS_URL: ${{ vars.VITE_MULTIPLAYER_WS_URL }}
         run: npm run build
 
       - name: Install Lambda dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,11 +95,32 @@ jobs:
           echo "http_api_url=$(terraform output -raw http_api_url)" >> "$GITHUB_OUTPUT"
           echo "ws_api_url=$(terraform output -raw ws_api_url)" >> "$GITHUB_OUTPUT"
 
+      # Prefer repository Variables when set (stable URLs, no Terraform needed to
+      # change them). Otherwise use Terraform outputs from this apply.
+      - name: Resolve multiplayer URLs for Vite build
+        id: mp
+        env:
+          TF_HTTP: ${{ steps.tf.outputs.http_api_url }}
+          TF_WS: ${{ steps.tf.outputs.ws_api_url }}
+          VAR_HTTP: ${{ vars.VITE_MULTIPLAYER_HTTP_URL }}
+          VAR_WS: ${{ vars.VITE_MULTIPLAYER_WS_URL }}
+        run: |
+          set -e
+          HTTP="${VAR_HTTP:-}"
+          WS="${VAR_WS:-}"
+          if [ -z "$HTTP" ]; then HTTP="${TF_HTTP}"; fi
+          if [ -z "$WS" ]; then WS="${TF_WS}"; fi
+          echo "http=${HTTP}" >> "$GITHUB_OUTPUT"
+          echo "ws=${WS}" >> "$GITHUB_OUTPUT"
+          if [ -z "$HTTP" ] || [ -z "$WS" ]; then
+            echo "::warning::VITE_MULTIPLAYER_HTTP_URL / VITE_MULTIPLAYER_WS_URL are empty after resolve. Set repository Variables (recommended) or ensure Terraform outputs http_api_url and ws_api_url are non-empty."
+          fi
+
       # 3. Build the site with multiplayer endpoints baked in.
       - name: Build site
         env:
-          VITE_MULTIPLAYER_HTTP_URL: ${{ steps.tf.outputs.http_api_url }}
-          VITE_MULTIPLAYER_WS_URL: ${{ steps.tf.outputs.ws_api_url }}
+          VITE_MULTIPLAYER_HTTP_URL: ${{ steps.mp.outputs.http }}
+          VITE_MULTIPLAYER_WS_URL: ${{ steps.mp.outputs.ws }}
         run: npm run build
 
       # 4. Sync static assets to S3 + invalidate CloudFront.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,15 @@ Required GitHub configuration (repository **secrets** only — no Variables for 
 
 - `AWS_ROLE_ARN`, `ROOM_JWT_SECRET`, `AWS_REGION`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`.
 
+Optional repository **Variables** (plaintext) for Vite — set these so every
+`npm run build` (CI and deploy) bakes in stable API endpoints without depending
+only on the Terraform step output in the same job:
+
+- `VITE_MULTIPLAYER_HTTP_URL` — same value as `terraform output -raw http_api_url` (no trailing slash).
+- `VITE_MULTIPLAYER_WS_URL` — same value as `terraform output -raw ws_api_url` (includes stage path, e.g. `/prod`).
+
+Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for that run. Copy the two lines from the last successful **Deploy** job summary into Variables once, then re-run **Deploy** (or push) so CloudFront serves a bundle with multiplayer enabled.
+
 ### Future backlog (not in this PR)
 
 - **TURN relay** for symmetric-NAT / strict-firewall peers (STUN-only may

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ npm run dev
 
 Then open the URL Vite prints (usually `http://localhost:5173`).
 
+### Online multiplayer (local)
+
+After you have deployed once, copy the **HTTP API** and **WebSocket API** URLs from the GitHub **Deploy** workflow summary (or run `terraform output -raw http_api_url` / `ws_api_url` under `deploy/terraform/aws`). Create `.env.local` from [`.env.example`](.env.example) and set `VITE_MULTIPLAYER_HTTP_URL` and `VITE_MULTIPLAYER_WS_URL`, then restart `npm run dev`.
+
 Choosing another entry in the **Game** menu updates the selection only; press **Start deal** (or **New deal** when a hand is already on the table) to shuffle and play.
 
 Use **Rules** (next to **End game**) to open a modal with the in-app rules for the **currently selected** game (you can read them before **Start deal**).

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,11 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_MULTIPLAYER_HTTP_URL?: string
+  readonly VITE_MULTIPLAYER_WS_URL?: string
+  readonly VITE_MULTIPLAYER_STUN_URLS?: string
+}
+
 declare module '*.yaml?raw' {
   const src: string
   export default src


### PR DESCRIPTION
## Summary

Single commit cherry-picked from `feature/multiplayer-aws` after multiplayer PR #14 was merged to `main`. Ensures production and CI builds can embed multiplayer API URLs reliably.

## Changes

- **Deploy workflow**: Resolve `VITE_MULTIPLAYER_HTTP_URL` / `VITE_MULTIPLAYER_WS_URL` from repository **Variables** when set; otherwise use Terraform outputs from the same run. Warn if both are still empty.
- **CI workflow**: Pass the same optional Variables into `npm run build` so CI matches prod when Variables are configured.
- **`.env.example`**: Template for local `.env.local` (gitignored via `*.local`).
- **`README.md`**, **`AGENTS.md`**, **`AWS_SETUP.md`**: Document Variables and where to copy URLs from (Deploy job summary / `terraform output`).

## After merge

Set GitHub Actions **Variables** `VITE_MULTIPLAYER_HTTP_URL` and `VITE_MULTIPLAYER_WS_URL` (from your last Deploy summary), then run **Deploy** again so CloudFront serves a bundle with multiplayer enabled.
