### PR TITLE
fix: Vite must statically read multiplayer env vars

### DIFF
--- a/src/net/config.ts
+++ b/src/net/config.ts
@@ -1,19 +1,21 @@
 /**
  * Runtime configuration for multiplayer endpoints.
  * Populated from Vite env vars at build time:
- *   - VITE_MULTIPLAYER_HTTP_URL   → e.g. https://abc123.execute-api.us-east-1.amazonaws.com/prod
+ *   - VITE_MULTIPLAYER_HTTP_URL   → e.g. https://abc123.execute-api.us-east-1.amazonaws.com
  *   - VITE_MULTIPLAYER_WS_URL     → e.g. wss://def456.execute-api.us-east-1.amazonaws.com/prod
  *   - VITE_MULTIPLAYER_STUN_URLS  → comma-separated STUN urls (default: Google public STUN)
  *
  * If HTTP/WS URLs are missing, multiplayer is disabled at runtime and the UI hides join/host.
+ *
+ * Important: read each `VITE_*` via **static** `import.meta.env.VITE_*` access. A helper like
+ * `import.meta.env[key]` is not rewritten by Vite, so CI/deploy can export the vars correctly
+ * while the production bundle would still see them as missing.
  */
 
-type ViteLikeEnv = Record<string, string | undefined> & { MODE?: string }
-
-function readEnv(key: string): string | undefined {
-  const meta = import.meta as unknown as { env?: ViteLikeEnv }
-  const value = meta.env?.[key]
-  return typeof value === 'string' && value.length > 0 ? value : undefined
+function envString(v: unknown): string | undefined {
+  if (typeof v !== 'string') return undefined
+  const t = v.trim()
+  return t.length > 0 ? t : undefined
 }
 
 export interface MultiplayerConfig {
@@ -23,7 +25,7 @@ export interface MultiplayerConfig {
 }
 
 export function getMultiplayerConfig(): MultiplayerConfig {
-  const stunRaw = readEnv('VITE_MULTIPLAYER_STUN_URLS')
+  const stunRaw = envString(import.meta.env.VITE_MULTIPLAYER_STUN_URLS)
   const stunUrls = stunRaw
     ? stunRaw
         .split(',')
@@ -31,8 +33,8 @@ export function getMultiplayerConfig(): MultiplayerConfig {
         .filter(Boolean)
     : ['stun:stun.l.google.com:19302']
   return {
-    httpUrl: readEnv('VITE_MULTIPLAYER_HTTP_URL'),
-    wsUrl: readEnv('VITE_MULTIPLAYER_WS_URL'),
+    httpUrl: envString(import.meta.env.VITE_MULTIPLAYER_HTTP_URL),
+    wsUrl: envString(import.meta.env.VITE_MULTIPLAYER_WS_URL),
     stunUrls,
   }
 }


### PR DESCRIPTION
## Problem

Deploy logs showed `VITE_MULTIPLAYER_HTTP_URL` / `VITE_MULTIPLAYER_WS_URL` correctly passed into `npm run build`, but the live site still showed “Multiplayer is not configured”.

## Root cause

`src/net/config.ts` used `meta.env?.[key]` with a runtime string key. **Vite only inlines `VITE_*` values when they appear as static `import.meta.env.VITE_*` references.** Dynamic lookups are not rewritten, so the production bundle never received the URLs at build time.

## Fix

Use `import.meta.env.VITE_MULTIPLAYER_HTTP_URL` (and WS / STUN) directly, with a small `envString()` helper that only normalizes the already-resolved value.

## Verify locally

```powershell
$env:VITE_MULTIPLAYER_HTTP_URL="https://example.execute-api.us-east-1.amazonaws.com"
$env:VITE_MULTIPLAYER_WS_URL="wss://example.execute-api.us-east-1.amazonaws.com/prod"
npm run build
# dist/assets/*.js should contain "example.execute-api"
```

After merge, run **Deploy** once (or push to `main`) so CloudFront picks up the new bundle.
