### PR TITLE
fix(ui): End game returns to lobby (Host/Join)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -601,6 +601,7 @@
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 0.75rem;
   background: rgba(255, 255, 255, 0.03);
+  text-align: left;
 }
 
 .multiplayerPanel h3 {
@@ -617,13 +618,16 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  align-items: center;
+  align-items: flex-start;
+  justify-content: flex-start;
 }
 
 .multiplayerPanel__join {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .multiplayerPanel__join input {
@@ -662,7 +666,7 @@
   font-size: 0.9rem;
 }
 
-.multiplayerPanel__meta {
-  margin: 0.5rem 0 0;
-  opacity: 0.6;
+.multiplayerPanel__hosting,
+.multiplayerPanel__client {
+  text-align: left;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,16 +306,16 @@ function App() {
     if (!session) return
     if (
       !window.confirm(
-        'End this session? The table clears, any match progress is abandoned, and AI count and difficulty settings unlock.',
+        'End this session? You return to the lobby (game picker, Host / Join when available, then Start deal). Match progress for this hand is abandoned.',
       )
     ) {
       return
     }
-    setSession(createSession(gameId, Math.random, undefined, makeDealOptions(true)))
+    setSession(null)
     setSkyjoDumpStep('idle')
     setGfAwaitingOpponent(false)
     setGfRank('A')
-  }, [session, gameId, makeDealOptions])
+  }, [session])
 
   const onNextMatchRound = useCallback(() => {
     if (!session) return

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createRoom, joinRoom } from '../net/api'
-import { getMultiplayerConfig, isMultiplayerConfigured } from '../net/config'
+import { isMultiplayerConfigured } from '../net/config'
 import { RoomClient } from '../net/client'
 import { RoomHost, type HostedPeer } from '../net/host'
 import { isRoomCode } from '../net/protocol'
@@ -131,8 +131,6 @@ export function MultiplayerPanel({
     )
   }
 
-  const endpoints = getMultiplayerConfig()
-
   return (
     <section className="multiplayerPanel" aria-label="Multiplayer">
       <h3>Online play</h3>
@@ -200,11 +198,6 @@ export function MultiplayerPanel({
           {error}
         </p>
       )}
-      <p className="multiplayerPanel__meta">
-        <small>
-          Signaling server: {endpoints.wsUrl?.replace(/^wss?:\/\//, '') ?? '—'}
-        </small>
-      </p>
     </section>
   )
 }


### PR DESCRIPTION
## Summary

**End game** previously started a new practice session via \createSession(..., skipMatch: true)\, so \session\ stayed non-null and the Host/Join \MultiplayerPanel\ (shown only when \!session\) never appeared.

## Change

- On confirm, \setSession(null)\ and reset the same UI flags as before, matching **change game** / initial lobby behavior.
- Confirm copy updated to mention returning to the lobby.

## Test

- Start a deal → **End game** → confirm → expect lobby hint + multiplayer panel (for supported games) + **Start deal** without an active table.

Made with [Cursor](https://cursor.com)