### PR TITLE
fix(lambda): HTTP handler crashes on nanoid (ESM vs CommonJS)

### DIFF
--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -11,8 +11,7 @@
         "@aws-sdk/client-apigatewaymanagementapi": "^3.651.0",
         "@aws-sdk/client-dynamodb": "^3.651.0",
         "@aws-sdk/lib-dynamodb": "^3.651.0",
-        "jsonwebtoken": "^9.0.2",
-        "nanoid": "^5.0.7"
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.140",
@@ -3261,24 +3260,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -15,8 +15,7 @@
     "@aws-sdk/client-apigatewaymanagementapi": "^3.651.0",
     "@aws-sdk/client-dynamodb": "^3.651.0",
     "@aws-sdk/lib-dynamodb": "^3.651.0",
-    "jsonwebtoken": "^9.0.2",
-    "nanoid": "^5.0.7"
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.140",

--- a/lambda/src/http.ts
+++ b/lambda/src/http.ts
@@ -1,5 +1,5 @@
 import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda'
-import { nanoid } from 'nanoid'
+import { randomBytes } from 'node:crypto'
 import { signRoomToken } from './auth'
 import { generateRoomCode } from './roomCode'
 import {
@@ -67,6 +67,11 @@ interface JoinRoomRequest {
   roomCode?: string
 }
 
+/** URL-safe ~12-char suffix; avoids nanoid (ESM-only in v5) under Lambda CommonJS `require`. */
+function randomPeerSuffix(): string {
+  return randomBytes(9).toString('base64url').slice(0, 12)
+}
+
 export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> => {
   const origin = event.headers?.origin ?? event.headers?.Origin
   const method = (event.requestContext.http.method ?? 'GET').toUpperCase()
@@ -105,7 +110,7 @@ async function handleCreateRoom(
   const maxClientsRaw = Number(body.maxClients ?? 7)
   const maxClients = Math.min(Math.max(Math.floor(maxClientsRaw) || 1, 1), 7)
 
-  const hostPeerId = `h-${nanoid(12)}`
+  const hostPeerId = `h-${randomPeerSuffix()}`
   const ttlSeconds = getRoomTtlSeconds()
 
   for (let attempt = 0; attempt < 5; attempt++) {
@@ -149,7 +154,7 @@ async function handleJoinRoom(
   const meta = await getRoom(rc)
   if (!meta) return bad(404, 'Room not found', origin)
 
-  const clientPeerId = `c-${nanoid(12)}`
+  const clientPeerId = `c-${randomPeerSuffix()}`
   const ttlSeconds = getRoomTtlSeconds()
   const token = signRoomToken(
     { roomCode: rc, peerId: clientPeerId, role: 'client' },


### PR DESCRIPTION
## Cause

CloudWatch reported `ERR_REQUIRE_ESM`: `require()` of **nanoid** v5 from `http.js`. The Lambda bundle is **CommonJS**; **nanoid v5 is ESM-only**, so the runtime fails at cold start before any route runs. API Gateway then returns **500** / Internal Server Error when using **Host game**.

## Fix

- Remove the **nanoid** dependency from the Lambda package.
- Generate host/client peer ID suffixes with `node:crypto` — `randomBytes(9).toString('base64url').slice(0, 12)` — similar length and URL-safe, no ESM/CJS mismatch.

## Verify

```bash
cd lambda && npm ci && npm run build && npm run test
```

## After merge

Run the **Deploy** workflow (or rebuild the Lambda zip and apply Terraform) so production picks up the new `http` bundle.
