### PR TITLE
fix(multiplayer): table sync, client status, host disconnect

### DIFF
--- a/lambda/src/websocket.ts
+++ b/lambda/src/websocket.ts
@@ -212,6 +212,18 @@ async function onDisconnect(
   if (!binding) return
   await deleteConnection(binding.roomCode, connectionId)
   const peers = await listConnections(binding.roomCode)
+
+  if (binding.role === 'host') {
+    // Host WebSocket gone: notify every remaining client so UIs can tear down.
+    const hostPeerId = binding.peerId
+    for (const p of peers) {
+      if (p.role === 'client') {
+        await postTo(client, p.connectionId, { type: 'peer-left', peerId: hostPeerId })
+      }
+    }
+    return
+  }
+
   const host = peers.find((p) => p.role === 'host')
   if (!host) return
   await postTo(client, host.connectionId, { type: 'peer-left', peerId: binding.peerId })

--- a/src/App.css
+++ b/src/App.css
@@ -670,3 +670,20 @@
 .multiplayerPanel__client {
   text-align: left;
 }
+
+.multiplayerPanel__compact {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem 0.75rem;
+  margin-top: 0.35rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  font-size: 0.9rem;
+}
+
+.multiplayerPanel__compact button {
+  flex: 0 0 auto;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 import { AI_DIFFICULTY_OPTIONS, normalizeAiDifficulty, type AiDifficulty } from './core/aiContext'
 import { type MatchState } from './core/match'
@@ -18,6 +18,8 @@ import {
   normalizeAiDifficultiesForCount,
 } from './session/playerConfig'
 import { GameHouseRulesPanel } from './ui/GameHouseRulesPanel'
+import type { RoomHost } from './net/host'
+import { parseSessionSnapshot, serializeSessionSnapshot } from './net/sessionSnapshot'
 import { MultiplayerPanel } from './ui/MultiplayerPanel'
 import { RulesModal } from './ui/RulesModal'
 import { TableView, type ActiveTurnHighlight, type TableIntent } from './ui/TableView'
@@ -248,6 +250,12 @@ function App() {
   const [aiOpponents, setAiOpponents] = useState(1)
   const [aiDifficulties, setAiDifficulties] = useState<AiDifficulty[]>(['medium'])
   const [session, setSession] = useState<GameSession | null>(null)
+  const [joinedAsClient, setJoinedAsClient] = useState(false)
+  const [remoteSpectator, setRemoteSpectator] = useState(false)
+
+  const roomHostRef = useRef<RoomHost | null>(null)
+  const sessionRef = useRef<GameSession | null>(null)
+  const pushSnapshotRef = useRef<() => void>(() => {})
 
   const [gfAwaitingOpponent, setGfAwaitingOpponent] = useState(false)
   const [gfRank, setGfRank] = useState('A')
@@ -255,6 +263,26 @@ function App() {
   const [rulesOpen, setRulesOpen] = useState(false)
 
   const selectedManifest = useMemo(() => parseGameManifestYaml(GAME_SOURCES[gameId]), [gameId])
+
+  useEffect(() => {
+    sessionRef.current = session
+  }, [session])
+
+  useEffect(() => {
+    pushSnapshotRef.current = () => {
+      if (remoteSpectator) return
+      const host = roomHostRef.current
+      if (!host) return
+      const roster = host.getRoster()
+      if (!roster.some((r) => r.state === 'open')) return
+      const sess = sessionRef.current
+      if (!sess) return
+      const wire = serializeSessionSnapshot(sess)
+      if (!wire) return
+      host.broadcastSnapshot(() => wire)
+    }
+    pushSnapshotRef.current()
+  }, [session, remoteSpectator])
 
   const makeDealOptions = useCallback(
     (
@@ -299,10 +327,23 @@ function App() {
   }, [])
 
   const startOrNewDeal = useCallback(() => {
+    if (joinedAsClient || remoteSpectator) return
     applyFreshDeal(gameId)
-  }, [gameId, applyFreshDeal])
+  }, [gameId, applyFreshDeal, joinedAsClient, remoteSpectator])
 
   const endGame = useCallback(() => {
+    if (remoteSpectator) {
+      if (!session) return
+      if (
+        !window.confirm(
+          'Hide this table? You stay in the room until you leave; the host can start another deal.',
+        )
+      ) {
+        return
+      }
+      setSession(null)
+      return
+    }
     if (!session) return
     if (
       !window.confirm(
@@ -315,19 +356,53 @@ function App() {
     setSkyjoDumpStep('idle')
     setGfAwaitingOpponent(false)
     setGfRank('A')
-  }, [session])
+  }, [session, remoteSpectator])
+
+  const onHostStarted = useCallback((host: RoomHost) => {
+    roomHostRef.current = host
+  }, [])
+
+  const onClientStarted = useCallback(() => {
+    setJoinedAsClient(true)
+  }, [])
+
+  const onSessionSnapshot = useCallback((wire: unknown) => {
+    const parsed = parseSessionSnapshot(wire)
+    if (!parsed) return
+    setSession(parsed)
+    setGameId(parsed.manifest.id as (typeof GAME_IDS)[number])
+    setRemoteSpectator(true)
+    setGfAwaitingOpponent(false)
+    setGfRank('A')
+    setSkyjoDumpStep('idle')
+  }, [])
+
+  const onMultiplayerTeardown = useCallback((_wasHost: boolean) => {
+    roomHostRef.current = null
+    setJoinedAsClient(false)
+    setRemoteSpectator(false)
+    setSession(null)
+    setGfAwaitingOpponent(false)
+    setGfRank('A')
+    setSkyjoDumpStep('idle')
+  }, [])
+
+  const onHostingRosterChange = useCallback(() => {
+    pushSnapshotRef.current()
+  }, [])
 
   const onNextMatchRound = useCallback(() => {
-    if (!session) return
+    if (!session || remoteSpectator) return
     try {
       const next = startNextMatchRound(session, gameId)
       setSession(next)
     } catch (e) {
       window.alert(e instanceof Error ? e.message : String(e))
     }
-  }, [session, gameId])
+  }, [session, gameId, remoteSpectator])
 
   const dispatchAction = useCallback((action: GameAction) => {
+    if (remoteSpectator) return
     setSession((prev) => {
       if (!prev) return prev
       const result = prev.module.applyAction(prev.table, prev.gameState, action)
@@ -341,7 +416,7 @@ function App() {
         gameState: result.gameState,
       }
     })
-  }, [])
+  }, [remoteSpectator])
 
   const status = useMemo(() => {
     if (!session) return ''
@@ -458,6 +533,7 @@ function App() {
   }, [session])
 
   useEffect(() => {
+    if (remoteSpectator) return
     if (!session) return
     if (!isGoFishSession(session)) return
     const gs = session.gameState
@@ -479,9 +555,10 @@ function App() {
     }, 550)
 
     return () => window.clearTimeout(handle)
-  }, [session])
+  }, [session, remoteSpectator])
 
   useEffect(() => {
+    if (remoteSpectator) return
     if (!session) return
     if (!isCrazyEightsSession(session)) return
     const gs = session.gameState as { phase?: string; currentPlayer?: number }
@@ -507,9 +584,10 @@ function App() {
     }, 500)
 
     return () => window.clearTimeout(handle)
-  }, [session])
+  }, [session, remoteSpectator])
 
   useEffect(() => {
+    if (remoteSpectator) return
     if (!session) return
     if (!isUnoSession(session)) return
     const gs = session.gameState as { phase?: string; currentPlayer?: number }
@@ -535,9 +613,10 @@ function App() {
     }, 500)
 
     return () => window.clearTimeout(handle)
-  }, [session])
+  }, [session, remoteSpectator])
 
   useEffect(() => {
+    if (remoteSpectator) return
     if (!session) return
     if (!TABLE_AI_MEDIUM_MODULES.has(session.manifest.module)) return
     const gs = session.gameState as { phase?: string; currentPlayer?: number }
@@ -563,9 +642,10 @@ function App() {
     }, 500)
 
     return () => window.clearTimeout(handle)
-  }, [session])
+  }, [session, remoteSpectator])
 
   useEffect(() => {
+    if (remoteSpectator) return
     if (!session) return
     if (!isSkyjoSession(session)) return
     const gs = session.gameState
@@ -589,7 +669,7 @@ function App() {
     }, 650)
 
     return () => window.clearTimeout(handle)
-  }, [session])
+  }, [session, remoteSpectator])
 
   useEffect(() => {
     if (!session) return
@@ -640,7 +720,7 @@ function App() {
 
   const handleTableIntent = useCallback(
     (intent: TableIntent) => {
-      if (!session) return
+      if (!session || remoteSpectator) return
       if (isSkyjoSession(session)) {
         const gs = session.gameState
         if (gs.phase === 'roundOver' || gs.currentPlayer !== 0) return
@@ -735,7 +815,7 @@ function App() {
         }
       }
     },
-    [session, dispatchAction, skyjoDumpStep, gfAwaitingOpponent, gfRank, humanRanks],
+    [session, remoteSpectator, dispatchAction, skyjoDumpStep, gfAwaitingOpponent, gfRank, humanRanks],
   )
 
   return (
@@ -753,6 +833,12 @@ function App() {
                     <select
                       className="app__select"
                       value={gameId}
+                      disabled={joinedAsClient || remoteSpectator}
+                      title={
+                        joinedAsClient || remoteSpectator
+                          ? 'Game is chosen by the host while you are in an online room.'
+                          : undefined
+                      }
                       onChange={(e) => onGameIdChange(e.target.value as (typeof GAME_IDS)[number])}
                     >
                       {GAME_IDS.map((id) => (
@@ -771,11 +857,13 @@ function App() {
                         min={1}
                         max={MAX_AI_OPPONENTS}
                         value={aiOpponents}
-                        disabled={aiCountLocked}
+                        disabled={aiCountLocked || joinedAsClient || remoteSpectator}
                         title={
-                          aiCountLocked
-                            ? 'Finish or advance the match before changing player count.'
-                            : `1–${MAX_AI_OPPONENTS} computer players (${1 + aiOpponents} total). Applies on Start deal / New deal.`
+                          joinedAsClient || remoteSpectator
+                            ? 'Player count is set by the host while you are in an online room.'
+                            : aiCountLocked
+                              ? 'Finish or advance the match before changing player count.'
+                              : `1–${MAX_AI_OPPONENTS} computer players (${1 + aiOpponents} total). Applies on Start deal / New deal.`
                         }
                         onChange={(e) => {
                           const n = clampAiOpponentCount(gameId, Number(e.target.value))
@@ -787,7 +875,17 @@ function App() {
                   <div className="app__toolbarActions">
                     <span className="app__toolbarActionsLabel">Actions</span>
                     <div className="app__toolbarActionsBtns">
-                      <button type="button" className="app__btnToolbar app__btnSecondary" onClick={startOrNewDeal}>
+                      <button
+                        type="button"
+                        className="app__btnToolbar app__btnSecondary"
+                        onClick={startOrNewDeal}
+                        disabled={joinedAsClient || remoteSpectator}
+                        title={
+                          joinedAsClient || remoteSpectator
+                            ? 'Only the host can start or refresh the deal while you are in an online room.'
+                            : undefined
+                        }
+                      >
                         {session ? 'New deal' : 'Start deal'}
                       </button>
                       <button
@@ -812,11 +910,13 @@ function App() {
                       <select
                         className="app__select app__select--diff"
                         value={aiDifficulties[i] ?? 'medium'}
-                        disabled={aiCountLocked}
+                        disabled={aiCountLocked || joinedAsClient || remoteSpectator}
                         title={
-                          aiCountLocked
-                            ? 'Finish or advance the match before editing AI settings.'
-                            : 'Locked for this deal. Changing starts a new deal.'
+                          joinedAsClient || remoteSpectator
+                            ? 'AI settings are controlled by the host while you are in an online room.'
+                            : aiCountLocked
+                              ? 'Finish or advance the match before editing AI settings.'
+                              : 'Locked for this deal. Changing starts a new deal.'
                         }
                         onChange={(e) => {
                           const v = normalizeAiDifficulty(e.target.value)
@@ -869,24 +969,35 @@ function App() {
         </div>
       </header>
 
+      {gameSupportsOnlineMultiplayer(gameId) && (
+        <MultiplayerPanel
+          gameId={gameId}
+          maxClients={MAX_REMOTE_HUMANS}
+          tableActive={!!session}
+          onHostStarted={onHostStarted}
+          onClientStarted={onClientStarted}
+          onSessionSnapshot={onSessionSnapshot}
+          onHostingRosterChange={onHostingRosterChange}
+          onTeardown={onMultiplayerTeardown}
+        />
+      )}
+
       {!session && (
-        <>
-          <p className="app__lobbyHint" role="status">
-            Select a game, adjust AI options if needed, then press <strong>Start deal</strong>.
-          </p>
-          {gameSupportsOnlineMultiplayer(gameId) && (
-            <MultiplayerPanel
-              gameId={gameId}
-              maxClients={MAX_REMOTE_HUMANS}
-            />
+        <p className="app__lobbyHint" role="status">
+          {joinedAsClient ? (
+            'Waiting for the host to deal — the table appears here when they start.'
+          ) : (
+            <>
+              Select a game, adjust AI options if needed, then press <strong>Start deal</strong>.
+            </>
           )}
-        </>
+        </p>
       )}
 
       {session && (
         <>
           <p className="app__status" role="status">
-            {status}
+            {remoteSpectator ? `${status} (viewing host — read-only)` : status}
           </p>
 
           {matchPreviewTotals && session.match && !session.match.complete && (
@@ -902,7 +1013,13 @@ function App() {
           )}
           {canAdvanceMatch && (
             <div className="app__matchActions">
-              <button type="button" className="app__btnPrimary" onClick={onNextMatchRound}>
+              <button
+                type="button"
+                className="app__btnPrimary"
+                onClick={onNextMatchRound}
+                disabled={remoteSpectator}
+                title={remoteSpectator ? 'Only the host can advance the match.' : undefined}
+              >
                 Next round (apply scores)
               </button>
             </div>
@@ -936,7 +1053,12 @@ function App() {
                       : 'Click a card in your hand to choose the rank, then click an opponent’s hand or books.'}
                   </p>
                   {legal.some((a) => a.type === 'goFishPass') && (
-                    <button type="button" className="app__btnSecondary" onClick={() => dispatchAction({ type: 'goFishPass' })}>
+                    <button
+                      type="button"
+                      className="app__btnSecondary"
+                      disabled={remoteSpectator}
+                      onClick={() => dispatchAction({ type: 'goFishPass' })}
+                    >
                       Pass turn
                     </button>
                   )}
@@ -970,6 +1092,8 @@ function App() {
                     key={customActionKey(a)}
                     type="button"
                     className="app__btnSecondary"
+                    disabled={remoteSpectator}
+                    title={remoteSpectator ? 'Viewing the host table — actions are disabled.' : undefined}
                     onClick={() => dispatchAction(a)}
                   >
                     {labelCustomAction(a)}
@@ -983,7 +1107,8 @@ function App() {
                 type="button"
                 className="app__btnPrimary"
                 onClick={onPrimary}
-                disabled={legal.length === 0}
+                disabled={legal.length === 0 || remoteSpectator}
+                title={remoteSpectator ? 'Viewing the host table — actions are disabled.' : undefined}
               >
                 {primaryLabel}
               </button>

--- a/src/net/client.ts
+++ b/src/net/client.ts
@@ -18,6 +18,8 @@ export interface RoomClientOptions {
   onSnapshot?: (snapshot: PeerHostSnapshot) => void
   onStatus?: (message: string) => void
   onAck?: (nonce: string, ok: boolean, error: string | undefined) => void
+  /** Host closed the room or disconnected; stop signaling and data channel. */
+  onHostEnded?: () => void
 }
 
 /**
@@ -43,8 +45,7 @@ export class RoomClient {
         } else if (msg.type === 'relay' && msg.to === opts.clientPeerId) {
           this.ensureLink().acceptSignal(msg.payload)
         } else if (msg.type === 'peer-left' && msg.peerId === opts.hostPeerId) {
-          this.link?.close()
-          this.link = null
+          this.handleHostEnded()
         }
       },
     })
@@ -69,6 +70,13 @@ export class RoomClient {
       onPeerMessage: (msg) => this.handlePeerMessage(msg),
     })
     return this.link
+  }
+
+  private handleHostEnded(): void {
+    this.link?.close()
+    this.link = null
+    this.signaling.close()
+    this.opts.onHostEnded?.()
   }
 
   private handlePeerMessage(msg: PeerMessage) {

--- a/src/net/sessionSnapshot.ts
+++ b/src/net/sessionSnapshot.ts
@@ -1,0 +1,54 @@
+import { parseGameManifestYaml } from '../core/loadYaml'
+import { getGameModule } from '../core/registry'
+import type { GameModule } from '../core/gameModule'
+import type { MatchState } from '../core/match'
+import type { GameManifestYaml, TableState } from '../core/types'
+import { GAME_SOURCES } from '../data/manifests'
+import type { GameSession } from '../session'
+
+/** Wire shape sent in {@link PeerHostSnapshot.state} for table sync. */
+export interface SessionSnapshotWire {
+  gameId: string
+  table: TableState
+  gameState: unknown
+  match?: MatchState
+}
+
+export function isSessionSnapshotWire(value: unknown): value is SessionSnapshotWire {
+  if (!value || typeof value !== 'object') return false
+  const v = value as SessionSnapshotWire
+  return typeof v.gameId === 'string' && v.table !== undefined && v.table !== null && 'gameState' in v
+}
+
+/** JSON-safe clone for host → DataChannel (drops functions / cycles). */
+export function serializeSessionSnapshot(session: GameSession): SessionSnapshotWire | null {
+  try {
+    const wire: SessionSnapshotWire = {
+      gameId: session.manifest.id,
+      table: JSON.parse(JSON.stringify(session.table)) as TableState,
+      gameState: JSON.parse(JSON.stringify(session.gameState)),
+      match: session.match ? (JSON.parse(JSON.stringify(session.match)) as MatchState) : undefined,
+    }
+    return wire
+  } catch {
+    return null
+  }
+}
+
+export function parseSessionSnapshot(value: unknown): GameSession | null {
+  if (!isSessionSnapshotWire(value)) return null
+  const gameId = value.gameId as keyof typeof GAME_SOURCES
+  const raw = GAME_SOURCES[gameId]
+  if (!raw) return null
+  const manifest = parseGameManifestYaml(raw) as GameManifestYaml
+  const mod = getGameModule(manifest.module)
+  if (!mod) return null
+  return {
+    manifest,
+    module: mod as GameModule,
+    table: value.table,
+    gameState: value.gameState,
+    match: value.match,
+    aiPlayerConfig: undefined,
+  }
+}

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -11,10 +11,18 @@ export interface MultiplayerPanelProps {
   gameId: string
   /** Max remote clients this host is willing to accept. */
   maxClients: number
+  /** Host has an active table — keep RoomHost mounted; show compact room UI. */
+  tableActive?: boolean
   /** Called when a hosted room becomes active; useful for the parent to wire snapshots. */
   onHostStarted?: (host: RoomHost) => void
   /** Called when this browser successfully joins a remote host. */
   onClientStarted?: (client: RoomClient) => void
+  /** Host state received over the data channel (viewer). */
+  onSessionSnapshot?: (state: unknown) => void
+  /** Host roster changed (e.g. client connected); parent may push a table snapshot. */
+  onHostingRosterChange?: () => void
+  /** Any multiplayer teardown (Close room, Leave room, or host disconnect). */
+  onTeardown?: (wasHost: boolean) => void
   onClosed?: () => void
 }
 
@@ -23,8 +31,12 @@ type Mode = 'idle' | 'hosting' | 'client'
 export function MultiplayerPanel({
   gameId,
   maxClients,
+  tableActive = false,
   onHostStarted,
   onClientStarted,
+  onSessionSnapshot,
+  onHostingRosterChange,
+  onTeardown,
   onClosed,
 }: MultiplayerPanelProps) {
   const [mode, setMode] = useState<Mode>('idle')
@@ -40,7 +52,15 @@ export function MultiplayerPanel({
 
   const configured = isMultiplayerConfigured()
 
-  const teardown = useCallback(() => {
+  const updatePeerStatus = useCallback((s: PeerState) => {
+    setPeerState(s)
+    if (s === 'open') setStatus('Connected to host.')
+    else if (s === 'connecting') setStatus('Connecting to host…')
+    else if (s === 'closed') setStatus('Disconnected from host.')
+  }, [])
+
+  const teardown = useCallback((opts?: { clientKickedByHost?: boolean }) => {
+    const wasHost = hostRef.current !== null
     hostRef.current?.close()
     hostRef.current = null
     clientRef.current?.close()
@@ -50,9 +70,11 @@ export function MultiplayerPanel({
     setRoster([])
     setSignalingState('closed')
     setPeerState('new')
-    setStatus('')
+    setStatus(opts?.clientKickedByHost ? 'Host closed the room or disconnected.' : '')
+    setError('')
+    onTeardown?.(wasHost)
     onClosed?.()
-  }, [onClosed])
+  }, [onClosed, onTeardown])
 
   useEffect(() => () => teardown(), [teardown])
 
@@ -70,7 +92,10 @@ export function MultiplayerPanel({
         hostPeerId,
         token,
         onSignalingState: setSignalingState,
-        onRosterChange: setRoster,
+        onRosterChange: (peers) => {
+          setRoster(peers)
+          onHostingRosterChange?.()
+        },
         onIntent: () => {
           // Intents are consumed by the parent via onHostStarted wiring.
         },
@@ -84,7 +109,7 @@ export function MultiplayerPanel({
       setError(e instanceof Error ? e.message : String(e))
       setStatus('')
     }
-  }, [gameId, maxClients, onHostStarted])
+  }, [gameId, maxClients, onHostStarted, onHostingRosterChange])
 
   const startClient = useCallback(async () => {
     setError('')
@@ -105,19 +130,22 @@ export function MultiplayerPanel({
         clientPeerId,
         token,
         onSignalingState: setSignalingState,
-        onPeerState: setPeerState,
+        onPeerState: updatePeerStatus,
+        onSnapshot: (snap) => onSessionSnapshot?.(snap.state),
         onStatus: (m) => setStatus(m),
+        onHostEnded: () => {
+          teardown({ clientKickedByHost: true })
+        },
       })
       clientRef.current = client
       setRoomCode(rc)
       setMode('client')
-      setStatus('Connecting to host…')
       onClientStarted?.(client)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
       setStatus('')
     }
-  }, [joinCodeInput, onClientStarted])
+  }, [joinCodeInput, onClientStarted, onSessionSnapshot, teardown, updatePeerStatus])
 
   if (!configured) {
     return (
@@ -131,11 +159,13 @@ export function MultiplayerPanel({
     )
   }
 
+  const showCompact = tableActive && mode !== 'idle'
+
   return (
     <section className="multiplayerPanel" aria-label="Multiplayer">
       <h3>Online play</h3>
 
-      {mode === 'idle' && (
+      {!showCompact && mode === 'idle' && (
         <div className="multiplayerPanel__controls">
           <button type="button" onClick={startHost}>
             Host game
@@ -163,7 +193,30 @@ export function MultiplayerPanel({
         </div>
       )}
 
-      {mode === 'hosting' && (
+      {showCompact && mode === 'hosting' && (
+        <div className="multiplayerPanel__compact">
+          <span>
+            Hosting · code <strong className="multiplayerPanel__code">{roomCode}</strong>
+          </span>
+          <button type="button" onClick={() => teardown()}>
+            Close room
+          </button>
+        </div>
+      )}
+
+      {showCompact && mode === 'client' && (
+        <div className="multiplayerPanel__compact">
+          <span>
+            Joined · code <strong className="multiplayerPanel__code">{roomCode}</strong> · signaling{' '}
+            <em>{signalingState}</em> · peer <em>{peerState}</em>
+          </span>
+          <button type="button" onClick={() => teardown()}>
+            Leave room
+          </button>
+        </div>
+      )}
+
+      {!showCompact && mode === 'hosting' && (
         <div className="multiplayerPanel__hosting">
           <p>
             Room code: <strong className="multiplayerPanel__code">{roomCode}</strong>
@@ -172,13 +225,13 @@ export function MultiplayerPanel({
             Signaling: <em>{signalingState}</em>
           </p>
           <ConnectedPeers roster={roster} />
-          <button type="button" onClick={teardown}>
+          <button type="button" onClick={() => teardown()}>
             Close room
           </button>
         </div>
       )}
 
-      {mode === 'client' && (
+      {!showCompact && mode === 'client' && (
         <div className="multiplayerPanel__client">
           <p>
             Room code: <strong className="multiplayerPanel__code">{roomCode}</strong>
@@ -186,7 +239,7 @@ export function MultiplayerPanel({
           <p>
             Signaling: <em>{signalingState}</em> · Peer: <em>{peerState}</em>
           </p>
-          <button type="button" onClick={teardown}>
+          <button type="button" onClick={() => teardown()}>
             Leave room
           </button>
         </div>


### PR DESCRIPTION
## Summary

- **Host table sync**: Serialize `GameSession` to the wire and broadcast when the session changes or when a client data channel reaches `open` (roster callback). Clients parse snapshots into a local read-only session.
- **Panel stays mounted**: `MultiplayerPanel` remains visible while a deal is active (`tableActive`) so `RoomHost` and WebRTC are not torn down on Start deal.
- **Client status**: Stop overwriting peer status with "Connecting…" after the link may already be open; peer state updates drive the status line.
- **Host disconnect**: Lambda WebSocket `onDisconnect` notifies clients when the host leaves so they receive `peer-left` and run full teardown (`RoomClient.onHostEnded` → panel teardown).
- **Remote UX**: Disable local Start deal, game picker, AI controls, and table actions while joined or spectating; skip local AI timers when viewing the host table.

## Deploy note

Redeploy the **WebSocket Lambda** for host-disconnect notifications to reach production.

## Verification

- `npm run lint` / `npm run build`
- `cd lambda && npm run build && npm run test`
