### PR TITLE
fix(ui): align AI and multiplayer seat labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 import { AI_DIFFICULTY_OPTIONS, normalizeAiDifficulty, type AiDifficulty } from './core/aiContext'
 import { type MatchState } from './core/match'
-import { playerSeatLabel } from './core/playerLabels'
+import { aiPlayerMenuLabel, playerSeatLabel } from './core/playerLabels'
 import { parseGameManifestYaml } from './core/loadYaml'
 import { createSession, startNextMatchRound, type CreateSessionOptions, type GameSession } from './session'
 import { createSessionOptionsHouseRules } from './data/houseRules'
@@ -19,7 +19,7 @@ import {
 } from './session/playerConfig'
 import { GameHouseRulesPanel } from './ui/GameHouseRulesPanel'
 import type { RoomClient } from './net/client'
-import type { RoomHost } from './net/host'
+import type { HostedPeer, RoomHost } from './net/host'
 import type { PeerClientIntent, PeerHostSnapshot } from './net/protocol'
 import { parseSessionSnapshot, serializeSessionSnapshot } from './net/sessionSnapshot'
 import { MultiplayerPanel } from './ui/MultiplayerPanel'
@@ -49,6 +49,13 @@ function firstAiSeatIndex(session: GameSession | null): number {
   return session.manifest.players.human
 }
 
+/** Server seat for “You” in score tables; null when spectating (no local seat). */
+function localViewerSeat(session: GameSession | null): number | null {
+  if (!session?.net) return 0
+  if (session.net.spectator) return null
+  return session.net.seat
+}
+
 function MatchCumulativePanel({
   match,
   toolbar,
@@ -56,6 +63,7 @@ function MatchCumulativePanel({
   caption = 'Cumulative scores',
   scoringMode = 'points',
   pendingRoundScores,
+  playerSeatCaption,
 }: {
   match: MatchState
   toolbar?: boolean
@@ -64,6 +72,8 @@ function MatchCumulativePanel({
   scoringMode?: 'points' | 'chips'
   /** Round scored in game state but not yet merged — updates Total column only (no layout change). */
   pendingRoundScores?: number[] | null
+  /** Row header for each seat (defaults to {@link playerSeatLabel}). */
+  playerSeatCaption?: (playerIndex: number) => string
 }) {
   const unit = scoringMode === 'chips' ? 'chips' : 'points'
   const history = match.completedRoundScores ?? []
@@ -73,6 +83,8 @@ function MatchCumulativePanel({
   const displayTotals = pending
     ? match.cumulativeScores.map((c, i) => c + (pending[i] ?? 0))
     : match.cumulativeScores
+
+  const rowCaption = playerSeatCaption ?? ((pi: number) => playerSeatLabel(pi))
 
   return (
     <div className={`matchCumulative${toolbar ? ' matchCumulative--toolbar' : ''}`}>
@@ -109,7 +121,7 @@ function MatchCumulativePanel({
             {match.cumulativeScores.map((_, pi) => (
               <tr key={pi}>
                 <th scope="row" className="matchCumulative__playerCell">
-                  {playerSeatLabel(pi)}
+                  {rowCaption(pi)}
                 </th>
                 {history.map((roundVec, ri) => (
                   <td
@@ -132,7 +144,7 @@ function MatchCumulativePanel({
         {' · '}
         Stop when someone reaches ≥{match.config.targetScore} {unit} · {match.config.winnerIs} total wins
         {match.complete && match.matchWinnerIndex !== null && (
-          <> — Winner: {playerSeatLabel(match.matchWinnerIndex)}</>
+          <> — Winner: {rowCaption(match.matchWinnerIndex)}</>
         )}
       </p>
     </div>
@@ -283,11 +295,47 @@ function App() {
   const [gfRank, setGfRank] = useState('A')
   const [skyjoDumpStep, setSkyjoDumpStep] = useState<SkyjoDumpUiStep>('idle')
   const [rulesOpen, setRulesOpen] = useState(false)
+  const [hostClientRoster, setHostClientRoster] = useState<HostedPeer[]>([])
 
   const selectedManifest = useMemo(() => parseGameManifestYaml(GAME_SOURCES[gameId]), [gameId])
 
   const onlineClientShell = joinedAsClient || !!session?.net
   const networkSpectator = !!session?.net?.spectator
+
+  const seatDisplayName = useCallback(
+    (serverPlayerIndex: number): string => {
+      if (!session) return `Player ${serverPlayerIndex + 1}`
+      const humanCount = session.manifest.players.human
+      if (serverPlayerIndex >= humanCount) {
+        return aiPlayerMenuLabel(serverPlayerIndex - humanCount)
+      }
+      if (session.net && !session.net.spectator) {
+        if (serverPlayerIndex === 0) return 'Host'
+        return `Player ${serverPlayerIndex + 1}`
+      }
+      if (!session.net) {
+        if (serverPlayerIndex === 0) return 'Host'
+        const peer = hostClientRoster.find((r) => r.seat === serverPlayerIndex)
+        if (peer) {
+          const id = peer.peerId
+          return id.length > 16 ? `${id.slice(0, 15)}…` : id
+        }
+        return `Player ${serverPlayerIndex + 1}`
+      }
+      if (serverPlayerIndex === 0) return 'Host'
+      return `Player ${serverPlayerIndex + 1}`
+    },
+    [session, hostClientRoster],
+  )
+
+  const cumulativeRowCaption = useCallback(
+    (pi: number) => {
+      const local = localViewerSeat(session)
+      if (local !== null && pi === local) return 'You'
+      return seatDisplayName(pi)
+    },
+    [session, seatDisplayName],
+  )
 
   useEffect(() => {
     sessionRef.current = session
@@ -397,6 +445,7 @@ function App() {
 
   const onHostStarted = useCallback((host: RoomHost) => {
     roomHostRef.current = host
+    setHostClientRoster(host.getRoster())
   }, [])
 
   const onClientStarted = useCallback((client: RoomClient) => {
@@ -452,13 +501,15 @@ function App() {
     roomHostRef.current = null
     roomClientRef.current = null
     setJoinedAsClient(false)
+    setHostClientRoster([])
     setSession(null)
     setGfAwaitingOpponent(false)
     setGfRank('A')
     setSkyjoDumpStep('idle')
   }, [])
 
-  const onHostingRosterChange = useCallback(() => {
+  const onHostingRosterChange = useCallback((peers?: HostedPeer[]) => {
+    if (peers) setHostClientRoster(peers)
     pushSnapshotRef.current()
   }, [])
 
@@ -1017,10 +1068,10 @@ function App() {
                 </div>
               </div>
               {gameSupportsPerSeatAiDifficulty(gameId) && aiOpponents >= 1 && (
-                <div className="app__toolbarRow app__toolbarRow--diff" role="group" aria-label="AI difficulty per seat">
+                <div className="app__toolbarRow app__toolbarRow--diff" role="group" aria-label="AI player difficulty">
                   {Array.from({ length: aiOpponents }, (_, i) => (
                     <label key={i} className="app__label app__label--inline">
-                      Player {i + 2}
+                      {aiPlayerMenuLabel(i)}
                       <select
                         className="app__select app__select--diff"
                         value={aiDifficulties[i] ?? 'medium'}
@@ -1076,6 +1127,7 @@ function App() {
                   }
                   scoringMode={session.manifest.match?.scoringMode === 'chips' ? 'chips' : 'points'}
                   pendingRoundScores={pendingMergeRoundScores}
+                  playerSeatCaption={cumulativeRowCaption}
                 />
               </div>
             )}
@@ -1120,7 +1172,7 @@ function App() {
               Totals if you merge this round:{' '}
               {matchPreviewTotals.map((s, i) => (
                 <span key={i}>
-                  {playerSeatLabel(i)}: {s}
+                  {cumulativeRowCaption(i)}: {s}
                   {i < matchPreviewTotals.length - 1 ? ' · ' : ''}
                 </span>
               ))}
@@ -1143,6 +1195,7 @@ function App() {
           <TableView
             table={session.table}
             humanPlayerIndex={tableViewHumanIndex(session)}
+            getSeatDisplayName={seatDisplayName}
             onTableIntent={tableIntentZones ? handleTableIntent : undefined}
             intentZoneAllowlist={tableIntentZones}
             pendingStacksColumn={

--- a/src/core/playerLabels.ts
+++ b/src/core/playerLabels.ts
@@ -5,3 +5,8 @@ export function playerSeatLabel(playerIndex: number, humanIndex = 0): string {
   if (humanIndex >= 0 && playerIndex === humanIndex) return 'You'
   return `Player ${playerIndex + 1}`
 }
+
+/** Ordinal among AI seats only (first AI seat in table order → 1). */
+export function aiPlayerMenuLabel(aiOrdinal: number): string {
+  return `AI Player ${aiOrdinal + 1}`
+}

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -22,7 +22,7 @@ export interface MultiplayerPanelProps {
   /** Client → host game intents (host only). */
   onRemoteIntent?: (intent: PeerClientIntent, fromPeerId: string) => void
   /** Host roster changed (e.g. client connected); parent may push a table snapshot. */
-  onHostingRosterChange?: () => void
+  onHostingRosterChange?: (peers: HostedPeer[]) => void
   /** Any multiplayer teardown (Close room, Leave room, or host disconnect). */
   onTeardown?: (wasHost: boolean) => void
   onClosed?: () => void
@@ -97,7 +97,7 @@ export function MultiplayerPanel({
         onSignalingState: setSignalingState,
         onRosterChange: (peers) => {
           setRoster(peers)
-          onHostingRosterChange?.()
+          onHostingRosterChange?.(peers)
         },
         onIntent: (msg, from) => {
           if (msg.type === 'intent') onRemoteIntent?.(msg, from)

--- a/src/ui/TableView.tsx
+++ b/src/ui/TableView.tsx
@@ -21,6 +21,11 @@ export interface TableViewProps {
   /** Player index for the human; their pile cards can be shown face-down but “owned” */
   humanPlayerIndex?: number
   /**
+   * Server seat index → display name for opponents (not used for the viewer seat; that stays “You” / “Your …”).
+   * When omitted, {@link playerSeatLabel} is used for other seats.
+   */
+  getSeatDisplayName?: (serverPlayerIndex: number) => string
+  /**
    * When set together with {@link intentZoneAllowlist}, card and stack clicks emit intents.
    * Games map these to {@link import('../core/types').GameAction}s in the shell (e.g. App).
    */
@@ -49,34 +54,35 @@ function zoneAllowsIntent(zoneId: string, allowlist: readonly string[] | undefin
   return !!allowlist?.length && allowlist.includes(zoneId)
 }
 
-function zoneLabel(zone: Zone, humanPlayerIndex: number): string {
+function zoneLabel(zone: Zone, humanPlayerIndex: number, getSeatDisplayName?: (i: number) => string): string {
+  const other = (i: number) => getSeatDisplayName?.(i) ?? playerSeatLabel(i, humanPlayerIndex)
   if (zone.id === 'skirmish') return 'Table (skirmish)'
   if (zone.id === 'discard') return 'Discard pile'
   if (zone.id === 'stock' || zone.id === 'draw') return 'Draw pile'
   const b = /^books:(\d+)$/.exec(zone.id)
   if (b) {
     const i = Number(b[1])
-    return i === humanPlayerIndex ? 'Your books' : `${playerSeatLabel(i, humanPlayerIndex)}'s books`
+    return i === humanPlayerIndex ? 'Your books' : `${other(i)}'s books`
   }
   const h = /^hand:(\d+)$/.exec(zone.id)
   if (h) {
     const i = Number(h[1])
-    return i === humanPlayerIndex ? 'Your hand' : `${playerSeatLabel(i, humanPlayerIndex)}'s hand`
+    return i === humanPlayerIndex ? 'Your hand' : `${other(i)}'s hand`
   }
   const m = /^pile:(\d+)$/.exec(zone.id)
   if (m) {
     const i = Number(m[1])
-    return i === humanPlayerIndex ? 'You' : `${playerSeatLabel(i, humanPlayerIndex)} (AI)`
+    return i === humanPlayerIndex ? 'You' : other(i)
   }
   const s = /^show:(\d+)$/.exec(zone.id)
   if (s) {
     const i = Number(s[1])
-    return i === humanPlayerIndex ? 'Your card' : playerSeatLabel(i, humanPlayerIndex)
+    return i === humanPlayerIndex ? 'Your card' : other(i)
   }
   const g = /^grid:(\d+)$/.exec(zone.id)
   if (g) {
     const i = Number(g[1])
-    return i === humanPlayerIndex ? 'Your grid (3×4)' : `${playerSeatLabel(i, humanPlayerIndex)}'s grid`
+    return i === humanPlayerIndex ? 'Your grid (3×4)' : `${other(i)}'s grid`
   }
   return zone.id
 }
@@ -140,6 +146,7 @@ function buildLayoutGroups(order: string[], zones: TableState['zones']): LayoutG
 export function TableView({
   table,
   humanPlayerIndex = 0,
+  getSeatDisplayName,
   onTableIntent,
   intentZoneAllowlist,
   pendingStacksColumn,
@@ -185,7 +192,7 @@ export function TableView({
     const zone = table.zones[zid]
     if (!zone || zone.kind !== 'stack') return null
     const cards = zone.cards
-    const label = zoneLabel(zone, humanPlayerIndex)
+    const label = zoneLabel(zone, humanPlayerIndex, getSeatDisplayName)
     const zoneInteractive = intentsEnabled && zoneAllowsIntent(zid, intentZoneAllowlist)
     return (
       <>
@@ -223,7 +230,7 @@ export function TableView({
     const zone = table.zones[zid]
     if (!zone) return null
     const cards = zone.cards
-    const label = zoneLabel(zone, humanPlayerIndex)
+    const label = zoneLabel(zone, humanPlayerIndex, getSeatDisplayName)
     const zoneInteractive = intentsEnabled && zoneAllowsIntent(zid, intentZoneAllowlist)
 
     const activeTurn =


### PR DESCRIPTION
## Summary

- **AI seats**: Toolbar difficulty controls are labeled **AI Player 1**, **AI Player 2**, … (`aiPlayerMenuLabel`). The same names appear on table zones (grids, hands, books, piles) via `TableView.getSeatDisplayName`.
- **Host**: Remote human seats use the **short WebRTC peer id** from the live host roster (truncated if very long) so grids read like `c-smAJ2S…'s grid` instead of a mismatched `Player 2`.
- **Network client**: Server seat **0** is labeled **Host** for opponent zones; the guest’s own seat stays **Your grid** / **You** in score rows.
- **Scores**: Cumulative match table and “Totals if you merge…” preview use the same **row captions** as the table (`cumulativeRowCaption`).
- **Wiring**: `onHostingRosterChange(peers)` passes the roster; App keeps `hostClientRoster` and refreshes it when hosting starts.

## Verification

- `npm run lint`
- `npm run build`
