### PR TITLE
feat(multiplayer): seat profiles and editable display names

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -715,6 +715,51 @@
   margin: 0.15rem 0;
 }
 
+.multiplayerPanel__nameplate {
+  margin-top: 0.65rem;
+  padding: 0.5rem 0.55rem;
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.18);
+  font-size: 0.88rem;
+  text-align: left;
+}
+
+.multiplayerPanel__nameplateLabel {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+}
+
+.multiplayerPanel__nameplateRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.multiplayerPanel__nameplateInput {
+  flex: 1 1 140px;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.25);
+  color: inherit;
+}
+
+.multiplayerPanel__nameplateSave {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.65rem;
+  border-radius: 0.35rem;
+  cursor: pointer;
+}
+
+.multiplayerPanel__nameplateHint {
+  margin: 0.4rem 0 0;
+  font-size: 0.78rem;
+  opacity: 0.75;
+}
+
 fieldset.app__houseRules {
   margin: 0;
   padding: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { type MatchState } from './core/match'
 import { aiPlayerMenuLabel, playerSeatLabel } from './core/playerLabels'
 import { parseGameManifestYaml } from './core/loadYaml'
 import { createSession, startNextMatchRound, type CreateSessionOptions, type GameSession } from './session'
+import { buildDefaultSeatProfiles } from './session/seatProfiles'
 import { createSessionOptionsHouseRules } from './data/houseRules'
 import { GAME_IDS, GAME_SOURCES } from './data/manifests'
 import { rulesTextForGame, type RulesGameId } from './data/rulesSources'
@@ -20,7 +21,12 @@ import {
 import { GameHouseRulesPanel } from './ui/GameHouseRulesPanel'
 import type { RoomClient } from './net/client'
 import type { HostedPeer, RoomHost } from './net/host'
-import type { PeerClientIntent, PeerHostSnapshot } from './net/protocol'
+import {
+  sanitizeDisplayName,
+  type PeerClientIntent,
+  type PeerClientSetDisplayName,
+  type PeerHostSnapshot,
+} from './net/protocol'
 import { parseSessionSnapshot, serializeSessionSnapshot } from './net/sessionSnapshot'
 import { MultiplayerPanel } from './ui/MultiplayerPanel'
 import { RulesModal } from './ui/RulesModal'
@@ -29,6 +35,16 @@ import { skyjoDumpUiStepShouldReset, type SkyjoDumpUiStep } from './ui/tableUiFl
 import type { GameAction } from './core/types'
 import type { GoFishGameState } from './games/go-fish'
 import { isSkyjoSlotTemplateId, type SkyjoGameState } from './games/skyjo'
+import type { MultiplayerNameplateProps } from './ui/MultiplayerPanel'
+
+function attachHostSeatProfilesIfNeeded(
+  sess: GameSession,
+  id: (typeof GAME_IDS)[number],
+  hosting: boolean,
+): GameSession {
+  if (!hosting || !gameSupportsOnlineMultiplayer(id)) return sess
+  return { ...sess, seatProfiles: buildDefaultSeatProfiles(sess.manifest) }
+}
 
 /** Local human’s server seat index (0 = host / solo). */
 function shellHumanSeat(session: GameSession | null): number {
@@ -296,6 +312,8 @@ function App() {
   const [skyjoDumpStep, setSkyjoDumpStep] = useState<SkyjoDumpUiStep>('idle')
   const [rulesOpen, setRulesOpen] = useState(false)
   const [hostClientRoster, setHostClientRoster] = useState<HostedPeer[]>([])
+  /** True while this browser is an active room host (not ref-driven — avoids reading refs during render). */
+  const [multiplayerHostActive, setMultiplayerHostActive] = useState(false)
 
   const selectedManifest = useMemo(() => parseGameManifestYaml(GAME_SOURCES[gameId]), [gameId])
 
@@ -305,6 +323,8 @@ function App() {
   const seatDisplayName = useCallback(
     (serverPlayerIndex: number): string => {
       if (!session) return `Player ${serverPlayerIndex + 1}`
+      const profileLabel = session.seatProfiles?.find((s) => s.seat === serverPlayerIndex)?.displayName?.trim()
+      if (profileLabel) return profileLabel
       const humanCount = session.manifest.players.human
       if (serverPlayerIndex >= humanCount) {
         return aiPlayerMenuLabel(serverPlayerIndex - humanCount)
@@ -394,7 +414,13 @@ function App() {
         openRemotes > 0 && gameSupportsOnlineMultiplayer(id)
           ? { ...baseOpts, remoteHumanCount: openRemotes }
           : baseOpts
-      setSession(createSession(id, Math.random, undefined, withRemotes))
+      const hosting = !!roomHostRef.current
+      const sess = attachHostSeatProfilesIfNeeded(
+        createSession(id, Math.random, undefined, withRemotes),
+        id,
+        hosting,
+      )
+      setSession(sess)
       setGfAwaitingOpponent(false)
       setGfRank('A')
       setSkyjoDumpStep('idle')
@@ -445,6 +471,7 @@ function App() {
 
   const onHostStarted = useCallback((host: RoomHost) => {
     roomHostRef.current = host
+    setMultiplayerHostActive(true)
     setHostClientRoster(host.getRoster())
   }, [])
 
@@ -467,6 +494,36 @@ function App() {
     setGfAwaitingOpponent(false)
     setGfRank('A')
     setSkyjoDumpStep('idle')
+  }, [])
+
+  const onRemoteSetDisplayName = useCallback((msg: PeerClientSetDisplayName, fromPeerId: string) => {
+    const host = roomHostRef.current
+    if (!host) return
+    const roster = host.getRoster()
+    const rec = roster.find((r) => r.peerId === fromPeerId)
+    if (!rec || rec.seat !== msg.seat) {
+      host.ack(fromPeerId, msg.nonce, false, 'Seat mismatch')
+      return
+    }
+    const name = sanitizeDisplayName(msg.displayName)
+    if (!name) {
+      host.ack(fromPeerId, msg.nonce, false, 'Invalid name')
+      return
+    }
+    const prev = sessionRef.current
+    if (!prev?.seatProfiles?.length) {
+      host.ack(fromPeerId, msg.nonce, false, 'No seat roster')
+      return
+    }
+    const ix = prev.seatProfiles.findIndex((s) => s.seat === msg.seat && s.id === msg.playerId)
+    if (ix < 0) {
+      host.ack(fromPeerId, msg.nonce, false, 'Unknown seat id')
+      return
+    }
+    const nextProfiles = prev.seatProfiles.slice()
+    nextProfiles[ix] = { ...nextProfiles[ix]!, displayName: name }
+    setSession({ ...prev, seatProfiles: nextProfiles })
+    host.ack(fromPeerId, msg.nonce, true)
   }, [])
 
   const onRemoteIntent = useCallback((msg: PeerClientIntent, fromPeerId: string) => {
@@ -501,6 +558,7 @@ function App() {
     roomHostRef.current = null
     roomClientRef.current = null
     setJoinedAsClient(false)
+    setMultiplayerHostActive(false)
     setHostClientRoster([])
     setSession(null)
     setGfAwaitingOpponent(false)
@@ -516,12 +574,80 @@ function App() {
   const onNextMatchRound = useCallback(() => {
     if (!session || session.net) return
     try {
-      const next = startNextMatchRound(session, gameId)
+      const next = attachHostSeatProfilesIfNeeded(
+        startNextMatchRound(session, gameId),
+        gameId,
+        !!roomHostRef.current,
+      )
       setSession(next)
     } catch (e) {
       window.alert(e instanceof Error ? e.message : String(e))
     }
   }, [session, gameId])
+
+  const commitLocalSeatDisplayName = useCallback((raw: string) => {
+    const name = sanitizeDisplayName(raw)
+    if (!name) return
+    setSession((prev) => {
+      if (!prev?.seatProfiles?.length) return prev
+      const seat = prev.net?.spectator ? null : prev.net ? prev.net.seat : 0
+      if (seat == null) return prev
+      const ix = prev.seatProfiles.findIndex((s) => s.seat === seat)
+      if (ix < 0) return prev
+      const nextProfiles = prev.seatProfiles.slice()
+      nextProfiles[ix] = { ...nextProfiles[ix]!, displayName: name }
+      return { ...prev, seatProfiles: nextProfiles }
+    })
+  }, [])
+
+  const sendDisplayNameToHost = useCallback((raw: string) => {
+    const name = sanitizeDisplayName(raw)
+    if (!name) return
+    const prev = sessionRef.current
+    const c = roomClientRef.current
+    if (!prev?.net || prev.net.spectator || !c) return
+    const seat = prev.net.seat
+    const profile = prev.seatProfiles?.find((s) => s.seat === seat)
+    if (!profile) return
+    c.sendSetDisplayName({
+      nonce: crypto.randomUUID(),
+      seat,
+      playerId: profile.id,
+      displayName: name,
+    })
+  }, [])
+
+  const multiplayerNameplate = useMemo((): Omit<MultiplayerNameplateProps, 'onCommit'> | null => {
+    if (!session?.seatProfiles?.length || !gameSupportsOnlineMultiplayer(gameId)) return null
+    if (session.net?.spectator) return null
+    const seat = session.net ? session.net.seat : 0
+    const profile = session.seatProfiles.find((s) => s.seat === seat)
+    if (!profile) return null
+    const hostTable = !session.net && multiplayerHostActive
+    const clientTable = !!session.net
+    if (!hostTable && !clientTable) return null
+    return {
+      seat: profile.seat,
+      playerId: profile.id,
+      initialName: profile.displayName,
+      disabled: networkSpectator,
+    }
+  }, [session, gameId, networkSpectator, multiplayerHostActive])
+
+  const handleNameplateCommit = useCallback(
+    (raw: string) => {
+      if (sessionRef.current?.net && !sessionRef.current.net.spectator) {
+        sendDisplayNameToHost(raw)
+      } else {
+        commitLocalSeatDisplayName(raw)
+      }
+    },
+    [commitLocalSeatDisplayName, sendDisplayNameToHost],
+  )
+
+  const onPeerAck = useCallback((_nonce: string, ok: boolean, error: string | undefined) => {
+    if (!ok && error) window.alert(error)
+  }, [])
 
   const dispatchAction = useCallback((action: GameAction) => {
     const prev = sessionRef.current
@@ -1098,7 +1224,13 @@ function App() {
                           while (next.length < aiOpponents) next.push('medium')
                           setAiDifficulties(next)
                           if (session) {
-                            setSession(createSession(gameId, Math.random, undefined, makeDealOptions(undefined, gameId, next)))
+                            const hosting = !!roomHostRef.current
+                            const s = attachHostSeatProfilesIfNeeded(
+                              createSession(gameId, Math.random, undefined, makeDealOptions(undefined, gameId, next)),
+                              gameId,
+                              hosting,
+                            )
+                            setSession(s)
                             setSkyjoDumpStep('idle')
                             setGfAwaitingOpponent(false)
                             setGfRank('A')
@@ -1144,8 +1276,15 @@ function App() {
           onClientStarted={onClientStarted}
           onSessionSnapshot={onSessionSnapshot}
           onRemoteIntent={onRemoteIntent}
+          onRemoteSetDisplayName={onRemoteSetDisplayName}
           onHostingRosterChange={onHostingRosterChange}
           onTeardown={onMultiplayerTeardown}
+          onPeerAck={onPeerAck}
+          nameplate={
+            multiplayerNameplate
+              ? { ...multiplayerNameplate, onCommit: handleNameplateCommit }
+              : undefined
+          }
         />
       )}
 

--- a/src/net/client.ts
+++ b/src/net/client.ts
@@ -1,6 +1,7 @@
 import { PeerLink, type PeerState } from './peer'
 import {
   type PeerClientIntent,
+  type PeerClientSetDisplayName,
   type PeerHostSnapshot,
   type PeerMessage,
   type SignalingRelay,
@@ -87,6 +88,10 @@ export class RoomClient {
 
   sendIntent(intent: Omit<PeerClientIntent, 'type'>): void {
     this.link?.send({ type: 'intent', ...intent })
+  }
+
+  sendSetDisplayName(body: Omit<PeerClientSetDisplayName, 'type'>): void {
+    this.link?.send({ type: 'setDisplayName', ...body })
   }
 
   close(): void {

--- a/src/net/host.ts
+++ b/src/net/host.ts
@@ -2,6 +2,7 @@ import { PeerLink, type PeerState } from './peer'
 import {
   PROTOCOL_VERSION,
   type PeerClientIntent,
+  type PeerClientSetDisplayName,
   type PeerHostSnapshot,
   type PeerMessage,
   type SignalingRelay,
@@ -21,7 +22,8 @@ export interface RoomHostOptions {
   token: string
   onRosterChange?: (peers: HostedPeer[]) => void
   onSignalingState?: (state: SignalingState) => void
-  onIntent?: (intent: PeerClientIntent, fromPeerId: string) => void
+  /** Game intents and auxiliary seat updates from clients. */
+  onIntent?: (msg: PeerClientIntent | PeerClientSetDisplayName, fromPeerId: string) => void
 }
 
 interface HostPeerRecord {
@@ -119,7 +121,7 @@ export class RoomHost {
   }
 
   private handlePeerMessage(msg: PeerMessage, fromPeerId: string) {
-    if (msg.type === 'intent') {
+    if (msg.type === 'intent' || msg.type === 'setDisplayName') {
       this.opts.onIntent?.(msg, fromPeerId)
     } else if (msg.type === 'ping') {
       const rec = this.peers.get(fromPeerId)

--- a/src/net/protocol.test.ts
+++ b/src/net/protocol.test.ts
@@ -6,6 +6,7 @@ import {
   isRoomCode,
   isSignalingMessage,
   isPeerMessage,
+  sanitizeDisplayName,
 } from './protocol'
 import { mulberry32 } from '../core/shuffle'
 
@@ -30,6 +31,19 @@ describe('room codes', () => {
   })
 })
 
+describe('sanitizeDisplayName', () => {
+  it('trims and caps length', () => {
+    expect(sanitizeDisplayName('  River  ')).toBe('River')
+    expect(sanitizeDisplayName('x'.repeat(50))!.length).toBe(40)
+  })
+
+  it('rejects empty', () => {
+    expect(sanitizeDisplayName('')).toBeNull()
+    expect(sanitizeDisplayName('   ')).toBeNull()
+    expect(sanitizeDisplayName(1 as unknown)).toBeNull()
+  })
+})
+
 describe('message type guards', () => {
   it('isSignalingMessage', () => {
     expect(isSignalingMessage({ type: 'hello' })).toBe(true)
@@ -41,6 +55,7 @@ describe('message type guards', () => {
   it('isPeerMessage', () => {
     expect(isPeerMessage({ type: 'snapshot' })).toBe(true)
     expect(isPeerMessage({ type: 'intent' })).toBe(true)
+    expect(isPeerMessage({ type: 'setDisplayName' })).toBe(true)
     expect(isPeerMessage({ type: 'nope' })).toBe(false)
   })
 })

--- a/src/net/protocol.ts
+++ b/src/net/protocol.ts
@@ -8,7 +8,7 @@
  * host sends back. Incrementing {@link PROTOCOL_VERSION} is a breaking change.
  */
 
-export const PROTOCOL_VERSION = 1
+export const PROTOCOL_VERSION = 2
 
 /** Room codes are 6 uppercase alphanumeric chars, ambiguous glyphs dropped. */
 export const ROOM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
@@ -137,6 +137,31 @@ export interface PeerClientIntent {
   action: unknown
 }
 
+/** Client → host: change display label for their seat (host validates seat + player id). */
+export interface PeerClientSetDisplayName {
+  type: 'setDisplayName'
+  nonce: string
+  seat: number
+  /** Must match the seat’s profile id from the last snapshot (prevents spoofing another seat). */
+  playerId: string
+  displayName: string
+}
+
+/** Single-line display name for UI; returns null if empty after trim / invalid type. */
+export function sanitizeDisplayName(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const t = raw
+    .trim()
+    .split('')
+    .filter((ch) => {
+      const c = ch.charCodeAt(0)
+      return c >= 32 && c !== 127
+    })
+    .join('')
+    .slice(0, 40)
+  return t.length ? t : null
+}
+
 /** Client → host: liveness ping to detect silent disconnects. */
 export interface PeerClientPing {
   type: 'ping'
@@ -153,6 +178,7 @@ export type PeerMessage =
   | PeerHostAck
   | PeerHostStatus
   | PeerClientIntent
+  | PeerClientSetDisplayName
   | PeerClientPing
   | PeerHostPong
 
@@ -179,6 +205,7 @@ export function isPeerMessage(value: unknown): value is PeerMessage {
     t === 'ack' ||
     t === 'status' ||
     t === 'intent' ||
+    t === 'setDisplayName' ||
     t === 'ping' ||
     t === 'pong'
   )

--- a/src/net/sessionSnapshot.test.ts
+++ b/src/net/sessionSnapshot.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { GameManifestYaml, TableState } from '../core/types'
+import {
+  gridSeatCountFromTable,
+  parseWireSeatProfiles,
+  reconcileManifestPlayersForTable,
+} from './sessionSnapshot'
+
+function emptyTableWithGrids(maxPlayerIndex: number): TableState {
+  const zones: TableState['zones'] = {}
+  for (let i = 0; i <= maxPlayerIndex; i++) {
+    zones[`grid:${i}`] = { id: `grid:${i}`, kind: 'grid', defaultFaceUp: false, cards: [] }
+  }
+  return {
+    zones,
+    zoneOrder: Object.keys(zones),
+    templates: {},
+  }
+}
+
+describe('gridSeatCountFromTable', () => {
+  it('returns null when there are no grid zones', () => {
+    const t: TableState = { zones: {}, zoneOrder: [], templates: {} }
+    expect(gridSeatCountFromTable(t)).toBeNull()
+  })
+
+  it('returns max grid index + 1', () => {
+    const t = emptyTableWithGrids(2)
+    expect(gridSeatCountFromTable(t)).toBe(3)
+  })
+})
+
+describe('reconcileManifestPlayersForTable', () => {
+  const skyjoYamlLike: GameManifestYaml = {
+    id: 'skyjo',
+    name: 'Skyjo',
+    module: 'skyjo',
+    deck: 'skyjo',
+    players: { human: 1, ai: 1 },
+  }
+
+  it('does nothing when manifest already matches grid count', () => {
+    const t = emptyTableWithGrids(1)
+    const m = { ...skyjoYamlLike, players: { human: 2, ai: 0 } }
+    expect(reconcileManifestPlayersForTable(m, t)).toEqual(m)
+  })
+
+  it('grows human slots when YAML under-counts vs table (remote client snapshot)', () => {
+    const t = emptyTableWithGrids(2)
+    const out = reconcileManifestPlayersForTable(skyjoYamlLike, t)
+    expect(out.players).toEqual({ human: 2, ai: 1 })
+  })
+
+  it('does not shrink an oversized manifest when grid count is smaller', () => {
+    const t = emptyTableWithGrids(1)
+    const m = { ...skyjoYamlLike, players: { human: 3, ai: 0 } }
+    expect(reconcileManifestPlayersForTable(m, t)).toEqual(m)
+  })
+})
+
+describe('parseWireSeatProfiles', () => {
+  it('parses valid seat profile rows', () => {
+    const out = parseWireSeatProfiles([
+      { seat: 0, id: 'a-uuid', displayName: 'Host' },
+      { seat: 1, id: 'b-uuid', displayName: 'River' },
+    ])
+    expect(out).toEqual([
+      { seat: 0, id: 'a-uuid', displayName: 'Host' },
+      { seat: 1, id: 'b-uuid', displayName: 'River' },
+    ])
+  })
+
+  it('returns undefined for invalid input', () => {
+    expect(parseWireSeatProfiles(null)).toBeUndefined()
+    expect(parseWireSeatProfiles([])).toBeUndefined()
+    expect(parseWireSeatProfiles([{ seat: 0, displayName: 'x' }])).toBeUndefined()
+  })
+})

--- a/src/net/sessionSnapshot.ts
+++ b/src/net/sessionSnapshot.ts
@@ -5,6 +5,40 @@ import type { MatchState } from '../core/match'
 import type { GameManifestYaml, TableState } from '../core/types'
 import { GAME_SOURCES } from '../data/manifests'
 import type { AiPlayerConfig, GameSession } from '../session'
+import type { SeatProfile } from '../session/seatProfiles'
+
+/**
+ * When the client falls back to YAML-only manifests (older hosts omitting `manifest` on the wire),
+ * `players.human` can be too low (e.g. Skyjo defaults to 1 human) while the table already has a
+ * `grid:N` zone per seat. Reconcile counts from the table so seat labels and spectator detection match.
+ */
+export function gridSeatCountFromTable(table: TableState): number | null {
+  let max = -1
+  for (const k of Object.keys(table.zones ?? {})) {
+    const m = /^grid:(\d+)$/.exec(k)
+    if (!m) continue
+    max = Math.max(max, Number(m[1]))
+  }
+  if (max < 0) return null
+  return max + 1
+}
+
+/** If the table has more grid seats than `human+ai`, grow humans (keeping AI when it still fits). */
+export function reconcileManifestPlayersForTable(
+  manifest: GameManifestYaml,
+  table: TableState,
+): GameManifestYaml {
+  const gridCount = gridSeatCountFromTable(table)
+  if (gridCount == null) return manifest
+  const h = manifest.players.human
+  const a = manifest.players.ai
+  const total = h + a
+  if (gridCount <= total) return manifest
+  const nextAi = Math.min(a, Math.max(0, gridCount - 1))
+  const nextHuman = gridCount - nextAi
+  if (nextHuman < 1) return manifest
+  return { ...manifest, players: { human: nextHuman, ai: nextAi } }
+}
 
 /** Wire shape sent in {@link PeerHostSnapshot.state} for table sync. */
 export interface SessionSnapshotWire {
@@ -22,6 +56,23 @@ export interface SessionSnapshotWire {
   viewerSeat?: number
   /** True when this seat is not in the current deal’s human slots (mid-join spectator). */
   spectator?: boolean
+  /** Host-authored seat ids + display names (optional). */
+  seatProfiles?: SeatProfile[]
+}
+
+export function parseWireSeatProfiles(raw: unknown): SeatProfile[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const out: SeatProfile[] = []
+  for (const row of raw) {
+    if (!row || typeof row !== 'object') continue
+    const o = row as { seat?: unknown; id?: unknown; displayName?: unknown }
+    const seat = Number(o.seat)
+    const id = typeof o.id === 'string' ? o.id : ''
+    const displayName = typeof o.displayName === 'string' ? o.displayName : ''
+    if (!Number.isFinite(seat) || seat < 0 || !id) continue
+    out.push({ seat, id, displayName: displayName.slice(0, 48) })
+  }
+  return out.length ? out : undefined
 }
 
 export function isSessionSnapshotWire(value: unknown): value is SessionSnapshotWire {
@@ -42,6 +93,9 @@ export function serializeSessionSnapshot(session: GameSession): SessionSnapshotW
       aiPlayerConfig: session.aiPlayerConfig
         ? (JSON.parse(JSON.stringify(session.aiPlayerConfig)) as AiPlayerConfig)
         : undefined,
+      seatProfiles: session.seatProfiles
+        ? (JSON.parse(JSON.stringify(session.seatProfiles)) as SeatProfile[])
+        : undefined,
     }
     return wire
   } catch {
@@ -55,14 +109,16 @@ export function parseSessionSnapshot(value: unknown, peerSeatFallback?: number):
   const gameId = w.gameId as keyof typeof GAME_SOURCES
   const raw = GAME_SOURCES[gameId]
   if (!raw) return null
-  const manifest = (
+  let manifest = (
     w.manifest ? w.manifest : (parseGameManifestYaml(raw) as GameManifestYaml)
   ) as GameManifestYaml
+  manifest = reconcileManifestPlayersForTable(manifest, w.table)
   const mod = getGameModule(manifest.module)
   if (!mod) return null
   const remoteHumans = Math.max(0, manifest.players.human - 1)
   const seat = typeof w.viewerSeat === 'number' ? w.viewerSeat : peerSeatFallback ?? 1
   const spectator = typeof w.spectator === 'boolean' ? w.spectator : seat > remoteHumans
+  const seatProfiles = parseWireSeatProfiles(w.seatProfiles)
   return {
     manifest,
     module: mod as GameModule,
@@ -71,5 +127,6 @@ export function parseSessionSnapshot(value: unknown, peerSeatFallback?: number):
     match: w.match,
     aiPlayerConfig: w.aiPlayerConfig,
     net: { seat, spectator },
+    seatProfiles,
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,11 +12,13 @@ import {
   normalizeAiDifficultiesForCount,
   type CreateSessionOptions,
 } from './session/playerConfig'
+import type { SeatProfile } from './session/seatProfiles'
 import { clampMatchTargetScore, createSessionOptionsHouseRules, effectiveReshuffleDiscardWhenDrawEmpty } from './data/houseRules'
 import type { RulesGameId } from './data/rulesSources'
 
 export type { MatchState } from './core/match'
 export type { CreateSessionOptions } from './session/playerConfig'
+export type { SeatProfile } from './session/seatProfiles'
 
 /** Locked at deal time; `difficulties[i]` is for human player index `i + 1`. */
 export interface AiPlayerConfig {
@@ -42,6 +44,8 @@ export interface GameSession<T = unknown> {
   aiPlayerConfig?: AiPlayerConfig
   /** Set for browsers consuming a host snapshot over the network. */
   net?: GameSessionNetMeta
+  /** Per-seat display ids/names for online play (optional for local-only tables). */
+  seatProfiles?: SeatProfile[]
 }
 
 export function createSession(

--- a/src/session/seatProfiles.test.ts
+++ b/src/session/seatProfiles.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import type { GameManifestYaml } from '../core/types'
+import { buildDefaultSeatProfiles } from './seatProfiles'
+
+describe('buildDefaultSeatProfiles', () => {
+  it('assigns Host, human slots, then AI labels', () => {
+    const m: GameManifestYaml = {
+      id: 'skyjo',
+      name: 'Skyjo',
+      module: 'skyjo',
+      deck: 'skyjo',
+      players: { human: 2, ai: 1 },
+    }
+    const p = buildDefaultSeatProfiles(m)
+    expect(p).toHaveLength(3)
+    expect(p[0]).toMatchObject({ seat: 0, displayName: 'Host' })
+    expect(p[1]).toMatchObject({ seat: 1, displayName: 'Player 2' })
+    expect(p[2]).toMatchObject({ seat: 2, displayName: 'AI Player 1' })
+    expect(p[0]!.id).toBeTruthy()
+    expect(p[0]!.id).not.toBe(p[1]!.id)
+  })
+})

--- a/src/session/seatProfiles.ts
+++ b/src/session/seatProfiles.ts
@@ -1,0 +1,31 @@
+import { aiPlayerMenuLabel } from '../core/playerLabels'
+import type { GameManifestYaml } from '../core/types'
+
+export interface SeatProfile {
+  seat: number
+  id: string
+  displayName: string
+}
+
+function randomSeatId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `seat-${Math.random().toString(36).slice(2, 12)}`
+}
+
+/** One profile per server seat index for the current deal (`0 … human+ai-1`). */
+export function buildDefaultSeatProfiles(manifest: GameManifestYaml): SeatProfile[] {
+  const { human, ai } = manifest.players
+  const total = human + ai
+  const out: SeatProfile[] = []
+  for (let seat = 0; seat < total; seat++) {
+    const id = randomSeatId()
+    let displayName: string
+    if (seat === 0) displayName = 'Host'
+    else if (seat < human) displayName = `Player ${seat + 1}`
+    else displayName = aiPlayerMenuLabel(seat - human)
+    out.push({ seat, id, displayName })
+  }
+  return out
+}

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -3,9 +3,17 @@ import { createRoom, joinRoom } from '../net/api'
 import { isMultiplayerConfigured } from '../net/config'
 import { RoomClient } from '../net/client'
 import { RoomHost, type HostedPeer } from '../net/host'
-import { isRoomCode, type PeerClientIntent, type PeerHostSnapshot } from '../net/protocol'
+import { isRoomCode, type PeerClientIntent, type PeerClientSetDisplayName, type PeerHostSnapshot } from '../net/protocol'
 import type { PeerState } from '../net/peer'
 import type { SignalingState } from '../net/signaling'
+
+export interface MultiplayerNameplateProps {
+  seat: number
+  playerId: string
+  initialName: string
+  disabled?: boolean
+  onCommit: (raw: string) => void
+}
 
 export interface MultiplayerPanelProps {
   gameId: string
@@ -21,11 +29,17 @@ export interface MultiplayerPanelProps {
   onSessionSnapshot?: (snap: PeerHostSnapshot) => void
   /** Client → host game intents (host only). */
   onRemoteIntent?: (intent: PeerClientIntent, fromPeerId: string) => void
+  /** Client → host display name updates (host only). */
+  onRemoteSetDisplayName?: (msg: PeerClientSetDisplayName, fromPeerId: string) => void
   /** Host roster changed (e.g. client connected); parent may push a table snapshot. */
   onHostingRosterChange?: (peers: HostedPeer[]) => void
   /** Any multiplayer teardown (Close room, Leave room, or host disconnect). */
   onTeardown?: (wasHost: boolean) => void
   onClosed?: () => void
+  /** Host acks from the peer channel (e.g. failed rename). */
+  onPeerAck?: (nonce: string, ok: boolean, error: string | undefined) => void
+  /** Local viewer’s seat label editor (when the table has a seat roster). */
+  nameplate?: MultiplayerNameplateProps
 }
 
 type Mode = 'idle' | 'hosting' | 'client'
@@ -38,9 +52,12 @@ export function MultiplayerPanel({
   onClientStarted,
   onSessionSnapshot,
   onRemoteIntent,
+  onRemoteSetDisplayName,
   onHostingRosterChange,
   onTeardown,
   onClosed,
+  onPeerAck,
+  nameplate,
 }: MultiplayerPanelProps) {
   const [mode, setMode] = useState<Mode>('idle')
   const [roomCode, setRoomCode] = useState<string>('')
@@ -101,6 +118,7 @@ export function MultiplayerPanel({
         },
         onIntent: (msg, from) => {
           if (msg.type === 'intent') onRemoteIntent?.(msg, from)
+          else if (msg.type === 'setDisplayName') onRemoteSetDisplayName?.(msg, from)
         },
       })
       hostRef.current = host
@@ -112,7 +130,7 @@ export function MultiplayerPanel({
       setError(e instanceof Error ? e.message : String(e))
       setStatus('')
     }
-  }, [gameId, maxClients, onHostStarted, onHostingRosterChange, onRemoteIntent])
+  }, [gameId, maxClients, onHostStarted, onHostingRosterChange, onRemoteIntent, onRemoteSetDisplayName])
 
   const startClient = useCallback(async () => {
     setError('')
@@ -136,6 +154,7 @@ export function MultiplayerPanel({
         onPeerState: updatePeerStatus,
         onSnapshot: (snap) => onSessionSnapshot?.(snap),
         onStatus: (m) => setStatus(m),
+        onAck: (nonce, ok, err) => onPeerAck?.(nonce, ok, err),
         onHostEnded: () => {
           teardown({ clientKickedByHost: true })
         },
@@ -148,7 +167,7 @@ export function MultiplayerPanel({
       setError(e instanceof Error ? e.message : String(e))
       setStatus('')
     }
-  }, [joinCodeInput, onClientStarted, onSessionSnapshot, teardown, updatePeerStatus])
+  }, [joinCodeInput, onClientStarted, onPeerAck, onSessionSnapshot, teardown, updatePeerStatus])
 
   if (!configured) {
     return (
@@ -263,6 +282,16 @@ export function MultiplayerPanel({
         </div>
       )}
 
+      {nameplate && tableActive && (
+        <NameplateEditor
+          seat={nameplate.seat}
+          playerId={nameplate.playerId}
+          initialName={nameplate.initialName}
+          disabled={nameplate.disabled}
+          onCommit={nameplate.onCommit}
+        />
+      )}
+
       {status && <p className="multiplayerPanel__status">{status}</p>}
       {error && (
         <p className="multiplayerPanel__error" role="alert">
@@ -270,6 +299,48 @@ export function MultiplayerPanel({
         </p>
       )}
     </section>
+  )
+}
+
+function NameplateEditor({
+  seat,
+  playerId,
+  initialName,
+  disabled,
+  onCommit,
+}: Pick<MultiplayerNameplateProps, 'seat' | 'playerId' | 'initialName' | 'disabled' | 'onCommit'>) {
+  const [draft, setDraft] = useState(initialName)
+  useEffect(() => {
+    setDraft(initialName)
+  }, [playerId, initialName])
+  if (!playerId) return null
+  return (
+    <div className="multiplayerPanel__nameplate">
+      <label className="multiplayerPanel__nameplateLabel" htmlFor={`mp-display-name-${seat}`}>
+        Your table name (seat {seat})
+      </label>
+      <div className="multiplayerPanel__nameplateRow">
+        <input
+          id={`mp-display-name-${seat}`}
+          className="multiplayerPanel__nameplateInput"
+          type="text"
+          maxLength={40}
+          autoComplete="nickname"
+          value={draft}
+          disabled={disabled}
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        <button
+          type="button"
+          className="multiplayerPanel__nameplateSave"
+          disabled={disabled || !draft.trim()}
+          onClick={() => onCommit(draft)}
+        >
+          Save
+        </button>
+      </div>
+      <p className="multiplayerPanel__nameplateHint">Shown on the table and score card. Does not change your seat.</p>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Adds a per-deal seat roster: each seat gets a stable player id (UUID) and a display name when the host starts a deal with an active online room and the game supports multiplayer. Labels appear on the table and cumulative score UI through the existing `seatDisplayName` path (profile names override defaults like Host, Player 2, AI Player 1).

## Wire

- Bumps `PROTOCOL_VERSION` to **2**.
- New peer message `setDisplayName`: client sends `seat`, `playerId`, and `displayName`. The host checks roster seat and matching `playerId`, sanitizes the name, sends an ack, updates session, and snapshots propagate the change.

## UI

- In the Multiplayer panel, when a table is active and the session includes seat profiles, a **Your table name** field and Save button appear for the host (local update) and for remote clients (message to host).

## Tests

- `buildDefaultSeatProfiles`, `parseWireSeatProfiles`, protocol type guards, `sanitizeDisplayName`, and snapshot reconciliation tests in `src/net/sessionSnapshot.test.ts`.
