### PR TITLE
ui(multiplayer): compact inline table name editor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -697,6 +697,27 @@
   gap: 0.5rem 0.75rem;
 }
 
+.multiplayerPanel__compactRow--split {
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem 0.5rem;
+}
+
+.multiplayerPanel__compactLead {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.multiplayerPanel__compactTail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem 0.5rem;
+  flex: 1 1 10rem;
+  min-width: 0;
+}
+
 .multiplayerPanel__compact button {
   flex: 0 0 auto;
 }
@@ -715,49 +736,42 @@
   margin: 0.15rem 0;
 }
 
-.multiplayerPanel__nameplate {
-  margin-top: 0.65rem;
-  padding: 0.5rem 0.55rem;
-  border-radius: 0.5rem;
-  background: rgba(0, 0, 0, 0.18);
-  font-size: 0.88rem;
-  text-align: left;
-}
-
-.multiplayerPanel__nameplateLabel {
-  display: block;
-  margin-bottom: 0.35rem;
-  font-weight: 600;
-}
-
-.multiplayerPanel__nameplateRow {
+/* One-line name editor inside compact host / client row */
+.multiplayerPanel__nameplateInline {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  flex-direction: row;
   align-items: center;
-}
-
-.multiplayerPanel__nameplateInput {
-  flex: 1 1 140px;
+  gap: 0.3rem;
+  flex: 0 1 auto;
   min-width: 0;
-  padding: 0.35rem 0.5rem;
-  border-radius: 0.35rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.82rem;
+}
+
+.multiplayerPanel__nameplateInlineShort {
+  flex-shrink: 0;
+  opacity: 0.88;
+  white-space: nowrap;
+}
+
+.multiplayerPanel__nameplateInlineInput {
+  width: 7rem;
+  min-width: 4.5rem;
+  max-width: 12rem;
+  flex: 1 1 6rem;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.3rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(0, 0, 0, 0.22);
   color: inherit;
+  font-size: 0.82rem;
 }
 
-.multiplayerPanel__nameplateSave {
-  flex: 0 0 auto;
-  padding: 0.35rem 0.65rem;
-  border-radius: 0.35rem;
+.multiplayerPanel__nameplateInlineSave {
+  flex-shrink: 0;
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.3rem;
   cursor: pointer;
-}
-
-.multiplayerPanel__nameplateHint {
-  margin: 0.4rem 0 0;
-  font-size: 0.78rem;
-  opacity: 0.75;
+  font-size: 0.8rem;
 }
 
 fieldset.app__houseRules {

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -217,13 +217,24 @@ export function MultiplayerPanel({
 
       {showCompact && mode === 'hosting' && (
         <div className="multiplayerPanel__compact multiplayerPanel__compact--stacked">
-          <div className="multiplayerPanel__compactRow">
-            <span>
+          <div className="multiplayerPanel__compactRow multiplayerPanel__compactRow--split">
+            <span className="multiplayerPanel__compactLead">
               Hosting · code <strong className="multiplayerPanel__code">{roomCode}</strong>
             </span>
-            <button type="button" onClick={() => teardown()}>
-              Close room
-            </button>
+            <div className="multiplayerPanel__compactTail">
+              {nameplate && (
+                <NameplateInline
+                  seat={nameplate.seat}
+                  playerId={nameplate.playerId}
+                  initialName={nameplate.initialName}
+                  disabled={nameplate.disabled}
+                  onCommit={nameplate.onCommit}
+                />
+              )}
+              <button type="button" onClick={() => teardown()}>
+                Close room
+              </button>
+            </div>
           </div>
           {roster.length > 0 ? (
             <ul className="multiplayerPanel__compactRoster" aria-label="Connected clients">
@@ -241,14 +252,25 @@ export function MultiplayerPanel({
 
       {showCompact && mode === 'client' && (
         <div className="multiplayerPanel__compact">
-          <div className="multiplayerPanel__compactRow">
-            <span>
+          <div className="multiplayerPanel__compactRow multiplayerPanel__compactRow--split">
+            <span className="multiplayerPanel__compactLead">
               Joined · code <strong className="multiplayerPanel__code">{roomCode}</strong> · signaling{' '}
               <em>{signalingState}</em> · peer <em>{peerState}</em>
             </span>
-            <button type="button" onClick={() => teardown()}>
-              Leave room
-            </button>
+            <div className="multiplayerPanel__compactTail">
+              {nameplate && (
+                <NameplateInline
+                  seat={nameplate.seat}
+                  playerId={nameplate.playerId}
+                  initialName={nameplate.initialName}
+                  disabled={nameplate.disabled}
+                  onCommit={nameplate.onCommit}
+                />
+              )}
+              <button type="button" onClick={() => teardown()}>
+                Leave room
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -282,16 +304,6 @@ export function MultiplayerPanel({
         </div>
       )}
 
-      {nameplate && tableActive && (
-        <NameplateEditor
-          seat={nameplate.seat}
-          playerId={nameplate.playerId}
-          initialName={nameplate.initialName}
-          disabled={nameplate.disabled}
-          onCommit={nameplate.onCommit}
-        />
-      )}
-
       {status && <p className="multiplayerPanel__status">{status}</p>}
       {error && (
         <p className="multiplayerPanel__error" role="alert">
@@ -302,7 +314,9 @@ export function MultiplayerPanel({
   )
 }
 
-function NameplateEditor({
+const NAMEPLATE_HINT = 'Shown on the table and score card. Does not change your seat.'
+
+function NameplateInline({
   seat,
   playerId,
   initialName,
@@ -314,32 +328,32 @@ function NameplateEditor({
     setDraft(initialName)
   }, [playerId, initialName])
   if (!playerId) return null
+  const inputId = `mp-display-name-${seat}`
   return (
-    <div className="multiplayerPanel__nameplate">
-      <label className="multiplayerPanel__nameplateLabel" htmlFor={`mp-display-name-${seat}`}>
-        Your table name (seat {seat})
+    <div className="multiplayerPanel__nameplateInline" title={NAMEPLATE_HINT}>
+      <label className="multiplayerPanel__nameplateInlineShort" htmlFor={inputId}>
+        Name
       </label>
-      <div className="multiplayerPanel__nameplateRow">
-        <input
-          id={`mp-display-name-${seat}`}
-          className="multiplayerPanel__nameplateInput"
-          type="text"
-          maxLength={40}
-          autoComplete="nickname"
-          value={draft}
-          disabled={disabled}
-          onChange={(e) => setDraft(e.target.value)}
-        />
-        <button
-          type="button"
-          className="multiplayerPanel__nameplateSave"
-          disabled={disabled || !draft.trim()}
-          onClick={() => onCommit(draft)}
-        >
-          Save
-        </button>
-      </div>
-      <p className="multiplayerPanel__nameplateHint">Shown on the table and score card. Does not change your seat.</p>
+      <input
+        id={inputId}
+        className="multiplayerPanel__nameplateInlineInput"
+        type="text"
+        maxLength={40}
+        autoComplete="nickname"
+        value={draft}
+        disabled={disabled}
+        aria-label={`Table display name, seat ${seat}`}
+        onChange={(e) => setDraft(e.target.value)}
+      />
+      <button
+        type="button"
+        className="multiplayerPanel__nameplateInlineSave"
+        disabled={disabled || !draft.trim()}
+        title={NAMEPLATE_HINT}
+        onClick={() => onCommit(draft)}
+      >
+        Save
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Makes the multiplayer **table display name** editor a single inline row instead of a separate block.

## Changes

- **Host (compact):** The first hosting row is split: left shows hosting + room code; the right **tail** clusters `Name` + input + `Save` with **Close room**.
- **Client (compact):** Same pattern: joined / signaling line on the left; **Name** + input + **Save** grouped with **Leave room** on the right (one visual row when space allows; wraps on narrow widths).
- Long hint text moved to `title` on the inline container and Save button (no extra paragraph).
