### PR TITLE
docs+ui: multiplayer toolbar styling and shell design doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ This document summarizes how the **card-game** repository is structured, how gam
 | `src/ui/GameHouseRulesPanel.tsx` | Per-game toggles/inputs saved to **`houseRules`** storage. |
 | `src/ui/CardView.tsx` | Card face/back, Skyjo tiers, standard ranks/suits. |
 | `docs/*.md` | Longer **repo documentation** per game (can diverge slightly from modal text). |
+| `docs/ui-design.md` | **Shell UI**: header toolbar button classes (`app__btn*`), multiplayer compact row layout (`multiplayerPanel__compact*` in `App.css`). |
 | `README.md` | User-facing run instructions and game table linking to `docs/`. |
 
 ---
@@ -253,7 +254,7 @@ Client-side entry points:
 | `src/net/peer.ts` | `RTCPeerConnection` + DataChannel wrapper. |
 | `src/net/host.ts` | `RoomHost` — accepts clients, assigns seats, broadcasts snapshots. |
 | `src/net/client.ts` | `RoomClient` — dials host, consumes snapshots, sends intents. |
-| `src/ui/MultiplayerPanel.tsx` | Lobby UI (Host / Join / roster / status). |
+| `src/ui/MultiplayerPanel.tsx` | Lobby UI (Host / Join / roster / status); chrome per **`docs/ui-design.md`**. |
 | `src/session/playerConfig.ts` | `remoteHumanCount`, `gameSupportsOnlineMultiplayer`, `manifestWithPlayerCounts`. |
 
 Backend entry points live in `lambda/src/` (`http.ts`, `websocket.ts`,
@@ -317,3 +318,4 @@ Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for 
 - **Never** edit unrelated games when fixing one title unless shared core behavior requires it.
 - After behavior changes, update **`src/rules/*.md`** (and **`AGENTS.md`** / **`README`** if the architecture list changes).
 - **`playerIndex` 0** is the **human** in the shell; AI seats are **1…N**.
+- For **header toolbar**, **Rules** modal actions, and **multiplayer** shell controls, follow **`docs/ui-design.md`** and reuse **`app__btnSecondary app__btnToolbar`** from **`src/App.css`** unless there is a strong reason not to.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Pick a game from the in-app **Game** menu. Each row links to a short note in [`d
 | [`src/data/manifests.ts`](src/data/manifests.ts) | Wires game and deck ids to bundled YAML. |
 | [`src/rules/`](src/rules/) | In-app rules copy (markdown) shown in the **Rules** modal; see [`src/data/rulesSources.ts`](src/data/rulesSources.ts). |
 | [`docs/`](docs/) | Longer per-game notes (repo docs; can diverge slightly from the modal text). |
+| [`docs/ui-design.md`](docs/ui-design.md) | Shared shell UI (toolbar buttons, online multiplayer strip layout). |
 
 ## Contributing
 

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -1,0 +1,53 @@
+# Shell UI design
+
+Conventions for the **app chrome** around the table: header toolbar, dialogs that reuse shell styles, and the **Online play** (`MultiplayerPanel`) block. Implementation lives primarily in [`src/App.css`](../src/App.css); the shell is [`src/App.tsx`](../src/App.tsx).
+
+## Toolbar buttons (header)
+
+Secondary actions in the header (e.g. **Rules**, **New deal**, **End game**, AI difficulty controls) use:
+
+- `app__btnSecondary` — base secondary button (border, transparent fill, theme text color).
+- `app__btnToolbar` — toolbar sizing: `min-height: 2.25rem`, slightly tighter horizontal padding than the default `app__btnSecondary` alone.
+
+**Pattern:** combine both classes on `<button>` elements:
+
+```html
+<button type="button" class="app__btnSecondary app__btnToolbar">Rules</button>
+```
+
+Primary actions use `app__btnPrimary` (e.g. **Next round**).
+
+Theme tokens used by buttons and inputs: `var(--border)`, `var(--bg)`, `var(--text-h)`, `var(--accent-bg)` / `var(--accent-border)` where applicable (see `index.css` for root definitions).
+
+## Multiplayer panel — compact row (table active)
+
+When a deal is on the table, host and client see a **compact** strip inside `.multiplayerPanel__compact`.
+
+**Layout**
+
+- Row: `.multiplayerPanel__compactRow.multiplayerPanel__compactRow--split`
+- **Lead** (left): `.multiplayerPanel__compactLead` — hosting/joined copy and room code (`flex: 1 1 …`, grows, truncates).
+- **Tail** (right): `.multiplayerPanel__compactTail` — inline name editor (`Name` + input + **Save**) and **Close room** / **Leave room**.
+- The tail uses **`margin-left: auto`** so the name + actions stay **right-aligned** on the row (and align to the end of the line when the row wraps on narrow widths).
+
+**Buttons**
+
+All actions in this strip (including **Save** on the name field) use **`app__btnSecondary app__btnToolbar`** so they match the header toolbar.
+
+**Name field**
+
+The inline display-name input uses theme-aligned borders/background (`--border`, `--bg`, `--text-h`) and `min-height: 2.25rem` to line up visually with toolbar buttons. Classes: `.multiplayerPanel__nameplateInline*` in `App.css`.
+
+## Multiplayer — lobby (no table yet)
+
+**Host game** and **Join** submit use the same **`app__btnSecondary app__btnToolbar`** pair for consistency with the header.
+
+## Expanded hosting / client (room open, no table)
+
+**Close room** / **Leave room** in the non-compact blocks also use **`app__btnSecondary app__btnToolbar`**.
+
+## When you change something
+
+1. Prefer reusing **`app__btnSecondary` + `app__btnToolbar`** for new shell-adjacent buttons instead of one-off panel button styles.
+2. If you add another “lead + actions” row, mirror **`.multiplayerPanel__compactRow--split`** / **`.multiplayerPanel__compactTail`** (`margin-left: auto`) so actions stay right-aligned.
+3. Update this doc when introducing new shared patterns or tokens.

--- a/src/App.css
+++ b/src/App.css
@@ -699,7 +699,7 @@
 
 .multiplayerPanel__compactRow--split {
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.35rem 0.5rem;
 }
 
@@ -708,17 +708,19 @@
   min-width: 0;
 }
 
+/* Right-align name + actions with host; margin-left: auto pins tail when row wraps too */
 .multiplayerPanel__compactTail {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   gap: 0.35rem 0.5rem;
-  flex: 1 1 10rem;
+  flex: 0 1 auto;
   min-width: 0;
+  margin-left: auto;
 }
 
-.multiplayerPanel__compact button {
+.multiplayerPanel__compact .app__btnToolbar {
   flex: 0 0 auto;
 }
 
@@ -758,20 +760,15 @@
   min-width: 4.5rem;
   max-width: 12rem;
   flex: 1 1 6rem;
-  padding: 0.2rem 0.4rem;
-  border-radius: 0.3rem;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  background: rgba(0, 0, 0, 0.22);
-  color: inherit;
+  box-sizing: border-box;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--border, #2e303a);
+  background: var(--bg, #16171d);
+  color: var(--text-h, #f3f4f6);
+  font: inherit;
   font-size: 0.82rem;
-}
-
-.multiplayerPanel__nameplateInlineSave {
-  flex-shrink: 0;
-  padding: 0.2rem 0.45rem;
-  border-radius: 0.3rem;
-  cursor: pointer;
-  font-size: 0.8rem;
 }
 
 fieldset.app__houseRules {

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -189,7 +189,7 @@ export function MultiplayerPanel({
 
       {!showCompact && mode === 'idle' && (
         <div className="multiplayerPanel__controls">
-          <button type="button" onClick={startHost}>
+          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={startHost}>
             Host game
           </button>
           <form
@@ -210,7 +210,9 @@ export function MultiplayerPanel({
               onChange={(e) => setJoinCodeInput(e.target.value.toUpperCase())}
               placeholder="ABC234"
             />
-            <button type="submit">Join</button>
+            <button type="submit" className="app__btnSecondary app__btnToolbar">
+              Join
+            </button>
           </form>
         </div>
       )}
@@ -231,7 +233,7 @@ export function MultiplayerPanel({
                   onCommit={nameplate.onCommit}
                 />
               )}
-              <button type="button" onClick={() => teardown()}>
+              <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
                 Close room
               </button>
             </div>
@@ -267,7 +269,7 @@ export function MultiplayerPanel({
                   onCommit={nameplate.onCommit}
                 />
               )}
-              <button type="button" onClick={() => teardown()}>
+              <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
                 Leave room
               </button>
             </div>
@@ -284,7 +286,7 @@ export function MultiplayerPanel({
             Signaling: <em>{signalingState}</em>
           </p>
           <ConnectedPeers roster={roster} />
-          <button type="button" onClick={() => teardown()}>
+          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
             Close room
           </button>
         </div>
@@ -298,7 +300,7 @@ export function MultiplayerPanel({
           <p>
             Signaling: <em>{signalingState}</em> · Peer: <em>{peerState}</em>
           </p>
-          <button type="button" onClick={() => teardown()}>
+          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
             Leave room
           </button>
         </div>
@@ -347,7 +349,7 @@ function NameplateInline({
       />
       <button
         type="button"
-        className="multiplayerPanel__nameplateInlineSave"
+        className="app__btnSecondary app__btnToolbar"
         disabled={disabled || !draft.trim()}
         title={NAMEPLATE_HINT}
         onClick={() => onCommit(draft)}


### PR DESCRIPTION
## Summary

Right-aligns the multiplayer **compact** action cluster (name + Save + room button) for parity with the host row, styles all multiplayer shell buttons like the **header toolbar** (`app__btnSecondary` + `app__btnToolbar`), and documents the pattern.

## Code

- **`App.css`:** `compactTail` uses `margin-left: auto` and `flex: 0 1 auto` so the tail stays on the right; name input uses theme tokens and `min-height` aligned to toolbar buttons; remove bespoke Save button rules (toolbar classes handle it).
- **`MultiplayerPanel.tsx`:** Host game, Join, Close/Leave room, and inline Save use **`app__btnSecondary app__btnToolbar`**.

## Docs

- New **`docs/ui-design.md`** — shell UI conventions (toolbar buttons, multiplayer compact layout).
- **`AGENTS.md`** — repository table row + agent convention bullet linking to the design doc.
- **`README.md`** — overview table links to `docs/ui-design.md`.
