### PR TITLE
feat(net): multiplayer room chat (popout + PROTOCOL v3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,7 @@ Client-side entry points:
 | `src/net/peer.ts` | `RTCPeerConnection` + DataChannel wrapper. |
 | `src/net/host.ts` | `RoomHost` — accepts clients, assigns seats, broadcasts snapshots. |
 | `src/net/client.ts` | `RoomClient` — dials host, consumes snapshots, sends intents. |
-| `src/ui/MultiplayerPanel.tsx` | Lobby UI (Host / Join / roster / status); chrome per **`docs/ui-design.md`**. |
+| `src/ui/MultiplayerPanel.tsx` | Lobby UI (Host / Join / roster / status, **Open chat**); chrome per **`docs/ui-design.md`**; room chat details in **`docs/multiplayer-chat.md`**. |
 | `src/session/playerConfig.ts` | `remoteHumanCount`, `gameSupportsOnlineMultiplayer`, `manifestWithPlayerCounts`. |
 
 Backend entry points live in `lambda/src/` (`http.ts`, `websocket.ts`,

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Then open the URL Vite prints (usually `http://localhost:5173`).
 
 After you have deployed once, copy the **HTTP API** and **WebSocket API** URLs from the GitHub **Deploy** workflow summary (or run `terraform output -raw http_api_url` / `ws_api_url` under `deploy/terraform/aws`). Create `.env.local` from [`.env.example`](.env.example) and set `VITE_MULTIPLAYER_HTTP_URL` and `VITE_MULTIPLAYER_WS_URL`, then restart `npm run dev`.
 
+In a live room, use **Open chat** in the **Online play** strip for [ephemeral room chat](docs/multiplayer-chat.md) (second window + toasts when the window is closed).
+
 Choosing another entry in the **Game** menu updates the selection only; press **Start deal** (or **New deal** when a hand is already on the table) to shuffle and play.
 
 Use **Rules** (next to **End game**) to open a modal with the in-app rules for the **currently selected** game (you can read them before **Start deal**).
@@ -83,6 +85,7 @@ Pick a game from the in-app **Game** menu. Each row links to a short note in [`d
 | [`src/rules/`](src/rules/) | In-app rules copy (markdown) shown in the **Rules** modal; see [`src/data/rulesSources.ts`](src/data/rulesSources.ts). |
 | [`docs/`](docs/) | Longer per-game notes (repo docs; can diverge slightly from the modal text). |
 | [`docs/ui-design.md`](docs/ui-design.md) | Shared shell UI (toolbar buttons, online multiplayer strip layout). |
+| [`docs/multiplayer-chat.md`](docs/multiplayer-chat.md) | Room chat (DataChannel + chat popout + toasts). |
 
 ## Contributing
 

--- a/chat-popout.html
+++ b/chat-popout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Room chat</title>
+  </head>
+  <body>
+    <div id="chat-popout-root"></div>
+    <script type="module" src="/src/chat-popout/main.tsx"></script>
+  </body>
+</html>

--- a/docs/multiplayer-chat.md
+++ b/docs/multiplayer-chat.md
@@ -1,0 +1,47 @@
+# Online room chat
+
+When **online multiplayer** is enabled in the build, hosts and joined clients can use **in-room text chat** alongside the table. Chat is **ephemeral**: the host keeps messages in memory only for the life of the WebRTC session; nothing is written to the signaling server or DynamoDB.
+
+## How to use it
+
+1. **Host a room** or **join** with a room code (same flow as normal online play).
+2. Click **Open chat**. The browser opens a **second window** with a short transcript and a composer.
+3. Type a message and press **Send** or **Enter**. Everyone in the room sees the line (after the host validates it).
+
+If the chat window is **closed**, new messages still appear as **toasts** in the bottom-right of the **main** game window (up to **five** at a time, each for about **three seconds**). While the chat popout is **open**, toasts appear **only** in that window so you do not get duplicates.
+
+## Names and limits
+
+- The sender label is the same **seat display name** used on the table (from seat profiles / defaults). Renaming via the inline **Name** field in the multiplayer strip updates future chat lines after you save.
+- Message bodies are trimmed, control characters removed, and capped at **140** characters (`sanitizeChatText` in `src/net/protocol.ts`).
+- The host applies a simple **rate limit** (per seat) so a buggy client cannot flood the channel.
+
+## Wire protocol
+
+Chat reuses the existing **game** DataChannel between host and clients:
+
+- **Client → host:** `PeerClientChatSend` (`type: 'chatSend'`, `seat`, `text`).
+- **Host → all clients:** `PeerHostChatLine` (`type: 'chatLine'`, `id`, `seat`, `senderLabel`, `text`, `ts`).
+
+These types are part of the `PeerMessage` union in `src/net/protocol.ts`. A protocol bump ships with the feature (`PROTOCOL_VERSION`).
+
+## Popout window and `postMessage`
+
+The chat UI is a **separate Vite HTML entry** (`chat-popout.html` → `src/chat-popout/main.tsx`). The main app and the popout exchange messages with a shared `source` tag (`CHAT_POPOUT_MESSAGE_SOURCE` in `src/chat/chatPopoutMessages.ts`):
+
+- **Popout → main:** `chat-popout-ready` (main responds with a full `chat-sync`), `chat-outgoing` (user sent text).
+- **Main → popout:** `chat-sync` (initial history), `chat-line` (one new line).
+
+**Do not** open the chat window with `noopener`, or `window.opener` may be null and the popout cannot receive history or send messages. Popup blockers may return `null` from `window.open`; the multiplayer strip shows a short error in that case.
+
+## Code map
+
+| Area | Files |
+|------|--------|
+| Types + sanitization | `src/net/protocol.ts` |
+| Host broadcast / client receive | `src/net/host.ts`, `src/net/client.ts` |
+| Main app state, popout bridge, toasts | `src/App.tsx`, `src/chat/useChatToasts.ts`, `src/ui/ChatToastStack.tsx` |
+| Open URL / window name | `src/ui/openChatPopout.ts` |
+| Popout UI | `chat-popout.html`, `src/chat-popout/main.tsx`, `src/chat-popout/chat-popout.css` |
+| Build (second page) | `vite.config.ts` |
+| Shell controls | `src/ui/MultiplayerPanel.tsx`, `src/App.css`, `docs/ui-design.md` |

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -27,7 +27,7 @@ When a deal is on the table, host and client see a **compact** strip inside `.mu
 
 - Row: `.multiplayerPanel__compactRow.multiplayerPanel__compactRow--split`
 - **Lead** (left): `.multiplayerPanel__compactLead` — hosting/joined copy and room code (`flex: 1 1 …`, grows, truncates).
-- **Tail** (right): `.multiplayerPanel__compactTail` — inline name editor (`Name` + input + **Save**) and **Close room** / **Leave room**.
+- **Tail** (right): `.multiplayerPanel__compactTail` — inline name editor (`Name` + input + **Save**), **Open chat**, and **Close room** / **Leave room**.
 - The tail uses **`margin-left: auto`** so the name + actions stay **right-aligned** on the row (and align to the end of the line when the row wraps on narrow widths).
 
 **Buttons**
@@ -45,6 +45,8 @@ The inline display-name input uses theme-aligned borders/background (`--border`,
 ## Expanded hosting / client (room open, no table)
 
 **Close room** / **Leave room** in the non-compact blocks also use **`app__btnSecondary app__btnToolbar`**.
+
+**Open chat** (compact and expanded multiplayer rows) uses the same button classes. It stays disabled for a joined client until a table snapshot assigns a seat. Behavior of the chat window and main-window toasts is documented in [`multiplayer-chat.md`](multiplayer-chat.md).
 
 ## When you change something
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,4 +33,11 @@ export default defineConfig([
       'react-hooks/set-state-in-effect': 'off',
     },
   },
+  {
+    files: ['src/chat-popout/**/*.tsx'],
+    rules: {
+      // Second Vite entry: mount-only file, not a hot-reload component module.
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/src/App.css
+++ b/src/App.css
@@ -777,3 +777,52 @@ fieldset.app__houseRules {
   border: none;
   min-width: 0;
 }
+
+/* Room chat toasts on main window (when chat popout is closed) */
+.chatToastStack--mainApp {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(360px, calc(100vw - 24px));
+  z-index: 10050;
+  pointer-events: none;
+}
+
+.chatToastStack__item {
+  pointer-events: auto;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, #2e303a);
+  background: rgba(22, 23, 29, 0.96);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.chatToastStack__sender {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent-bg, #6b9fff);
+  margin-bottom: 0.15rem;
+}
+
+.chatToastStack__text {
+  font-size: 0.85rem;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.multiplayerPanel__chatFail {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: #f87171;
+}
+
+.multiplayerPanel__hostingActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.5rem;
+  align-items: center;
+  margin-top: 0.35rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,16 +19,23 @@ import {
   normalizeAiDifficultiesForCount,
 } from './session/playerConfig'
 import { GameHouseRulesPanel } from './ui/GameHouseRulesPanel'
+import { CHAT_POPOUT_MESSAGE_SOURCE, isChatPopoutToMain, type MainToChatPopout } from './chat/chatPopoutMessages'
+import { useChatToasts } from './chat/useChatToasts'
 import type { RoomClient } from './net/client'
 import type { HostedPeer, RoomHost } from './net/host'
 import {
+  sanitizeChatText,
   sanitizeDisplayName,
+  type PeerClientChatSend,
   type PeerClientIntent,
   type PeerClientSetDisplayName,
+  type PeerHostChatLine,
   type PeerHostSnapshot,
 } from './net/protocol'
 import { parseSessionSnapshot, serializeSessionSnapshot } from './net/sessionSnapshot'
+import { ChatToastStack } from './ui/ChatToastStack'
 import { MultiplayerPanel } from './ui/MultiplayerPanel'
+import { openChatPopoutWindow } from './ui/openChatPopout'
 import { RulesModal } from './ui/RulesModal'
 import { TableView, type ActiveTurnHighlight, type TableIntent } from './ui/TableView'
 import { skyjoDumpUiStepShouldReset, type SkyjoDumpUiStep } from './ui/tableUiFlow'
@@ -70,6 +77,32 @@ function localViewerSeat(session: GameSession | null): number | null {
   if (!session?.net) return 0
   if (session.net.spectator) return null
   return session.net.seat
+}
+
+/** Display label for a seat in room chat (mirrors in-app seat labels; pure helper for host callbacks). */
+function chatSenderLabelForSeat(sess: GameSession | null, roster: HostedPeer[], serverPlayerIndex: number): string {
+  if (!sess) return `Player ${serverPlayerIndex + 1}`
+  const profileLabel = sess.seatProfiles?.find((s) => s.seat === serverPlayerIndex)?.displayName?.trim()
+  if (profileLabel) return profileLabel
+  const humanCount = sess.manifest.players.human
+  if (serverPlayerIndex >= humanCount) {
+    return aiPlayerMenuLabel(serverPlayerIndex - humanCount)
+  }
+  if (sess.net && !sess.net.spectator) {
+    if (serverPlayerIndex === 0) return 'Host'
+    return `Player ${serverPlayerIndex + 1}`
+  }
+  if (!sess.net) {
+    if (serverPlayerIndex === 0) return 'Host'
+    const peer = roster.find((r) => r.seat === serverPlayerIndex)
+    if (peer) {
+      const id = peer.peerId
+      return id.length > 16 ? `${id.slice(0, 15)}…` : id
+    }
+    return `Player ${serverPlayerIndex + 1}`
+  }
+  if (serverPlayerIndex === 0) return 'Host'
+  return `Player ${serverPlayerIndex + 1}`
 }
 
 function MatchCumulativePanel({
@@ -315,10 +348,29 @@ function App() {
   /** True while this browser is an active room host (not ref-driven — avoids reading refs during render). */
   const [multiplayerHostActive, setMultiplayerHostActive] = useState(false)
 
+  const [chatLines, setChatLines] = useState<PeerHostChatLine[]>([])
+  const [chatOpenFailed, setChatOpenFailed] = useState('')
+  const chatLinesRef = useRef<PeerHostChatLine[]>([])
+  const rosterRef = useRef<HostedPeer[]>([])
+  const chatPopoutRef = useRef<Window | null>(null)
+  const chatRateLimitRef = useRef<Map<number, number[]>>(new Map())
+  const { toasts: mainChatToasts, pushToast: pushMainChatToast, clearToasts: clearMainChatToasts } =
+    useChatToasts(5, 3000)
+
+  useEffect(() => {
+    chatLinesRef.current = chatLines
+  }, [chatLines])
+
+  useEffect(() => {
+    rosterRef.current = hostClientRoster
+  }, [hostClientRoster])
+
   const selectedManifest = useMemo(() => parseGameManifestYaml(GAME_SOURCES[gameId]), [gameId])
 
   const onlineClientShell = joinedAsClient || !!session?.net
   const networkSpectator = !!session?.net?.spectator
+  const multiplayerChatEnabled =
+    multiplayerHostActive || (!!session?.net && !session.net.spectator && joinedAsClient)
 
   const seatDisplayName = useCallback(
     (serverPlayerIndex: number): string => {
@@ -554,6 +606,145 @@ function App() {
     })
   }, [])
 
+  const deliverChatLineToUi = useCallback(
+    (line: PeerHostChatLine) => {
+      setChatLines((prev) => [...prev, line].slice(-200))
+      const w = chatPopoutRef.current
+      if (w && !w.closed) {
+        const payload: MainToChatPopout = {
+          source: CHAT_POPOUT_MESSAGE_SOURCE,
+          type: 'chat-line',
+          line,
+        }
+        w.postMessage(payload, window.location.origin)
+      } else {
+        pushMainChatToast({ id: line.id, senderLabel: line.senderLabel, text: line.text })
+      }
+    },
+    [pushMainChatToast],
+  )
+
+  const broadcastChatLineFromHost = useCallback(
+    (line: PeerHostChatLine) => {
+      roomHostRef.current?.broadcastChatLine(line)
+      deliverChatLineToUi(line)
+    },
+    [deliverChatLineToUi],
+  )
+
+  const onRemoteChatSend = useCallback(
+    (msg: PeerClientChatSend, fromPeerId: string) => {
+      const host = roomHostRef.current
+      if (!host) return
+      const roster = host.getRoster()
+      const rec = roster.find((r) => r.peerId === fromPeerId)
+      if (!rec || rec.seat !== msg.seat) return
+      const text = sanitizeChatText(msg.text)
+      if (!text) return
+      const now = Date.now()
+      const windowMs = 10_000
+      const max = 10
+      const arr = chatRateLimitRef.current.get(msg.seat) ?? []
+      const recent = arr.filter((t) => now - t < windowMs)
+      if (recent.length >= max) return
+      recent.push(now)
+      chatRateLimitRef.current.set(msg.seat, recent)
+      const sess = sessionRef.current
+      const senderLabel = chatSenderLabelForSeat(sess, rosterRef.current, msg.seat)
+      const line: PeerHostChatLine = {
+        type: 'chatLine',
+        id: crypto.randomUUID(),
+        seat: msg.seat,
+        senderLabel,
+        text,
+        ts: Date.now(),
+      }
+      broadcastChatLineFromHost(line)
+    },
+    [broadcastChatLineFromHost],
+  )
+
+  const onRoomChatLine = useCallback(
+    (line: PeerHostChatLine) => {
+      deliverChatLineToUi(line)
+    },
+    [deliverChatLineToUi],
+  )
+
+  const sendLocalRoomChat = useCallback(
+    (rawText: string) => {
+      const text = sanitizeChatText(rawText)
+      if (!text) return
+      const sess = sessionRef.current
+      const client = roomClientRef.current
+      if (client) {
+        if (!sess?.net || sess.net.spectator) return
+        client.sendChat({ seat: sess.net.seat, text })
+        return
+      }
+      const host = roomHostRef.current
+      if (!host) return
+      const hostSeat = 0
+      const now = Date.now()
+      const windowMs = 10_000
+      const max = 10
+      const arr = chatRateLimitRef.current.get(hostSeat) ?? []
+      const recent = arr.filter((t) => now - t < windowMs)
+      if (recent.length >= max) return
+      recent.push(now)
+      chatRateLimitRef.current.set(hostSeat, recent)
+      const senderLabel = chatSenderLabelForSeat(sess, rosterRef.current, hostSeat)
+      const line: PeerHostChatLine = {
+        type: 'chatLine',
+        id: crypto.randomUUID(),
+        seat: hostSeat,
+        senderLabel,
+        text,
+        ts: Date.now(),
+      }
+      broadcastChatLineFromHost(line)
+    },
+    [broadcastChatLineFromHost],
+  )
+
+  const handleOpenChat = useCallback(() => {
+    setChatOpenFailed('')
+    const w = openChatPopoutWindow()
+    if (!w) {
+      setChatOpenFailed(
+        'Could not open chat (popup blocked?). Allow pop-ups for this site from the address bar and try again.',
+      )
+      return
+    }
+    chatPopoutRef.current = w
+    clearMainChatToasts()
+  }, [clearMainChatToasts])
+
+  useEffect(() => {
+    const onMsg = (ev: MessageEvent) => {
+      if (ev.origin !== window.location.origin) return
+      if (!isChatPopoutToMain(ev.data)) return
+      if (ev.data.type === 'chat-popout-ready') {
+        const w = ev.source as Window | null
+        if (!w || w === window || w !== chatPopoutRef.current || w.closed) return
+        const sync: MainToChatPopout = {
+          source: CHAT_POPOUT_MESSAGE_SOURCE,
+          type: 'chat-sync',
+          lines: chatLinesRef.current,
+        }
+        w.postMessage(sync, window.location.origin)
+        return
+      }
+      if (ev.data.type === 'chat-outgoing') {
+        const w = ev.source as Window | null
+        if (!w || w !== chatPopoutRef.current) return
+        sendLocalRoomChat(ev.data.text)
+      }
+    }
+    window.addEventListener('message', onMsg)
+    return () => window.removeEventListener('message', onMsg)
+  }, [sendLocalRoomChat])
+
   const onMultiplayerTeardown = useCallback((_wasHost: boolean) => {
     roomHostRef.current = null
     roomClientRef.current = null
@@ -564,7 +755,18 @@ function App() {
     setGfAwaitingOpponent(false)
     setGfRank('A')
     setSkyjoDumpStep('idle')
-  }, [])
+    setChatLines([])
+    setChatOpenFailed('')
+    chatRateLimitRef.current.clear()
+    clearMainChatToasts()
+    try {
+      const w = chatPopoutRef.current
+      if (w && !w.closed) w.close()
+    } catch {
+      // ignore
+    }
+    chatPopoutRef.current = null
+  }, [clearMainChatToasts])
 
   const onHostingRosterChange = useCallback((peers?: HostedPeer[]) => {
     if (peers) setHostClientRoster(peers)
@@ -1277,6 +1479,11 @@ function App() {
           onSessionSnapshot={onSessionSnapshot}
           onRemoteIntent={onRemoteIntent}
           onRemoteSetDisplayName={onRemoteSetDisplayName}
+          onRemoteChatSend={onRemoteChatSend}
+          onRoomChatLine={onRoomChatLine}
+          onOpenChat={handleOpenChat}
+          chatEnabled={multiplayerChatEnabled}
+          chatOpenFailed={chatOpenFailed}
           onHostingRosterChange={onHostingRosterChange}
           onTeardown={onMultiplayerTeardown}
           onPeerAck={onPeerAck}
@@ -1444,6 +1651,7 @@ function App() {
           />
         }
       />
+      <ChatToastStack toasts={mainChatToasts} className="chatToastStack--mainApp" />
     </div>
   )
 }

--- a/src/chat-popout/chat-popout.css
+++ b/src/chat-popout/chat-popout.css
@@ -1,0 +1,131 @@
+:root {
+  font-family: system-ui, Segoe UI, Roboto, sans-serif;
+  color: var(--text-h, #e8eaed);
+  background: var(--bg, #12141a);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.chatPopout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+.chatPopout__header {
+  flex: 0 0 auto;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--border, #2a2f3a);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.chatPopout__transcript {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.chatPopout__line {
+  margin-bottom: 0.45rem;
+  word-break: break-word;
+}
+
+.chatPopout__meta {
+  opacity: 0.85;
+  font-size: 0.8rem;
+  margin-bottom: 0.1rem;
+}
+
+.chatPopout__sender {
+  font-weight: 600;
+  color: var(--accent-bg, #6b9fff);
+}
+
+.chatPopout__composer {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem 0.65rem;
+  border-top: 1px solid var(--border, #2a2f3a);
+  align-items: center;
+}
+
+.chatPopout__send {
+  flex: 0 0 auto;
+  min-height: 2.25rem;
+  padding: 0 0.85rem;
+  border-radius: 6px;
+  border: 1px solid var(--border, #2a2f3a);
+  background: var(--accent-bg, #3d5a99);
+  color: #fff;
+  font: inherit;
+  cursor: pointer;
+}
+
+.chatPopout__send:hover {
+  filter: brightness(1.08);
+}
+
+.chatPopout__input {
+  flex: 1 1 auto;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border, #2a2f3a);
+  border-radius: 6px;
+  background: var(--bg, #12141a);
+  color: inherit;
+  font: inherit;
+}
+
+.chatPopout__hint {
+  font-size: 0.75rem;
+  opacity: 0.75;
+  padding: 0 0.75rem 0.5rem;
+}
+
+.chatPopout__blocked {
+  padding: 1rem 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.chatToastStack {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(360px, calc(100vw - 24px));
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.chatToastStack__item {
+  pointer-events: auto;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, #2a2f3a);
+  background: rgba(24, 28, 36, 0.96);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.chatToastStack__sender {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent-bg, #6b9fff);
+  margin-bottom: 0.15rem;
+}
+
+.chatToastStack__text {
+  font-size: 0.85rem;
+  line-height: 1.3;
+  word-break: break-word;
+}

--- a/src/chat-popout/main.tsx
+++ b/src/chat-popout/main.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import '../index.css'
+import type { PeerHostChatLine } from '../net/protocol'
+import {
+  CHAT_POPOUT_MESSAGE_SOURCE,
+  isMainToChatPopout,
+  type ChatPopoutToMain,
+} from '../chat/chatPopoutMessages'
+import { useChatToasts } from '../chat/useChatToasts'
+import { ChatToastStack } from '../ui/ChatToastStack'
+import './chat-popout.css'
+
+function ChatPopoutApp() {
+  const openerRef = useRef<Window | null>(null)
+  const [lines, setLines] = useState<PeerHostChatLine[]>([])
+  const [draft, setDraft] = useState('')
+  const [noOpener, setNoOpener] = useState(() => typeof window !== 'undefined' && !window.opener)
+  const { toasts, pushToast, clearToasts } = useChatToasts(5, 3000)
+
+  const postToOpener = useCallback((msg: ChatPopoutToMain) => {
+    const target = openerRef.current
+    if (!target || target.closed) return
+    target.postMessage(msg, window.location.origin)
+  }, [])
+
+  useEffect(() => {
+    const o = window.opener as Window | null
+    openerRef.current = o
+    if (!o) {
+      setNoOpener(true)
+      return
+    }
+    postToOpener({ source: CHAT_POPOUT_MESSAGE_SOURCE, type: 'chat-popout-ready' })
+  }, [postToOpener])
+
+  useEffect(() => {
+    const onMessage = (ev: MessageEvent) => {
+      if (ev.origin !== window.location.origin) return
+      if (!isMainToChatPopout(ev.data)) return
+      if (ev.data.type === 'chat-sync') {
+        setLines(ev.data.lines)
+        clearToasts()
+        return
+      }
+      const { line } = ev.data
+      setLines((prev) => [...prev, line].slice(-200))
+      pushToast({ id: line.id, senderLabel: line.senderLabel, text: line.text })
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [pushToast, clearToasts])
+
+  const send = useCallback(() => {
+    const t = draft.trim()
+    if (!t) return
+    postToOpener({ source: CHAT_POPOUT_MESSAGE_SOURCE, type: 'chat-outgoing', text: draft })
+    setDraft('')
+  }, [draft, postToOpener])
+
+  if (noOpener) {
+    return (
+      <div className="chatPopout">
+        <div className="chatPopout__header">Room chat</div>
+        <p className="chatPopout__blocked">
+          This page must be opened from the card table with <strong>Open chat</strong>. If you opened it manually,
+          close this tab and use the button in the main game window.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="chatPopout">
+      <div className="chatPopout__header">Room chat</div>
+      <div className="chatPopout__transcript" aria-label="Chat transcript">
+        {lines.length === 0 ? (
+          <p className="chatPopout__hint">No messages yet.</p>
+        ) : (
+          lines.map((l) => (
+            <div key={l.id} className="chatPopout__line">
+              <div className="chatPopout__meta">
+                <span className="chatPopout__sender">{l.senderLabel}</span>
+                <span> · </span>
+                <time dateTime={new Date(l.ts).toISOString()}>{new Date(l.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>
+              </div>
+              <div>{l.text}</div>
+            </div>
+          ))
+        )}
+      </div>
+      <div className="chatPopout__composer">
+        <input
+          className="chatPopout__input"
+          type="text"
+          maxLength={500}
+          placeholder="Message (max 140 after send)"
+          value={draft}
+          aria-label="Chat message"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              send()
+            }
+          }}
+        />
+        <button type="button" className="chatPopout__send" onClick={send}>
+          Send
+        </button>
+      </div>
+      <p className="chatPopout__hint">Messages are not stored on the server and disappear when the room closes.</p>
+      <ChatToastStack toasts={toasts} />
+    </div>
+  )
+}
+
+const el = document.getElementById('chat-popout-root')
+if (el) {
+  createRoot(el).render(<ChatPopoutApp />)
+}

--- a/src/chat/chatPopoutMessages.ts
+++ b/src/chat/chatPopoutMessages.ts
@@ -1,0 +1,37 @@
+import type { PeerHostChatLine } from '../net/protocol'
+
+/** `postMessage` envelope so unrelated origins/extensions are ignored safely. */
+export const CHAT_POPOUT_MESSAGE_SOURCE = 'card-game-room-chat' as const
+
+export type ChatPopoutToMain =
+  | { source: typeof CHAT_POPOUT_MESSAGE_SOURCE; type: 'chat-popout-ready' }
+  | { source: typeof CHAT_POPOUT_MESSAGE_SOURCE; type: 'chat-outgoing'; text: string }
+
+export type MainToChatPopout =
+  | { source: typeof CHAT_POPOUT_MESSAGE_SOURCE; type: 'chat-sync'; lines: PeerHostChatLine[] }
+  | { source: typeof CHAT_POPOUT_MESSAGE_SOURCE; type: 'chat-line'; line: PeerHostChatLine }
+
+export function isChatPopoutToMain(data: unknown): data is ChatPopoutToMain {
+  if (!data || typeof data !== 'object') return false
+  const o = data as { source?: unknown; type?: unknown }
+  if (o.source !== CHAT_POPOUT_MESSAGE_SOURCE) return false
+  if (o.type === 'chat-popout-ready') return true
+  if (o.type === 'chat-outgoing') {
+    return typeof (data as { text?: unknown }).text === 'string'
+  }
+  return false
+}
+
+export function isMainToChatPopout(data: unknown): data is MainToChatPopout {
+  if (!data || typeof data !== 'object') return false
+  const o = data as { source?: unknown; type?: unknown }
+  if (o.source !== CHAT_POPOUT_MESSAGE_SOURCE) return false
+  if (o.type === 'chat-sync') {
+    return Array.isArray((data as { lines?: unknown }).lines)
+  }
+  if (o.type === 'chat-line') {
+    const line = (data as { line?: unknown }).line
+    return !!line && typeof line === 'object' && (line as { type?: unknown }).type === 'chatLine'
+  }
+  return false
+}

--- a/src/chat/useChatToasts.ts
+++ b/src/chat/useChatToasts.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react'
+
+export interface ChatToastItem {
+  id: string
+  senderLabel: string
+  text: string
+}
+
+export function useChatToasts(maxVisible = 5, ttlMs = 3000) {
+  const [toasts, setToasts] = useState<ChatToastItem[]>([])
+
+  const pushToast = useCallback(
+    (item: ChatToastItem) => {
+      setToasts((prev) => [...prev, item].slice(-maxVisible))
+      window.setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== item.id))
+      }, ttlMs)
+    },
+    [maxVisible, ttlMs],
+  )
+
+  const clearToasts = useCallback(() => {
+    setToasts([])
+  }, [])
+
+  return { toasts, pushToast, clearToasts }
+}

--- a/src/net/client.ts
+++ b/src/net/client.ts
@@ -1,7 +1,9 @@
 import { PeerLink, type PeerState } from './peer'
 import {
+  type PeerClientChatSend,
   type PeerClientIntent,
   type PeerClientSetDisplayName,
+  type PeerHostChatLine,
   type PeerHostSnapshot,
   type PeerMessage,
   type SignalingRelay,
@@ -21,6 +23,8 @@ export interface RoomClientOptions {
   onAck?: (nonce: string, ok: boolean, error: string | undefined) => void
   /** Host closed the room or disconnected; stop signaling and data channel. */
   onHostEnded?: () => void
+  /** Host broadcast room chat line. */
+  onChatLine?: (line: PeerHostChatLine) => void
 }
 
 /**
@@ -84,6 +88,7 @@ export class RoomClient {
     if (msg.type === 'snapshot') this.opts.onSnapshot?.(msg)
     else if (msg.type === 'status') this.opts.onStatus?.(msg.message)
     else if (msg.type === 'ack') this.opts.onAck?.(msg.nonce, msg.ok, msg.error)
+    else if (msg.type === 'chatLine') this.opts.onChatLine?.(msg)
   }
 
   sendIntent(intent: Omit<PeerClientIntent, 'type'>): void {
@@ -92,6 +97,10 @@ export class RoomClient {
 
   sendSetDisplayName(body: Omit<PeerClientSetDisplayName, 'type'>): void {
     this.link?.send({ type: 'setDisplayName', ...body })
+  }
+
+  sendChat(body: Omit<PeerClientChatSend, 'type'>): void {
+    this.link?.send({ type: 'chatSend', ...body })
   }
 
   close(): void {

--- a/src/net/host.ts
+++ b/src/net/host.ts
@@ -1,8 +1,10 @@
 import { PeerLink, type PeerState } from './peer'
 import {
   PROTOCOL_VERSION,
+  type PeerClientChatSend,
   type PeerClientIntent,
   type PeerClientSetDisplayName,
+  type PeerHostChatLine,
   type PeerHostSnapshot,
   type PeerMessage,
   type SignalingRelay,
@@ -22,8 +24,11 @@ export interface RoomHostOptions {
   token: string
   onRosterChange?: (peers: HostedPeer[]) => void
   onSignalingState?: (state: SignalingState) => void
-  /** Game intents and auxiliary seat updates from clients. */
-  onIntent?: (msg: PeerClientIntent | PeerClientSetDisplayName, fromPeerId: string) => void
+  /** Game intents, seat labels, and room chat from clients. */
+  onIntent?: (
+    msg: PeerClientIntent | PeerClientSetDisplayName | PeerClientChatSend,
+    fromPeerId: string,
+  ) => void
 }
 
 interface HostPeerRecord {
@@ -121,7 +126,7 @@ export class RoomHost {
   }
 
   private handlePeerMessage(msg: PeerMessage, fromPeerId: string) {
-    if (msg.type === 'intent' || msg.type === 'setDisplayName') {
+    if (msg.type === 'intent' || msg.type === 'setDisplayName' || msg.type === 'chatSend') {
       this.opts.onIntent?.(msg, fromPeerId)
     } else if (msg.type === 'ping') {
       const rec = this.peers.get(fromPeerId)
@@ -154,6 +159,13 @@ export class RoomHost {
   status(message: string): void {
     for (const rec of this.peers.values()) {
       rec.link.send({ type: 'status', message })
+    }
+  }
+
+  /** Broadcast one chat line to every connected client (host UI adds the line locally). */
+  broadcastChatLine(line: PeerHostChatLine): void {
+    for (const rec of this.peers.values()) {
+      rec.link.send(line)
     }
   }
 

--- a/src/net/protocol.test.ts
+++ b/src/net/protocol.test.ts
@@ -6,6 +6,7 @@ import {
   isRoomCode,
   isSignalingMessage,
   isPeerMessage,
+  sanitizeChatText,
   sanitizeDisplayName,
 } from './protocol'
 import { mulberry32 } from '../core/shuffle'
@@ -28,6 +29,20 @@ describe('room codes', () => {
     expect(isRoomCode('ABCDE1')).toBe(false)
     expect(isRoomCode('abcdef')).toBe(false)
     expect(isRoomCode(123 as unknown)).toBe(false)
+  })
+})
+
+describe('sanitizeChatText', () => {
+  it('trims, strips controls, caps at 140', () => {
+    expect(sanitizeChatText('  hi  ')).toBe('hi')
+    expect(sanitizeChatText('a'.repeat(200))!.length).toBe(140)
+    expect(sanitizeChatText('\x01visible')).toBe('visible')
+  })
+
+  it('rejects empty', () => {
+    expect(sanitizeChatText('')).toBeNull()
+    expect(sanitizeChatText('   ')).toBeNull()
+    expect(sanitizeChatText(1 as unknown)).toBeNull()
   })
 })
 
@@ -56,6 +71,8 @@ describe('message type guards', () => {
     expect(isPeerMessage({ type: 'snapshot' })).toBe(true)
     expect(isPeerMessage({ type: 'intent' })).toBe(true)
     expect(isPeerMessage({ type: 'setDisplayName' })).toBe(true)
+    expect(isPeerMessage({ type: 'chatSend' })).toBe(true)
+    expect(isPeerMessage({ type: 'chatLine' })).toBe(true)
     expect(isPeerMessage({ type: 'nope' })).toBe(false)
   })
 })

--- a/src/net/protocol.ts
+++ b/src/net/protocol.ts
@@ -8,7 +8,7 @@
  * host sends back. Incrementing {@link PROTOCOL_VERSION} is a breaking change.
  */
 
-export const PROTOCOL_VERSION = 2
+export const PROTOCOL_VERSION = 3
 
 /** Room codes are 6 uppercase alphanumeric chars, ambiguous glyphs dropped. */
 export const ROOM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
@@ -147,6 +147,38 @@ export interface PeerClientSetDisplayName {
   displayName: string
 }
 
+/** Host → all peers: one room chat line (in-memory; not persisted server-side). */
+export interface PeerHostChatLine {
+  type: 'chatLine'
+  id: string
+  seat: number
+  senderLabel: string
+  text: string
+  ts: number
+}
+
+/** Client → host: send a chat message from a human seat. */
+export interface PeerClientChatSend {
+  type: 'chatSend'
+  seat: number
+  text: string
+}
+
+/** Room chat body; max 140 chars after trim / control strip. */
+export function sanitizeChatText(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const t = raw
+    .trim()
+    .split('')
+    .filter((ch) => {
+      const c = ch.charCodeAt(0)
+      return c >= 32 && c !== 127
+    })
+    .join('')
+    .slice(0, 140)
+  return t.length ? t : null
+}
+
 /** Single-line display name for UI; returns null if empty after trim / invalid type. */
 export function sanitizeDisplayName(raw: unknown): string | null {
   if (typeof raw !== 'string') return null
@@ -177,8 +209,10 @@ export type PeerMessage =
   | PeerHostSnapshot
   | PeerHostAck
   | PeerHostStatus
+  | PeerHostChatLine
   | PeerClientIntent
   | PeerClientSetDisplayName
+  | PeerClientChatSend
   | PeerClientPing
   | PeerHostPong
 
@@ -206,6 +240,8 @@ export function isPeerMessage(value: unknown): value is PeerMessage {
     t === 'status' ||
     t === 'intent' ||
     t === 'setDisplayName' ||
+    t === 'chatSend' ||
+    t === 'chatLine' ||
     t === 'ping' ||
     t === 'pong'
   )

--- a/src/ui/ChatToastStack.tsx
+++ b/src/ui/ChatToastStack.tsx
@@ -1,0 +1,15 @@
+import type { ChatToastItem } from '../chat/useChatToasts'
+
+export function ChatToastStack({ toasts, className = '' }: { toasts: ChatToastItem[]; className?: string }) {
+  if (toasts.length === 0) return null
+  return (
+    <div className={`chatToastStack ${className}`.trim()} role="log" aria-live="polite" aria-relevant="additions">
+      {toasts.map((t) => (
+        <div key={t.id} className="chatToastStack__item">
+          <div className="chatToastStack__sender">{t.senderLabel}</div>
+          <div className="chatToastStack__text">{t.text}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -3,7 +3,14 @@ import { createRoom, joinRoom } from '../net/api'
 import { isMultiplayerConfigured } from '../net/config'
 import { RoomClient } from '../net/client'
 import { RoomHost, type HostedPeer } from '../net/host'
-import { isRoomCode, type PeerClientIntent, type PeerClientSetDisplayName, type PeerHostSnapshot } from '../net/protocol'
+import {
+  isRoomCode,
+  type PeerClientChatSend,
+  type PeerClientIntent,
+  type PeerClientSetDisplayName,
+  type PeerHostChatLine,
+  type PeerHostSnapshot,
+} from '../net/protocol'
 import type { PeerState } from '../net/peer'
 import type { SignalingState } from '../net/signaling'
 
@@ -31,6 +38,16 @@ export interface MultiplayerPanelProps {
   onRemoteIntent?: (intent: PeerClientIntent, fromPeerId: string) => void
   /** Client → host display name updates (host only). */
   onRemoteSetDisplayName?: (msg: PeerClientSetDisplayName, fromPeerId: string) => void
+  /** Client → host room chat (host only). */
+  onRemoteChatSend?: (msg: PeerClientChatSend, fromPeerId: string) => void
+  /** Host → client chat line (client only). */
+  onRoomChatLine?: (line: PeerHostChatLine) => void
+  /** Open second-window room chat (host or joined client). */
+  onOpenChat?: () => void
+  /** When false, **Open chat** is disabled (e.g. client waiting for first snapshot). */
+  chatEnabled?: boolean
+  /** Shown after a blocked popup when opening chat. */
+  chatOpenFailed?: string
   /** Host roster changed (e.g. client connected); parent may push a table snapshot. */
   onHostingRosterChange?: (peers: HostedPeer[]) => void
   /** Any multiplayer teardown (Close room, Leave room, or host disconnect). */
@@ -53,6 +70,11 @@ export function MultiplayerPanel({
   onSessionSnapshot,
   onRemoteIntent,
   onRemoteSetDisplayName,
+  onRemoteChatSend,
+  onRoomChatLine,
+  onOpenChat,
+  chatEnabled = true,
+  chatOpenFailed,
   onHostingRosterChange,
   onTeardown,
   onClosed,
@@ -119,6 +141,7 @@ export function MultiplayerPanel({
         onIntent: (msg, from) => {
           if (msg.type === 'intent') onRemoteIntent?.(msg, from)
           else if (msg.type === 'setDisplayName') onRemoteSetDisplayName?.(msg, from)
+          else if (msg.type === 'chatSend') onRemoteChatSend?.(msg, from)
         },
       })
       hostRef.current = host
@@ -130,7 +153,15 @@ export function MultiplayerPanel({
       setError(e instanceof Error ? e.message : String(e))
       setStatus('')
     }
-  }, [gameId, maxClients, onHostStarted, onHostingRosterChange, onRemoteIntent, onRemoteSetDisplayName])
+  }, [
+    gameId,
+    maxClients,
+    onHostStarted,
+    onHostingRosterChange,
+    onRemoteIntent,
+    onRemoteSetDisplayName,
+    onRemoteChatSend,
+  ])
 
   const startClient = useCallback(async () => {
     setError('')
@@ -155,6 +186,7 @@ export function MultiplayerPanel({
         onSnapshot: (snap) => onSessionSnapshot?.(snap),
         onStatus: (m) => setStatus(m),
         onAck: (nonce, ok, err) => onPeerAck?.(nonce, ok, err),
+        onChatLine: (line) => onRoomChatLine?.(line),
         onHostEnded: () => {
           teardown({ clientKickedByHost: true })
         },
@@ -167,7 +199,7 @@ export function MultiplayerPanel({
       setError(e instanceof Error ? e.message : String(e))
       setStatus('')
     }
-  }, [joinCodeInput, onClientStarted, onPeerAck, onSessionSnapshot, teardown, updatePeerStatus])
+  }, [joinCodeInput, onClientStarted, onPeerAck, onRoomChatLine, onSessionSnapshot, teardown, updatePeerStatus])
 
   if (!configured) {
     return (
@@ -182,6 +214,7 @@ export function MultiplayerPanel({
   }
 
   const showCompact = tableActive && mode !== 'idle'
+  const showOpenChat = mode !== 'idle' && !!onOpenChat
 
   return (
     <section className="multiplayerPanel" aria-label="Multiplayer">
@@ -233,6 +266,17 @@ export function MultiplayerPanel({
                   onCommit={nameplate.onCommit}
                 />
               )}
+              {showOpenChat && (
+                <button
+                  type="button"
+                  className="app__btnSecondary app__btnToolbar"
+                  disabled={!chatEnabled}
+                  title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                  onClick={() => onOpenChat?.()}
+                >
+                  Open chat
+                </button>
+              )}
               <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
                 Close room
               </button>
@@ -269,6 +313,17 @@ export function MultiplayerPanel({
                   onCommit={nameplate.onCommit}
                 />
               )}
+              {showOpenChat && (
+                <button
+                  type="button"
+                  className="app__btnSecondary app__btnToolbar"
+                  disabled={!chatEnabled}
+                  title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                  onClick={() => onOpenChat?.()}
+                >
+                  Open chat
+                </button>
+              )}
               <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
                 Leave room
               </button>
@@ -286,9 +341,22 @@ export function MultiplayerPanel({
             Signaling: <em>{signalingState}</em>
           </p>
           <ConnectedPeers roster={roster} />
-          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
-            Close room
-          </button>
+          <div className="multiplayerPanel__hostingActions">
+            {showOpenChat && (
+              <button
+                type="button"
+                className="app__btnSecondary app__btnToolbar"
+                disabled={!chatEnabled}
+                title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                onClick={() => onOpenChat?.()}
+              >
+                Open chat
+              </button>
+            )}
+            <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
+              Close room
+            </button>
+          </div>
         </div>
       )}
 
@@ -300,9 +368,22 @@ export function MultiplayerPanel({
           <p>
             Signaling: <em>{signalingState}</em> · Peer: <em>{peerState}</em>
           </p>
-          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
-            Leave room
-          </button>
+          <div className="multiplayerPanel__hostingActions">
+            {showOpenChat && (
+              <button
+                type="button"
+                className="app__btnSecondary app__btnToolbar"
+                disabled={!chatEnabled}
+                title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                onClick={() => onOpenChat?.()}
+              >
+                Open chat
+              </button>
+            )}
+            <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
+              Leave room
+            </button>
+          </div>
         </div>
       )}
 
@@ -312,6 +393,7 @@ export function MultiplayerPanel({
           {error}
         </p>
       )}
+      {chatOpenFailed ? <p className="multiplayerPanel__chatFail">{chatOpenFailed}</p> : null}
     </section>
   )
 }

--- a/src/ui/openChatPopout.ts
+++ b/src/ui/openChatPopout.ts
@@ -1,0 +1,26 @@
+/**
+ * Second-window chat uses `postMessage` with `window.opener`. Do **not** pass
+ * `noopener` in the features string — that severs `opener` in Chromium and the
+ * popout cannot talk to the main window.
+ *
+ * - **Chrome / Edge (Chromium):** `window.open` with a name reuses one tab per name.
+ * - **Firefox:** May open a new window each time unless the user allows the site to open popups.
+ * - **Safari:** Stricter popup blocking; user gesture (button click) improves success.
+ */
+export const CHAT_POPOUT_WINDOW_NAME = 'cardgame_room_chat'
+
+export function chatPopoutPageUrl(): string {
+  const base = import.meta.env.BASE_URL || '/'
+  const path = base.endsWith('/') ? `${base}chat-popout.html` : `${base}/chat-popout.html`
+  return new URL(path, window.location.origin).href
+}
+
+/**
+ * Opens the chat popout. Returns `null` if the browser blocked the window.
+ * Avoid `noopener` / `noreferrer` so `window.opener` stays usable for messaging.
+ */
+export function openChatPopoutWindow(): Window | null {
+  const url = chatPopoutPageUrl()
+  const features = 'width=420,height=560,menubar=no,toolbar=no,location=no,status=no'
+  return window.open(url, CHAT_POPOUT_WINDOW_NAME, features)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,19 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        chatPopout: resolve(__dirname, 'chat-popout.html'),
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

Adds **ephemeral in-room chat** for online multiplayer: clients send `chatSend` over the existing game DataChannel; the host validates, rate-limits, labels senders from seat display names, and broadcasts `chatLine` to every peer.

## UX

- **Open chat** in the multiplayer strip opens a **second window** (Vite entry `chat-popout.html`) with transcript + composer.
- **`postMessage`** bridges the popout and main app (no `noopener` on `window.open` so `opener` stays available).
- When the popout is **closed**, new lines appear as **bottom-right toasts** on the main app (max **5**, **~3s**). While the popout is **open**, toasts run only there to avoid duplicates.
- Messages are trimmed/sanitized to **140** characters (`sanitizeChatText`).

## Protocol

- Bumps **`PROTOCOL_VERSION`** to **3** (`PeerClientChatSend`, `PeerHostChatLine`).

## Docs

- New **`docs/multiplayer-chat.md`** (wire types, limits, code map, browser notes).
- README + `docs/ui-design.md` + `AGENTS.md` updated.

## Build

- **`vite.config.ts`**: multi-page `rollupOptions.input` for `chat-popout.html`.
