### PR TITLE
fix(ui): chat popout contrast and no duplicate toasts

### DIFF
--- a/docs/multiplayer-chat.md
+++ b/docs/multiplayer-chat.md
@@ -8,7 +8,7 @@ When **online multiplayer** is enabled in the build, hosts and joined clients ca
 2. Click **Open chat**. The browser opens a **second window** with a short transcript and a composer.
 3. Type a message and press **Send** or **Enter**. Everyone in the room sees the line (after the host validates it).
 
-If the chat window is **closed**, new messages still appear as **toasts** in the bottom-right of the **main** game window (up to **five** at a time, each for about **three seconds**). While the chat popout is **open**, toasts appear **only** in that window so you do not get duplicates.
+If the chat window is **closed**, new messages still appear as **toasts** in the bottom-right of the **main** game window (up to **five** at a time, each for about **three seconds**). While the chat popout is **open**, new lines appear **only** in the transcript there (no duplicate toasts in the popout).
 
 ## Names and limits
 

--- a/src/chat-popout/chat-popout.css
+++ b/src/chat-popout/chat-popout.css
@@ -22,6 +22,7 @@ body {
   border-bottom: 1px solid var(--border, #2a2f3a);
   font-size: 0.95rem;
   font-weight: 600;
+  color: var(--text-h, #08060d);
 }
 
 .chatPopout__transcript {
@@ -38,14 +39,32 @@ body {
 }
 
 .chatPopout__meta {
-  opacity: 0.85;
   font-size: 0.8rem;
   margin-bottom: 0.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.15rem;
 }
 
+/* Use heading foreground, not --accent-bg (that token is a wash for UI surfaces, not text). */
 .chatPopout__sender {
-  font-weight: 600;
-  color: var(--accent-bg, #6b9fff);
+  font-weight: 700;
+  color: var(--text-h, #08060d);
+}
+
+.chatPopout__metaSep {
+  color: var(--text-muted, #5c566a);
+  font-weight: 400;
+}
+
+.chatPopout__time {
+  color: var(--text-muted, #5c566a);
+  font-weight: 500;
+}
+
+.chatPopout__body {
+  color: var(--text-h, #08060d);
 }
 
 .chatPopout__composer {
@@ -94,38 +113,4 @@ body {
   padding: 1rem 0.75rem;
   font-size: 0.9rem;
   line-height: 1.4;
-}
-
-.chatToastStack {
-  position: fixed;
-  right: 12px;
-  bottom: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-width: min(360px, calc(100vw - 24px));
-  z-index: 9999;
-  pointer-events: none;
-}
-
-.chatToastStack__item {
-  pointer-events: auto;
-  padding: 0.5rem 0.65rem;
-  border-radius: 8px;
-  border: 1px solid var(--border, #2a2f3a);
-  background: rgba(24, 28, 36, 0.96);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
-}
-
-.chatToastStack__sender {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--accent-bg, #6b9fff);
-  margin-bottom: 0.15rem;
-}
-
-.chatToastStack__text {
-  font-size: 0.85rem;
-  line-height: 1.3;
-  word-break: break-word;
 }

--- a/src/chat-popout/main.tsx
+++ b/src/chat-popout/main.tsx
@@ -7,8 +7,6 @@ import {
   isMainToChatPopout,
   type ChatPopoutToMain,
 } from '../chat/chatPopoutMessages'
-import { useChatToasts } from '../chat/useChatToasts'
-import { ChatToastStack } from '../ui/ChatToastStack'
 import './chat-popout.css'
 
 function ChatPopoutApp() {
@@ -16,7 +14,6 @@ function ChatPopoutApp() {
   const [lines, setLines] = useState<PeerHostChatLine[]>([])
   const [draft, setDraft] = useState('')
   const [noOpener, setNoOpener] = useState(() => typeof window !== 'undefined' && !window.opener)
-  const { toasts, pushToast, clearToasts } = useChatToasts(5, 3000)
 
   const postToOpener = useCallback((msg: ChatPopoutToMain) => {
     const target = openerRef.current
@@ -40,16 +37,14 @@ function ChatPopoutApp() {
       if (!isMainToChatPopout(ev.data)) return
       if (ev.data.type === 'chat-sync') {
         setLines(ev.data.lines)
-        clearToasts()
         return
       }
       const { line } = ev.data
       setLines((prev) => [...prev, line].slice(-200))
-      pushToast({ id: line.id, senderLabel: line.senderLabel, text: line.text })
     }
     window.addEventListener('message', onMessage)
     return () => window.removeEventListener('message', onMessage)
-  }, [pushToast, clearToasts])
+  }, [])
 
   const send = useCallback(() => {
     const t = draft.trim()
@@ -81,10 +76,12 @@ function ChatPopoutApp() {
             <div key={l.id} className="chatPopout__line">
               <div className="chatPopout__meta">
                 <span className="chatPopout__sender">{l.senderLabel}</span>
-                <span> · </span>
-                <time dateTime={new Date(l.ts).toISOString()}>{new Date(l.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>
+                <span className="chatPopout__metaSep"> · </span>
+                <time className="chatPopout__time" dateTime={new Date(l.ts).toISOString()}>
+                  {new Date(l.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </time>
               </div>
-              <div>{l.text}</div>
+              <div className="chatPopout__body">{l.text}</div>
             </div>
           ))
         )}
@@ -110,7 +107,6 @@ function ChatPopoutApp() {
         </button>
       </div>
       <p className="chatPopout__hint">Messages are not stored on the server and disappear when the room closes.</p>
-      <ChatToastStack toasts={toasts} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **Sender names** in the room chat popout use \--text-h\ instead of \--accent-bg\ (the latter is a surface tint and was nearly invisible on white).
- **Toasts** are removed from the popout; new lines only appear in the transcript there. Main-window toasts when the popout is closed are unchanged.
- **Docs:** \docs/multiplayer-chat.md\ updated to match.

Made with [Cursor](https://cursor.com)