### PR TITLE
fix(ui): open room chat before first deal (joined clients)

### DIFF
--- a/docs/multiplayer-chat.md
+++ b/docs/multiplayer-chat.md
@@ -5,8 +5,8 @@ When **online multiplayer** is enabled in the build, hosts and joined clients ca
 ## How to use it
 
 1. **Host a room** or **join** with a room code (same flow as normal online play).
-2. Click **Open chat**. The browser opens a **second window** with a short transcript and a composer.
-3. Type a message and press **Send** or **Enter**. Everyone in the room sees the line (after the host validates it).
+2. Click **Open chat** as soon as you are in the room (you do not need to wait for the host to start a deal). The browser opens a **second window** with a short transcript and a composer.
+3. Type a message and press **Send** or **Enter**. Everyone in the room sees the line (after the host validates it). Until the host has sent at least one table snapshot, your **seat** for the wire protocol may not be known yet — **Send** does nothing until then (you can still read the transcript if others chat).
 
 If the chat window is **closed**, new messages still appear as **toasts** in the bottom-right of the **main** game window (up to **five** at a time, each for about **three seconds**). While the chat popout is **open**, new lines appear **only** in the transcript there (no duplicate toasts in the popout).
 

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -46,7 +46,7 @@ The inline display-name input uses theme-aligned borders/background (`--border`,
 
 **Close room** / **Leave room** in the non-compact blocks also use **`app__btnSecondary app__btnToolbar`**.
 
-**Open chat** (compact and expanded multiplayer rows) uses the same button classes. It stays disabled for a joined client until a table snapshot assigns a seat. Behavior of the chat window and main-window toasts is documented in [`multiplayer-chat.md`](multiplayer-chat.md).
+**Open chat** (compact and expanded multiplayer rows) uses the same button classes. It is available whenever you are in a room (host or joined client); it stays disabled only while **spectating**. Behavior of the chat window and main-window toasts is documented in [`multiplayer-chat.md`](multiplayer-chat.md).
 
 ## When you change something
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -342,6 +342,8 @@ function App() {
 
   const roomHostRef = useRef<RoomHost | null>(null)
   const roomClientRef = useRef<RoomClient | null>(null)
+  /** Host snapshot seat for this browser (joined client); set before parse so chat send works before first full session. */
+  const clientRemoteSeatRef = useRef<number | null>(null)
   const sessionRef = useRef<GameSession | null>(null)
   const pushSnapshotRef = useRef<() => void>(() => {})
 
@@ -377,8 +379,9 @@ function App() {
 
   const onlineClientShell = joinedAsClient || !!session?.net
   const networkSpectator = !!session?.net?.spectator
+  /** Open chat whenever in a room; joined clients can open before the first deal. Spectators stay disabled. */
   const multiplayerChatEnabled =
-    multiplayerHostActive || (!!session?.net && !session.net.spectator && joinedAsClient)
+    multiplayerHostActive || (joinedAsClient && (!session?.net || !session.net.spectator))
 
   const seatDisplayName = useCallback(
     (serverPlayerIndex: number): string => {
@@ -584,6 +587,7 @@ function App() {
   }, [])
 
   const onSessionSnapshot = useCallback((snap: PeerHostSnapshot) => {
+    clientRemoteSeatRef.current = snap.seat
     const parsed = parseSessionSnapshot(snap.state, snap.seat)
     if (!parsed) return
     setSession(parsed)
@@ -731,8 +735,11 @@ function App() {
       const sess = sessionRef.current
       const client = roomClientRef.current
       if (client) {
-        if (!sess?.net || sess.net.spectator) return
-        client.sendChat({ seat: sess.net.seat, text })
+        if (sess?.net?.spectator) return
+        const seat =
+          sess?.net && !sess.net.spectator ? sess.net.seat : clientRemoteSeatRef.current
+        if (seat == null || seat < 0) return
+        client.sendChat({ seat, text })
         return
       }
       const host = roomHostRef.current
@@ -819,6 +826,7 @@ function App() {
       // ignore
     }
     chatPopoutRef.current = null
+    clientRemoteSeatRef.current = null
   }, [clearMainChatToasts])
 
   const onHostingRosterChange = useCallback((peers?: HostedPeer[]) => {
@@ -1539,6 +1547,7 @@ function App() {
           onRoomChatLine={onRoomChatLine}
           onOpenChat={handleOpenChat}
           chatEnabled={multiplayerChatEnabled}
+          chatDisabledTitle={networkSpectator ? 'Spectating — room chat is disabled.' : undefined}
           chatOpenFailed={chatOpenFailed}
           onHostingRosterChange={onHostingRosterChange}
           onTeardown={onMultiplayerTeardown}

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -44,8 +44,10 @@ export interface MultiplayerPanelProps {
   onRoomChatLine?: (line: PeerHostChatLine) => void
   /** Open second-window room chat (host or joined client). */
   onOpenChat?: () => void
-  /** When false, **Open chat** is disabled (e.g. client waiting for first snapshot). */
+  /** When false, **Open chat** is disabled (e.g. spectating). */
   chatEnabled?: boolean
+  /** Tooltip when **Open chat** is disabled; defaults to a generic message. */
+  chatDisabledTitle?: string
   /** Shown after a blocked popup when opening chat. */
   chatOpenFailed?: string
   /** Host roster changed (e.g. client connected); parent may push a table snapshot. */
@@ -74,6 +76,7 @@ export function MultiplayerPanel({
   onRoomChatLine,
   onOpenChat,
   chatEnabled = true,
+  chatDisabledTitle,
   chatOpenFailed,
   onHostingRosterChange,
   onTeardown,
@@ -215,6 +218,7 @@ export function MultiplayerPanel({
 
   const showCompact = tableActive && mode !== 'idle'
   const showOpenChat = mode !== 'idle' && !!onOpenChat
+  const chatDisabledHint = chatDisabledTitle ?? 'Chat is not available.'
 
   return (
     <section className="multiplayerPanel" aria-label="Multiplayer">
@@ -271,7 +275,7 @@ export function MultiplayerPanel({
                   type="button"
                   className="app__btnSecondary app__btnToolbar"
                   disabled={!chatEnabled}
-                  title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                  title={!chatEnabled ? chatDisabledHint : undefined}
                   onClick={() => onOpenChat?.()}
                 >
                   Open chat
@@ -318,7 +322,7 @@ export function MultiplayerPanel({
                   type="button"
                   className="app__btnSecondary app__btnToolbar"
                   disabled={!chatEnabled}
-                  title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                  title={!chatEnabled ? chatDisabledHint : undefined}
                   onClick={() => onOpenChat?.()}
                 >
                   Open chat
@@ -347,7 +351,7 @@ export function MultiplayerPanel({
                 type="button"
                 className="app__btnSecondary app__btnToolbar"
                 disabled={!chatEnabled}
-                title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                title={!chatEnabled ? chatDisabledHint : undefined}
                 onClick={() => onOpenChat?.()}
               >
                 Open chat
@@ -374,7 +378,7 @@ export function MultiplayerPanel({
                 type="button"
                 className="app__btnSecondary app__btnToolbar"
                 disabled={!chatEnabled}
-                title={!chatEnabled ? 'Wait until you have a seat at the table.' : undefined}
+                title={!chatEnabled ? chatDisabledHint : undefined}
                 onClick={() => onOpenChat?.()}
               >
                 Open chat


### PR DESCRIPTION
## Summary
- **Open chat** stays enabled for joined clients as soon as they are in the room (not only after a table snapshot / deal).
- **Spectators** still get a disabled button with an explicit tooltip.
- **Send** from the popout uses PeerHostSnapshot.seat captured on every snapshot (before parse) so it works once the host has pushed at least one snapshot, even if full session parse failed; if no seat yet, send is a no-op (documented in docs/multiplayer-chat.md).
- Docs: docs/multiplayer-chat.md, docs/ui-design.md.

Made with [Cursor](https://cursor.com)