### PR TITLE
feat(deploy): cardgame.michaelj43.dev-style custom domain + GitHub Variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,16 +81,16 @@ jobs:
             -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
             -backend-config="encrypt=true"
 
-      # Optional custom domain: TF_CUSTOM_DOMAIN + TF_ACM_CERTIFICATE_ARN; optional TF_ROUTE53_HOSTED_ZONE_ID (see deploy/terraform/aws/README.md).
+      # Optional custom domain: TF_CUSTOM_DOMAIN (variable) + TF_ACM_CERTIFICATE_ARN (secret); optional TF_ROUTE53_HOSTED_ZONE_ID (secret). See deploy/terraform/aws/README.md.
       # Empty GitHub vars must not export TF_VAR_* or Terraform sees "" instead of null.
       - name: Terraform apply
         working-directory: deploy/terraform/aws
         run: |
           set -e
           if [ -n "${{ vars.TF_CUSTOM_DOMAIN }}" ]; then export TF_VAR_custom_domain="${{ vars.TF_CUSTOM_DOMAIN }}"; fi
-          if [ -n "${{ vars.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ vars.TF_ACM_CERTIFICATE_ARN }}"; fi
+          if [ -n "${{ secrets.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ secrets.TF_ACM_CERTIFICATE_ARN }}"; fi
           if [ -n "${{ vars.TF_ALLOWED_ORIGIN }}" ]; then export TF_VAR_allowed_origin="${{ vars.TF_ALLOWED_ORIGIN }}"; fi
-          if [ -n "${{ vars.TF_ROUTE53_HOSTED_ZONE_ID }}" ]; then export TF_VAR_route53_hosted_zone_id="${{ vars.TF_ROUTE53_HOSTED_ZONE_ID }}"; fi
+          if [ -n "${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}" ]; then export TF_VAR_route53_hosted_zone_id="${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}"; fi
           terraform apply -auto-approve
 
       - name: Capture Terraform outputs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
             -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
             -backend-config="encrypt=true"
 
-      # Optional custom domain: TF_CUSTOM_DOMAIN (variable) + TF_ACM_CERTIFICATE_ARN (secret); optional TF_ROUTE53_HOSTED_ZONE_ID (secret). See deploy/terraform/aws/README.md.
+      # Optional custom domain: TF_CUSTOM_DOMAIN (var) + TF_ACM_CERTIFICATE_ARN + TF_ROUTE53_HOSTED_ZONE_ID (secrets). See AGENTS.md / AWS_SETUP.md.
       # Empty GitHub vars must not export TF_VAR_* or Terraform sees "" instead of null.
       - name: Terraform apply
         working-directory: deploy/terraform/aws

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,9 +81,16 @@ jobs:
             -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
             -backend-config="encrypt=true"
 
+      # Optional custom domain: set repo Variables TF_CUSTOM_DOMAIN + TF_ACM_CERTIFICATE_ARN (see deploy/terraform/aws/README.md).
+      # Empty GitHub vars must not export TF_VAR_* or Terraform sees "" instead of null.
       - name: Terraform apply
         working-directory: deploy/terraform/aws
-        run: terraform apply -auto-approve
+        run: |
+          set -e
+          if [ -n "${{ vars.TF_CUSTOM_DOMAIN }}" ]; then export TF_VAR_custom_domain="${{ vars.TF_CUSTOM_DOMAIN }}"; fi
+          if [ -n "${{ vars.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ vars.TF_ACM_CERTIFICATE_ARN }}"; fi
+          if [ -n "${{ vars.TF_ALLOWED_ORIGIN }}" ]; then export TF_VAR_allowed_origin="${{ vars.TF_ALLOWED_ORIGIN }}"; fi
+          terraform apply -auto-approve
 
       - name: Capture Terraform outputs
         id: tf
@@ -92,6 +99,7 @@ jobs:
           echo "site_bucket=$(terraform output -raw site_bucket)" >> "$GITHUB_OUTPUT"
           echo "cloudfront_distribution_id=$(terraform output -raw cloudfront_distribution_id)" >> "$GITHUB_OUTPUT"
           echo "cloudfront_domain=$(terraform output -raw cloudfront_domain)" >> "$GITHUB_OUTPUT"
+          echo "site_url=$(terraform output -raw site_url)" >> "$GITHUB_OUTPUT"
           echo "http_api_url=$(terraform output -raw http_api_url)" >> "$GITHUB_OUTPUT"
           echo "ws_api_url=$(terraform output -raw ws_api_url)" >> "$GITHUB_OUTPUT"
 
@@ -142,6 +150,7 @@ jobs:
       - name: Summary
         run: |
           echo "### Deployment" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Site: https://${{ steps.tf.outputs.cloudfront_domain }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Site (public): ${{ steps.tf.outputs.site_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- CloudFront hostname: https://${{ steps.tf.outputs.cloudfront_domain }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- HTTP API: ${{ steps.tf.outputs.http_api_url }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- WS API: ${{ steps.tf.outputs.ws_api_url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
             -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
             -backend-config="encrypt=true"
 
-      # Optional custom domain: set repo Variables TF_CUSTOM_DOMAIN + TF_ACM_CERTIFICATE_ARN (see deploy/terraform/aws/README.md).
+      # Optional custom domain: TF_CUSTOM_DOMAIN + TF_ACM_CERTIFICATE_ARN; optional TF_ROUTE53_HOSTED_ZONE_ID (see deploy/terraform/aws/README.md).
       # Empty GitHub vars must not export TF_VAR_* or Terraform sees "" instead of null.
       - name: Terraform apply
         working-directory: deploy/terraform/aws
@@ -90,6 +90,7 @@ jobs:
           if [ -n "${{ vars.TF_CUSTOM_DOMAIN }}" ]; then export TF_VAR_custom_domain="${{ vars.TF_CUSTOM_DOMAIN }}"; fi
           if [ -n "${{ vars.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ vars.TF_ACM_CERTIFICATE_ARN }}"; fi
           if [ -n "${{ vars.TF_ALLOWED_ORIGIN }}" ]; then export TF_VAR_allowed_origin="${{ vars.TF_ALLOWED_ORIGIN }}"; fi
+          if [ -n "${{ vars.TF_ROUTE53_HOSTED_ZONE_ID }}" ]; then export TF_VAR_route53_hosted_zone_id="${{ vars.TF_ROUTE53_HOSTED_ZONE_ID }}"; fi
           terraform apply -auto-approve
 
       - name: Capture Terraform outputs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,8 +277,8 @@ sweeper process.
   (plus a Route 53 hosted zone if you bring a custom domain).
 - No `Scan` on hot paths (`relay` uses `GetItem` on the reverse index;
   `listConnections` uses `Query` within a single partition).
-- See `AWS_SETUP.md` (gitignored) for repository secrets and
-  `deploy/terraform/aws/README.md` for infra details.
+- See `AWS_SETUP.md` (gitignored) for repository secrets / CI wiring, and
+  `deploy/terraform/aws/README.md` for the Terraform module (resources, inputs, outputs).
 
 ### GitHub Actions
 
@@ -299,7 +299,7 @@ only on the Terraform step output in the same job:
 
 Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for that run. Copy the two lines from the last successful **Deploy** job summary into Variables once, then re-run **Deploy** (or push) so CloudFront serves a bundle with multiplayer enabled.
 
-Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable** `TF_CUSTOM_DOMAIN` and **Secret** `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). Optional **Secret** `TF_ROUTE53_HOSTED_ZONE_ID` for Terraform-managed Route 53 aliases. See **`deploy/terraform/aws/README.md`** and **`AWS_SETUP.md`** §7.
+Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable** `TF_CUSTOM_DOMAIN` and **Secret** `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). Optional **Secret** `TF_ROUTE53_HOSTED_ZONE_ID` for Terraform-managed Route 53 aliases. See **`AWS_SETUP.md`** §7 and **`.github/workflows/deploy.yml`**; **`deploy/terraform/aws/README.md`** documents what Terraform creates.
 
 ### Future backlog (not in this PR)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,7 +299,7 @@ only on the Terraform step output in the same job:
 
 Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for that run. Copy the two lines from the last successful **Deploy** job summary into Variables once, then re-run **Deploy** (or push) so CloudFront serves a bundle with multiplayer enabled.
 
-Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variables** `TF_CUSTOM_DOMAIN` and `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). See **`deploy/terraform/aws/README.md`** and **`AWS_SETUP.md`** §7.
+Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable** `TF_CUSTOM_DOMAIN` and **Secret** `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). Optional **Secret** `TF_ROUTE53_HOSTED_ZONE_ID` for Terraform-managed Route 53 aliases. See **`deploy/terraform/aws/README.md`** and **`AWS_SETUP.md`** §7.
 
 ### Future backlog (not in this PR)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,8 @@ only on the Terraform step output in the same job:
 
 Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for that run. Copy the two lines from the last successful **Deploy** job summary into Variables once, then re-run **Deploy** (or push) so CloudFront serves a bundle with multiplayer enabled.
 
+Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variables** `TF_CUSTOM_DOMAIN` and `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). See **`deploy/terraform/aws/README.md`** and **`AWS_SETUP.md`** §7.
+
 ### Future backlog (not in this PR)
 
 - **TURN relay** for symmetric-NAT / strict-firewall peers (STUN-only may

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Pick a game from the in-app **Game** menu. Each row links to a short note in [`d
 | [`docs/ui-design.md`](docs/ui-design.md) | Shared shell UI (toolbar buttons, online multiplayer strip layout). |
 | [`docs/multiplayer-chat.md`](docs/multiplayer-chat.md) | Room chat (DataChannel + chat popout + toasts). |
 | [`docs/audio-cues.md`](docs/audio-cues.md) | Optional chat / turn / card sounds (`public/sounds/*.wav`). |
-| [`deploy/terraform/aws/README.md`](deploy/terraform/aws/README.md) | AWS deploy (S3, CloudFront, Lambda, APIs); includes **custom subdomain** (e.g. `cardgame.michaelj43.dev`) + GitHub Variables. |
+| [`deploy/terraform/aws/README.md`](deploy/terraform/aws/README.md) | Terraform module reference: AWS resources, variables, outputs, file layout. |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Pick a game from the in-app **Game** menu. Each row links to a short note in [`d
 | [`docs/ui-design.md`](docs/ui-design.md) | Shared shell UI (toolbar buttons, online multiplayer strip layout). |
 | [`docs/multiplayer-chat.md`](docs/multiplayer-chat.md) | Room chat (DataChannel + chat popout + toasts). |
 | [`docs/audio-cues.md`](docs/audio-cues.md) | Optional chat / turn / card sounds (`public/sounds/*.wav`). |
+| [`deploy/terraform/aws/README.md`](deploy/terraform/aws/README.md) | AWS deploy (S3, CloudFront, Lambda, APIs); includes **custom subdomain** (e.g. `cardgame.michaelj43.dev`) + GitHub Variables. |
 
 ## Contributing
 

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -40,18 +40,25 @@ CloudFront only accepts certificates in `us-east-1`. This stack attaches the sam
 
 ### 2. Terraform / GitHub Actions
 
-The **Deploy** workflow exports optional `TF_VAR_*` only when repository **Variables** are non-empty (so Terraform still sees `null` when you omit them).
+The **Deploy** workflow exports optional `TF_VAR_*` only when the corresponding GitHub **Variable** or **Secret** is non-empty (so Terraform still sees `null` when you omit them).
 
-In GitHub: **Settings → Secrets and variables → Actions → Variables** (repository), add:
+**Variables** — **Settings → Secrets and variables → Actions → Variables**:
 
 | Variable | Example value | Required? |
 |----------|----------------|-----------|
 | `TF_CUSTOM_DOMAIN` | `cardgame.michaelj43.dev` | For custom hostnames |
-| `TF_ACM_CERTIFICATE_ARN` | `arn:aws:acm:us-east-1:…:certificate/…` | With `TF_CUSTOM_DOMAIN` |
-| `TF_ROUTE53_HOSTED_ZONE_ID` | `Z0ABCDEF123456` | Optional — set to let Terraform create **Route 53** alias records (see below) |
 | `TF_ALLOWED_ORIGIN` | *(omit unless needed)* | Optional exact CORS / Lambda origin override |
 
-**Route 53 variable:** In Route 53 → **Hosted zones** → open the zone whose name is exactly your `TF_CUSTOM_DOMAIN` → copy **Hosted zone ID** into `TF_ROUTE53_HOSTED_ZONE_ID`.
+**Secrets** — **Settings → Secrets and variables → Actions → Secrets** (values are masked in the UI and not printed by the workflow):
+
+| Secret | Example value | Required? |
+|--------|----------------|-----------|
+| `TF_ACM_CERTIFICATE_ARN` | `arn:aws:acm:us-east-1:…:certificate/…` | With `TF_CUSTOM_DOMAIN` |
+| `TF_ROUTE53_HOSTED_ZONE_ID` | `Z0ABCDEF123456` | Optional — set to let Terraform create **Route 53** alias records (see below) |
+
+If you previously stored **`TF_ACM_CERTIFICATE_ARN`** or **`TF_ROUTE53_HOSTED_ZONE_ID`** as repository **Variables**, move them to **Secrets** with the same names and delete the old variables so only one binding exists.
+
+**Route 53:** In Route 53 → **Hosted zones** → open the zone whose name is exactly your `TF_CUSTOM_DOMAIN` → copy **Hosted zone ID** into the **`TF_ROUTE53_HOSTED_ZONE_ID`** secret.
 
 Terraform will then:
 
@@ -60,7 +67,7 @@ Terraform will then:
 - Create **Route 53** alias **A** (and **AAAA** for the apex only) records: apex → CloudFront, `api` → HTTP API regional domain, `ws` → WebSocket API regional domain.
 - Set CORS / **`ALLOWED_ORIGIN`** and the HTTP Lambda **`WS_PUBLIC_URL`** to the vanity WebSocket URL when a custom domain is enabled.
 
-If you **omit** `TF_ROUTE53_HOSTED_ZONE_ID`, you must still point **DNS** for the apex, **api.**, and **ws.** at CloudFront / API Gateway yourself (same targets Terraform would have used).
+If you **omit** the **`TF_ROUTE53_HOSTED_ZONE_ID`** secret, you must still point **DNS** for the apex, **api.**, and **ws.** at CloudFront / API Gateway yourself (same targets Terraform would have used).
 
 **Apex DNS note:** You cannot use a plain **CNAME** at the zone apex. Use **Route 53 alias A/AAAA** to CloudFront (Terraform does this when the zone id is set).
 

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -2,9 +2,11 @@
 
 Creates:
 
-- S3 bucket + CloudFront distribution for the static site.
+- S3 bucket + CloudFront distribution for the static site (optional **alternate domain name** + ACM).
 - DynamoDB table for room metadata and WebSocket connections (pay-per-request, TTL enabled).
 - Two Lambda functions (`http`, `websocket`) behind API Gateway v2 (HTTP API + WebSocket API).
+- When **custom domain** is enabled: regional **API Gateway custom domain names** for `https://api.<custom_domain>` and `wss://ws.<custom_domain>/prod`.
+- When **custom domain** + **`route53_hosted_zone_id`** are set: **Route 53 alias** records in that zone (apex → CloudFront, `api` / `ws` → API Gateway regional targets).
 - IAM role + least-privilege inline policy.
 
 ## Inputs you must provide
@@ -18,66 +20,62 @@ Either via `terraform.tfvars`, environment variables, or the GitHub deploy workf
 
 Optional:
 
-- `custom_domain` + `acm_certificate_arn` (must be in `us-east-1`) for a vanity hostname.
+- `custom_domain` + `acm_certificate_arn` for the **site** hostname on CloudFront and (when both are set) for **api.*** / **ws.*** on API Gateway. The certificate must be in **`us-east-1`** for CloudFront; **`aws_region`** should be **`us-east-1`** so the **same** ACM ARN can be attached to API Gateway regional custom domain names.
+- `route53_hosted_zone_id` — Route 53 **public** hosted zone **id** (`Z…`) whose **domain name equals `custom_domain`** (e.g. zone `cardgame.example.com` when the site is `https://cardgame.example.com`). When set with a custom domain, Terraform manages DNS records in that zone.
 - `allowed_origin` — only if you must override the default (Terraform uses `https://<custom_domain>` for CORS when a custom domain is set, otherwise the CloudFront hostname).
 - `site_bucket_name` to pin a particular bucket name.
 
-## Example: `cardgame.michaelj43.dev` (subdomain only)
+## Example: `cardgame.michaelj43.dev` (delegated zone in Route 53)
 
-Use this when the **apex** `michaelj43.dev` already points elsewhere; only the **subdomain** serves this app.
+Use a **public hosted zone** for exactly `cardgame.michaelj43.dev` (NS-delegated from your registrar or Cloudflare). The ACM certificate should include at least **`cardgame.michaelj43.dev`** and **`*.cardgame.michaelj43.dev`** so **api.** / **ws.** subdomains are valid for TLS.
 
 ### 1. ACM certificate (must be **us-east-1**)
 
-CloudFront only accepts certificates in `us-east-1`.
+CloudFront only accepts certificates in `us-east-1`. This stack attaches the same ARN to API Gateway when `custom_domain` is set, so keep **`aws_region = "us-east-1"`** unless you maintain a **separate** regional ACM ARN (not implemented as a separate variable today).
 
-1. AWS Console → **Certificate Manager** → region **N. Virginia (us-east-1)** → **Request certificate**.
-2. Choose **Request a public certificate** → fully qualified domain name: **`cardgame.michaelj43.dev`** (DNS validation).
-3. In **Route 53** (if your zone is there) click **Create records in Route 53** for the validation CNAMEs.  
-   If DNS for `michaelj43.dev` lives at **Cloudflare, Namecheap, etc.**, add the **same** CNAME records there instead.
-4. Wait until the certificate status is **Issued** and copy the **ARN** (e.g. `arn:aws:acm:us-east-1:123456789012:certificate/…`).
+1. AWS Console → **Certificate Manager** → **N. Virginia (us-east-1)** → **Request certificate** → **DNS validation**.
+2. Add names such as **`cardgame.michaelj43.dev`** and **`*.cardgame.michaelj43.dev`**.
+3. Add the validation CNAMEs in the **authoritative** DNS for those names (your delegated Route 53 zone and/or parent zone, depending on ACM’s required record names).
+4. Wait until the certificate is **Issued**; copy the **ARN**.
 
-You do **not** need a separate Route 53 public hosted zone for the subdomain if you already manage `michaelj43.dev` somewhere.
+### 2. Terraform / GitHub Actions
 
-### 2. DNS record for the live site
-
-After the first Terraform apply **with** the custom domain (step 3), CloudFront gives you a distribution domain like `d1111abcdef8.cloudfront.net`.
-
-Create a **DNS record** for `cardgame` → **CNAME** (or an **ALIAS/A** if your DNS provider supports aliasing to CloudFront) pointing to that CloudFront hostname:
-
-| Type | Name / host | Target |
-|------|----------------|--------|
-| **CNAME** | `cardgame` | `dxxxx.cloudfront.net` (from AWS Console → CloudFront → distribution → domain name) |
-
-TTL: 300s while testing, then longer.
-
-### 3. Terraform / GitHub Actions
-
-The **Deploy** workflow exports optional `TF_VAR_*` only when repository **Variables** are non-empty (so Terraform still sees `null` when you are not using a custom domain).
+The **Deploy** workflow exports optional `TF_VAR_*` only when repository **Variables** are non-empty (so Terraform still sees `null` when you omit them).
 
 In GitHub: **Settings → Secrets and variables → Actions → Variables** (repository), add:
 
-| Variable | Example value |
-|----------|----------------|
-| `TF_CUSTOM_DOMAIN` | `cardgame.michaelj43.dev` |
-| `TF_ACM_CERTIFICATE_ARN` | `arn:aws:acm:us-east-1:…:certificate/…` |
-| `TF_ALLOWED_ORIGIN` | *(optional)* Only if you need an exact origin string different from `https://cardgame.michaelj43.dev` (e.g. trailing slash quirks). Usually **omit**. |
+| Variable | Example value | Required? |
+|----------|----------------|-----------|
+| `TF_CUSTOM_DOMAIN` | `cardgame.michaelj43.dev` | For custom hostnames |
+| `TF_ACM_CERTIFICATE_ARN` | `arn:aws:acm:us-east-1:…:certificate/…` | With `TF_CUSTOM_DOMAIN` |
+| `TF_ROUTE53_HOSTED_ZONE_ID` | `Z0ABCDEF123456` | Optional — set to let Terraform create **Route 53** alias records (see below) |
+| `TF_ALLOWED_ORIGIN` | *(omit unless needed)* | Optional exact CORS / Lambda origin override |
 
-Then run **Deploy** (push to `main` or **Actions → Deploy → Run workflow**). Terraform will:
+**Route 53 variable:** In Route 53 → **Hosted zones** → open the zone whose name is exactly your `TF_CUSTOM_DOMAIN` → copy **Hosted zone ID** into `TF_ROUTE53_HOSTED_ZONE_ID`.
 
-- Attach the certificate to CloudFront and set the **alternate domain name** to `cardgame.michaelj43.dev`.
-- Set API Gateway CORS and the HTTP Lambda **`ALLOWED_ORIGIN`** to `https://cardgame.michaelj43.dev` automatically when the custom domain is active.
+Terraform will then:
 
-### 4. Multiplayer URLs in the static build
+- Attach the certificate to CloudFront and set the alternate domain name to `cardgame.michaelj43.dev`.
+- Create **API Gateway** custom domains **`api.cardgame.michaelj43.dev`** and **`ws.cardgame.michaelj43.dev`** mapped to your HTTP and WebSocket APIs.
+- Create **Route 53** alias **A** (and **AAAA** for the apex only) records: apex → CloudFront, `api` → HTTP API regional domain, `ws` → WebSocket API regional domain.
+- Set CORS / **`ALLOWED_ORIGIN`** and the HTTP Lambda **`WS_PUBLIC_URL`** to the vanity WebSocket URL when a custom domain is enabled.
 
-The site bundle still needs the API Gateway URLs. Either:
+If you **omit** `TF_ROUTE53_HOSTED_ZONE_ID`, you must still point **DNS** for the apex, **api.**, and **ws.** at CloudFront / API Gateway yourself (same targets Terraform would have used).
 
-- Leave **repository Variables** `VITE_MULTIPLAYER_HTTP_URL` / `VITE_MULTIPLAYER_WS_URL` **unset** so each deploy uses the Terraform outputs from that run, or  
-- Set them once to stable values from the **Deploy** job summary (recommended if URLs rarely change).
+**Apex DNS note:** You cannot use a plain **CNAME** at the zone apex. Use **Route 53 alias A/AAAA** to CloudFront (Terraform does this when the zone id is set).
 
-### 5. Smoke test
+### 3. Multiplayer URLs in the static build
 
-1. Open `https://cardgame.michaelj43.dev` (TLS should succeed once DNS + cert propagate).
-2. **Online play** → Host / Join; browser devtools **Network** tab should show `POST` to your HTTP API without CORS errors (origin = `https://cardgame.michaelj43.dev`).
+Terraform outputs **`http_api_url`** and **`ws_api_url`** as:
+
+- **`https://api.<custom_domain>`** and **`wss://ws.<custom_domain>/prod`** when a custom domain is enabled, otherwise the default **execute-api** URLs.
+
+The deploy workflow passes those into **`VITE_MULTIPLAYER_*`** unless you override repository **Variables** `VITE_MULTIPLAYER_HTTP_URL` / `VITE_MULTIPLAYER_WS_URL`.
+
+### 4. Smoke test
+
+1. Open `https://cardgame.michaelj43.dev` (TLS + DNS after apply).
+2. **Online play** → Host / Join; **Network** tab should show `POST` to `https://api.cardgame…/rooms` (or your custom domain) without CORS errors.
 
 ## Remote state
 
@@ -96,7 +94,7 @@ terraform init \
 
 ## Outputs consumed by the site build
 
-- `http_api_url` → feed into `VITE_MULTIPLAYER_HTTP_URL` when running `npm run build`.
-- `ws_api_url` → feed into `VITE_MULTIPLAYER_WS_URL`.
+- `http_api_url` → `VITE_MULTIPLAYER_HTTP_URL`
+- `ws_api_url` → `VITE_MULTIPLAYER_WS_URL`
 
-The GitHub Actions deploy workflow wires this automatically.
+The GitHub Actions deploy workflow wires this automatically after `terraform apply`.

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -1,107 +1,76 @@
-# card-game Terraform (AWS)
+# AWS Terraform module (`deploy/terraform/aws`)
 
-Creates:
+Infrastructure-as-code for the **card-game** static site (S3 + CloudFront), **multiplayer** HTTP + WebSocket API Gateway v2 + Lambdas, **DynamoDB** rooms table, and optional **custom TLS hostnames** + **Route 53** aliases.
 
-- S3 bucket + CloudFront distribution for the static site (optional **alternate domain name** + ACM).
-- DynamoDB table for room metadata and WebSocket connections (pay-per-request, TTL enabled).
-- Two Lambda functions (`http`, `websocket`) behind API Gateway v2 (HTTP API + WebSocket API).
-- When **custom domain** is enabled: regional **API Gateway custom domain names** for `https://api.<custom_domain>` and `wss://ws.<custom_domain>/prod`.
-- When **custom domain** + **`route53_hosted_zone_id`** are set: **Route 53 alias** records in that zone (apex → CloudFront, `api` / `ws` → API Gateway regional targets).
-- IAM role + least-privilege inline policy.
+Human-facing setup and CI are documented in the repository **README**, **`AGENTS.md`**, and (if present locally) **`AWS_SETUP.md`** — not in this file.
 
-## Inputs you must provide
+---
 
-Either via `terraform.tfvars`, environment variables, or the GitHub deploy workflow
-(repository **secrets** supply `TF_VAR_room_jwt_secret` and backend config; see `AWS_SETUP.md`):
+## Resources (high level)
 
-- `room_jwt_secret` — any strong random string (e.g. 64 hex chars). Do not commit.
-- `http_lambda_zip`, `ws_lambda_zip` — paths to bundles produced by
-  `cd lambda && npm run build && npm run bundle` (default paths work when running from this dir).
+| Area | Resources |
+|------|-----------|
+| Site | `aws_s3_bucket.site`, OAC, bucket policy, `aws_cloudfront_distribution.site` |
+| APIs | `aws_apigatewayv2_api` (HTTP + WebSocket), integrations, routes, stages, Lambda invoke permissions |
+| Custom TLS | When `custom_domain` + `acm_certificate_arn` are set: CloudFront **aliases** + viewer cert; `aws_apigatewayv2_domain_name` + `aws_apigatewayv2_api_mapping` for `api.<custom_domain>` and `ws.<custom_domain>` |
+| DNS | When `custom_domain` + `acm_certificate_arn` + `route53_hosted_zone_id` are set: `aws_route53_record` apex **A/AAAA** → CloudFront; `api` / `ws` **A** aliases → API Gateway regional domain targets |
+| Data | `aws_dynamodb_table.rooms` (TTL) |
+| Compute | `aws_lambda_function` **http** / **ws**, log groups, IAM role + inline policy |
 
-Optional:
+**Certificate / region:** CloudFront requires an ACM cert in **`us-east-1`**. API Gateway regional custom domains use the same **`acm_certificate_arn`** in **`var.aws_region`** — use **`aws_region = "us-east-1"`** unless you split certs (not modeled as separate inputs). The cert must cover the site host and **`api.`** / **`ws.`** subdomains if those custom names are used.
 
-- `custom_domain` + `acm_certificate_arn` for the **site** hostname on CloudFront and (when both are set) for **api.*** / **ws.*** on API Gateway. The certificate must be in **`us-east-1`** for CloudFront; **`aws_region`** should be **`us-east-1`** so the **same** ACM ARN can be attached to API Gateway regional custom domain names.
-- `route53_hosted_zone_id` — Route 53 **public** hosted zone **id** (`Z…`) whose **domain name equals `custom_domain`** (e.g. zone `cardgame.example.com` when the site is `https://cardgame.example.com`). When set with a custom domain, Terraform manages DNS records in that zone.
-- `allowed_origin` — only if you must override the default (Terraform uses `https://<custom_domain>` for CORS when a custom domain is set, otherwise the CloudFront hostname).
-- `site_bucket_name` to pin a particular bucket name.
+**Route 53:** `route53_hosted_zone_id` must refer to a **public** hosted zone whose **zone name equals** `custom_domain` (Terraform creates relative names `""`, `api`, `ws` under that zone). Apex cannot be a plain CNAME; aliases use Route 53 **alias A/AAAA** to CloudFront and **alias A** to API Gateway `regional_domain_name` / `regional_hosted_zone_id`.
 
-## Example: `cardgame.michaelj43.dev` (delegated zone in Route 53)
+**Lambda env:** HTTP Lambda `ALLOWED_ORIGIN` / CORS follow `site_browser_origin` in `site.tf` (`allowed_origin` override, else `https://<custom_domain>`, else CloudFront URL). `WS_PUBLIC_URL` switches to the vanity **`wss://ws.<custom_domain>/<ws_stage>`** when a custom domain is enabled (`lambda.tf`).
 
-Use a **public hosted zone** for exactly `cardgame.michaelj43.dev` (NS-delegated from your registrar or Cloudflare). The ACM certificate should include at least **`cardgame.michaelj43.dev`** and **`*.cardgame.michaelj43.dev`** so **api.** / **ws.** subdomains are valid for TLS.
+---
 
-### 1. ACM certificate (must be **us-east-1**)
+## Inputs
 
-CloudFront only accepts certificates in `us-east-1`. This stack attaches the same ARN to API Gateway when `custom_domain` is set, so keep **`aws_region = "us-east-1"`** unless you maintain a **separate** regional ACM ARN (not implemented as a separate variable today).
+Defined in **`variables.tf`**. Required for any apply: **`room_jwt_secret`**; Lambda zip paths default under `lambda/dist/`.
 
-1. AWS Console → **Certificate Manager** → **N. Virginia (us-east-1)** → **Request certificate** → **DNS validation**.
-2. Add names such as **`cardgame.michaelj43.dev`** and **`*.cardgame.michaelj43.dev`**.
-3. Add the validation CNAMEs in the **authoritative** DNS for those names (your delegated Route 53 zone and/or parent zone, depending on ACM’s required record names).
-4. Wait until the certificate is **Issued**; copy the **ARN**.
+Notable optional inputs:
 
-### 2. Terraform / GitHub Actions
+- **`custom_domain`**, **`acm_certificate_arn`** — enable CloudFront alternate name + API Gateway custom domains + vanity-oriented outputs.
+- **`route53_hosted_zone_id`** — manage the DNS records above (only with custom domain + cert).
+- **`allowed_origin`** — override browser origin string for CORS / Lambda when non-empty.
+- **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
 
-The **Deploy** workflow exports optional `TF_VAR_*` only when the corresponding GitHub **Variable** or **Secret** is non-empty (so Terraform still sees `null` when you omit them).
+---
 
-**Variables** — **Settings → Secrets and variables → Actions → Variables**:
+## State backend
 
-| Variable | Example value | Required? |
-|----------|----------------|-----------|
-| `TF_CUSTOM_DOMAIN` | `cardgame.michaelj43.dev` | For custom hostnames |
-| `TF_ALLOWED_ORIGIN` | *(omit unless needed)* | Optional exact CORS / Lambda origin override |
+`versions.tf` declares **`backend "s3" {}`**. Pass **`-backend-config=...`** at `terraform init` (see workflow or local init examples in **`versions.tf`** comments). CI supplies bucket, key, region, and DynamoDB lock table.
 
-**Secrets** — **Settings → Secrets and variables → Actions → Secrets** (values are masked in the UI and not printed by the workflow):
+---
 
-| Secret | Example value | Required? |
-|--------|----------------|-----------|
-| `TF_ACM_CERTIFICATE_ARN` | `arn:aws:acm:us-east-1:…:certificate/…` | With `TF_CUSTOM_DOMAIN` |
-| `TF_ROUTE53_HOSTED_ZONE_ID` | `Z0ABCDEF123456` | Optional — set to let Terraform create **Route 53** alias records (see below) |
+## Outputs
 
-If you previously stored **`TF_ACM_CERTIFICATE_ARN`** or **`TF_ROUTE53_HOSTED_ZONE_ID`** as repository **Variables**, move them to **Secrets** with the same names and delete the old variables so only one binding exists.
+| Output | Meaning |
+|--------|---------|
+| `site_bucket` | S3 bucket name for static assets |
+| `cloudfront_distribution_id` | For `create-invalidation` |
+| `cloudfront_domain` | `*.cloudfront.net` hostname |
+| `site_url` | `https://<custom_domain>` when configured, else `https://<cloudfront_domain>` |
+| `http_api_url` | `https://api.<custom_domain>` when custom domain is on, else HTTP API `api_endpoint` |
+| `ws_api_url` | `wss://ws.<custom_domain>/<stage>` when custom domain is on, else default **execute-api** WebSocket URL |
+| `rooms_table` | DynamoDB table name |
 
-**Route 53:** In Route 53 → **Hosted zones** → open the zone whose name is exactly your `TF_CUSTOM_DOMAIN` → copy **Hosted zone ID** into the **`TF_ROUTE53_HOSTED_ZONE_ID`** secret.
+The site build consumes **`http_api_url`** and **`ws_api_url`** as **`VITE_MULTIPLAYER_HTTP_URL`** / **`VITE_MULTIPLAYER_WS_URL`** when those env vars are not overridden in CI.
 
-Terraform will then:
+---
 
-- Attach the certificate to CloudFront and set the alternate domain name to `cardgame.michaelj43.dev`.
-- Create **API Gateway** custom domains **`api.cardgame.michaelj43.dev`** and **`ws.cardgame.michaelj43.dev`** mapped to your HTTP and WebSocket APIs.
-- Create **Route 53** alias **A** (and **AAAA** for the apex only) records: apex → CloudFront, `api` → HTTP API regional domain, `ws` → WebSocket API regional domain.
-- Set CORS / **`ALLOWED_ORIGIN`** and the HTTP Lambda **`WS_PUBLIC_URL`** to the vanity WebSocket URL when a custom domain is enabled.
+## Source layout
 
-If you **omit** the **`TF_ROUTE53_HOSTED_ZONE_ID`** secret, you must still point **DNS** for the apex, **api.**, and **ws.** at CloudFront / API Gateway yourself (same targets Terraform would have used).
-
-**Apex DNS note:** You cannot use a plain **CNAME** at the zone apex. Use **Route 53 alias A/AAAA** to CloudFront (Terraform does this when the zone id is set).
-
-### 3. Multiplayer URLs in the static build
-
-Terraform outputs **`http_api_url`** and **`ws_api_url`** as:
-
-- **`https://api.<custom_domain>`** and **`wss://ws.<custom_domain>/prod`** when a custom domain is enabled, otherwise the default **execute-api** URLs.
-
-The deploy workflow passes those into **`VITE_MULTIPLAYER_*`** unless you override repository **Variables** `VITE_MULTIPLAYER_HTTP_URL` / `VITE_MULTIPLAYER_WS_URL`.
-
-### 4. Smoke test
-
-1. Open `https://cardgame.michaelj43.dev` (TLS + DNS after apply).
-2. **Online play** → Host / Join; **Network** tab should show `POST` to `https://api.cardgame…/rooms` (or your custom domain) without CORS errors.
-
-## Remote state
-
-`versions.tf` declares a stubbed `backend "s3" {}` block. Supply backend configuration via
-`-backend-config` flags during `terraform init` (the GitHub Actions workflow passes these).
-
-Example manual init:
-
-```bash
-terraform init \
-  -backend-config=bucket=<your-tfstate-bucket> \
-  -backend-config=key=card-game/terraform.tfstate \
-  -backend-config=region=us-east-1 \
-  -backend-config=dynamodb_table=<your-tfstate-lock-table>
-```
-
-## Outputs consumed by the site build
-
-- `http_api_url` → `VITE_MULTIPLAYER_HTTP_URL`
-- `ws_api_url` → `VITE_MULTIPLAYER_WS_URL`
-
-The GitHub Actions deploy workflow wires this automatically after `terraform apply`.
+| File | Role |
+|------|------|
+| `main.tf` | Naming, tags, `random_id` |
+| `versions.tf` | Terraform / provider versions; default **`aws`** provider in `var.aws_region`; aliased **`aws.us_east_1`** (currently unused by resources — cert is passed by ARN) |
+| `variables.tf` | Input variables |
+| `outputs.tf` | Outputs |
+| `site.tf` | S3 site bucket, OAC, CloudFront, locals for custom domain / browser origin / Route 53 flags |
+| `route53.tf` | Conditional Route 53 alias records |
+| `apigateway.tf` | HTTP + WebSocket APIs, optional custom domain names + mappings |
+| `lambda.tf` | Lambdas, env, log groups |
+| `iam.tf` | Execution role + policies |
+| `dynamodb.tf` | Rooms table |

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -19,7 +19,65 @@ Either via `terraform.tfvars`, environment variables, or the GitHub deploy workf
 Optional:
 
 - `custom_domain` + `acm_certificate_arn` (must be in `us-east-1`) for a vanity hostname.
+- `allowed_origin` — only if you must override the default (Terraform uses `https://<custom_domain>` for CORS when a custom domain is set, otherwise the CloudFront hostname).
 - `site_bucket_name` to pin a particular bucket name.
+
+## Example: `cardgame.michaelj43.dev` (subdomain only)
+
+Use this when the **apex** `michaelj43.dev` already points elsewhere; only the **subdomain** serves this app.
+
+### 1. ACM certificate (must be **us-east-1**)
+
+CloudFront only accepts certificates in `us-east-1`.
+
+1. AWS Console → **Certificate Manager** → region **N. Virginia (us-east-1)** → **Request certificate**.
+2. Choose **Request a public certificate** → fully qualified domain name: **`cardgame.michaelj43.dev`** (DNS validation).
+3. In **Route 53** (if your zone is there) click **Create records in Route 53** for the validation CNAMEs.  
+   If DNS for `michaelj43.dev` lives at **Cloudflare, Namecheap, etc.**, add the **same** CNAME records there instead.
+4. Wait until the certificate status is **Issued** and copy the **ARN** (e.g. `arn:aws:acm:us-east-1:123456789012:certificate/…`).
+
+You do **not** need a separate Route 53 public hosted zone for the subdomain if you already manage `michaelj43.dev` somewhere.
+
+### 2. DNS record for the live site
+
+After the first Terraform apply **with** the custom domain (step 3), CloudFront gives you a distribution domain like `d1111abcdef8.cloudfront.net`.
+
+Create a **DNS record** for `cardgame` → **CNAME** (or an **ALIAS/A** if your DNS provider supports aliasing to CloudFront) pointing to that CloudFront hostname:
+
+| Type | Name / host | Target |
+|------|----------------|--------|
+| **CNAME** | `cardgame` | `dxxxx.cloudfront.net` (from AWS Console → CloudFront → distribution → domain name) |
+
+TTL: 300s while testing, then longer.
+
+### 3. Terraform / GitHub Actions
+
+The **Deploy** workflow exports optional `TF_VAR_*` only when repository **Variables** are non-empty (so Terraform still sees `null` when you are not using a custom domain).
+
+In GitHub: **Settings → Secrets and variables → Actions → Variables** (repository), add:
+
+| Variable | Example value |
+|----------|----------------|
+| `TF_CUSTOM_DOMAIN` | `cardgame.michaelj43.dev` |
+| `TF_ACM_CERTIFICATE_ARN` | `arn:aws:acm:us-east-1:…:certificate/…` |
+| `TF_ALLOWED_ORIGIN` | *(optional)* Only if you need an exact origin string different from `https://cardgame.michaelj43.dev` (e.g. trailing slash quirks). Usually **omit**. |
+
+Then run **Deploy** (push to `main` or **Actions → Deploy → Run workflow**). Terraform will:
+
+- Attach the certificate to CloudFront and set the **alternate domain name** to `cardgame.michaelj43.dev`.
+- Set API Gateway CORS and the HTTP Lambda **`ALLOWED_ORIGIN`** to `https://cardgame.michaelj43.dev` automatically when the custom domain is active.
+
+### 4. Multiplayer URLs in the static build
+
+The site bundle still needs the API Gateway URLs. Either:
+
+- Leave **repository Variables** `VITE_MULTIPLAYER_HTTP_URL` / `VITE_MULTIPLAYER_WS_URL` **unset** so each deploy uses the Terraform outputs from that run, or  
+- Set them once to stable values from the **Deploy** job summary (recommended if URLs rarely change).
+
+### 5. Smoke test
+
+1. Open `https://cardgame.michaelj43.dev` (TLS should succeed once DNS + cert propagate).
+2. **Online play** → Host / Join; browser devtools **Network** tab should show `POST` to your HTTP API without CORS errors (origin = `https://cardgame.michaelj43.dev`).
 
 ## Remote state
 

--- a/deploy/terraform/aws/apigateway.tf
+++ b/deploy/terraform/aws/apigateway.tf
@@ -4,7 +4,7 @@ resource "aws_apigatewayv2_api" "http" {
   protocol_type = "HTTP"
 
   cors_configuration {
-    allow_origins = [coalesce(var.allowed_origin, "https://${aws_cloudfront_distribution.site.domain_name}")]
+    allow_origins = [local.site_browser_origin]
     allow_methods = ["POST", "OPTIONS"]
     allow_headers = ["content-type"]
     max_age       = 600

--- a/deploy/terraform/aws/apigateway.tf
+++ b/deploy/terraform/aws/apigateway.tf
@@ -95,3 +95,49 @@ resource "aws_lambda_permission" "ws_invoke" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.ws.execution_arn}/*/*"
 }
+
+# Regional custom hostnames (TLS) for api.<custom_domain> and ws.<custom_domain>.
+# Certificate must be in the same region as var.aws_region (same ARN as CloudFront when aws_region = us-east-1).
+resource "aws_apigatewayv2_domain_name" "http" {
+  count = local.use_custom_domain ? 1 : 0
+
+  domain_name = "api.${local.custom_domain_host}"
+
+  domain_name_configuration {
+    certificate_arn = trimspace(var.acm_certificate_arn)
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_apigatewayv2_domain_name" "ws" {
+  count = local.use_custom_domain ? 1 : 0
+
+  domain_name = "ws.${local.custom_domain_host}"
+
+  domain_name_configuration {
+    certificate_arn = trimspace(var.acm_certificate_arn)
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_apigatewayv2_api_mapping" "http" {
+  count = local.use_custom_domain ? 1 : 0
+
+  api_id      = aws_apigatewayv2_api.http.id
+  domain_name = aws_apigatewayv2_domain_name.http[0].domain_name
+  stage       = aws_apigatewayv2_stage.http.name
+}
+
+resource "aws_apigatewayv2_api_mapping" "ws" {
+  count = local.use_custom_domain ? 1 : 0
+
+  api_id      = aws_apigatewayv2_api.ws.id
+  domain_name = aws_apigatewayv2_domain_name.ws[0].domain_name
+  stage       = aws_apigatewayv2_stage.ws.name
+}

--- a/deploy/terraform/aws/lambda.tf
+++ b/deploy/terraform/aws/lambda.tf
@@ -24,9 +24,9 @@ resource "aws_lambda_function" "http" {
 
   environment {
     variables = {
-      ROOMS_TABLE      = aws_dynamodb_table.rooms.name
-      ROOM_JWT_SECRET  = var.room_jwt_secret
-      WS_PUBLIC_URL    = "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+      ROOMS_TABLE     = aws_dynamodb_table.rooms.name
+      ROOM_JWT_SECRET = var.room_jwt_secret
+      WS_PUBLIC_URL = local.use_custom_domain ? "wss://ws.${local.custom_domain_host}/${aws_apigatewayv2_stage.ws.name}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
       ALLOWED_ORIGIN   = local.site_browser_origin
       ROOM_TTL_SECONDS = tostring(var.room_ttl_seconds)
     }

--- a/deploy/terraform/aws/lambda.tf
+++ b/deploy/terraform/aws/lambda.tf
@@ -27,7 +27,7 @@ resource "aws_lambda_function" "http" {
       ROOMS_TABLE      = aws_dynamodb_table.rooms.name
       ROOM_JWT_SECRET  = var.room_jwt_secret
       WS_PUBLIC_URL    = "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
-      ALLOWED_ORIGIN   = coalesce(var.allowed_origin, "https://${aws_cloudfront_distribution.site.domain_name}")
+      ALLOWED_ORIGIN   = local.site_browser_origin
       ROOM_TTL_SECONDS = tostring(var.room_ttl_seconds)
     }
   }

--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -19,13 +19,13 @@ output "site_url" {
 }
 
 output "http_api_url" {
-  description = "HTTP API endpoint (POST /rooms, /rooms/join)."
-  value       = aws_apigatewayv2_api.http.api_endpoint
+  description = "HTTP API base URL for VITE_MULTIPLAYER_HTTP_URL: vanity https://api.<custom_domain> when custom domain is enabled, else execute-api URL."
+  value       = local.use_custom_domain ? "https://api.${local.custom_domain_host}" : aws_apigatewayv2_api.http.api_endpoint
 }
 
 output "ws_api_url" {
-  description = "WebSocket API endpoint for signaling."
-  value       = "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+  description = "WebSocket URL for VITE_MULTIPLAYER_WS_URL: vanity wss://ws.<custom_domain>/<stage> when custom domain is enabled, else execute-api URL."
+  value       = local.use_custom_domain ? "wss://ws.${local.custom_domain_host}/${aws_apigatewayv2_stage.ws.name}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
 }
 
 output "rooms_table" {

--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -15,7 +15,7 @@ output "cloudfront_domain" {
 
 output "site_url" {
   description = "Public site URL."
-  value       = local.use_custom_domain ? "https://${var.custom_domain}" : "https://${aws_cloudfront_distribution.site.domain_name}"
+  value       = local.use_custom_domain ? "https://${local.custom_domain_host}" : "https://${aws_cloudfront_distribution.site.domain_name}"
 }
 
 output "http_api_url" {

--- a/deploy/terraform/aws/route53.tf
+++ b/deploy/terraform/aws/route53.tf
@@ -1,0 +1,58 @@
+# Public DNS in Route 53 when the hosted zone domain equals custom_domain
+# (e.g. zone "cardgame.michaelj43.dev" for site https://cardgame.michaelj43.dev).
+
+resource "aws_route53_record" "site_apex_a" {
+  count = local.create_route53_records ? 1 : 0
+
+  zone_id = local.route53_zone_id
+  name    = ""
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "site_apex_aaaa" {
+  count = local.create_route53_records ? 1 : 0
+
+  zone_id = local.route53_zone_id
+  name    = ""
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "http_api_a" {
+  count = local.create_route53_records ? 1 : 0
+
+  zone_id = local.route53_zone_id
+  name    = "api"
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.http[0].regional_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.http[0].regional_hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "ws_api_a" {
+  count = local.create_route53_records ? 1 : 0
+
+  zone_id = local.route53_zone_id
+  name    = "ws"
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.ws[0].regional_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.ws[0].regional_hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/deploy/terraform/aws/site.tf
+++ b/deploy/terraform/aws/site.tf
@@ -35,6 +35,8 @@ resource "aws_cloudfront_origin_access_control" "site" {
 locals {
   custom_domain_host = var.custom_domain != null ? trimspace(var.custom_domain) : ""
   use_custom_domain    = local.custom_domain_host != "" && var.acm_certificate_arn != null && trimspace(var.acm_certificate_arn) != ""
+  route53_zone_id      = var.route53_hosted_zone_id != null ? trimspace(var.route53_hosted_zone_id) : ""
+  create_route53_records = local.use_custom_domain && local.route53_zone_id != ""
   # Browser Origin header for CORS / Lambda: explicit override, else HTTPS custom host, else CloudFront hostname.
   site_browser_origin = coalesce(
     var.allowed_origin != null && trimspace(var.allowed_origin) != "" ? trimspace(var.allowed_origin) : null,

--- a/deploy/terraform/aws/site.tf
+++ b/deploy/terraform/aws/site.tf
@@ -33,7 +33,14 @@ resource "aws_cloudfront_origin_access_control" "site" {
 }
 
 locals {
-  use_custom_domain = var.custom_domain != null && var.acm_certificate_arn != null
+  custom_domain_host = var.custom_domain != null ? trimspace(var.custom_domain) : ""
+  use_custom_domain    = local.custom_domain_host != "" && var.acm_certificate_arn != null && trimspace(var.acm_certificate_arn) != ""
+  # Browser Origin header for CORS / Lambda: explicit override, else HTTPS custom host, else CloudFront hostname.
+  site_browser_origin = coalesce(
+    var.allowed_origin != null && trimspace(var.allowed_origin) != "" ? trimspace(var.allowed_origin) : null,
+    local.use_custom_domain ? "https://${local.custom_domain_host}" : null,
+    "https://${aws_cloudfront_distribution.site.domain_name}",
+  )
 }
 
 resource "aws_cloudfront_distribution" "site" {
@@ -43,7 +50,7 @@ resource "aws_cloudfront_distribution" "site" {
   comment             = "${local.name} static site"
   price_class         = "PriceClass_100"
 
-  aliases = local.use_custom_domain ? [var.custom_domain] : []
+  aliases = local.use_custom_domain ? [local.custom_domain_host] : []
 
   origin {
     domain_name              = aws_s3_bucket.site.bucket_regional_domain_name

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -29,7 +29,13 @@ variable "custom_domain" {
 }
 
 variable "acm_certificate_arn" {
-  description = "ACM cert ARN in us-east-1 for custom_domain. Required when custom_domain is set."
+  description = "ACM public cert ARN used for CloudFront (must be in us-east-1) and, when custom_domain is set, for API Gateway custom domains api./ws. (must be in the same region as aws_region — use us-east-1 for both). Must cover custom_domain and api.* / ws.* (e.g. include *.cardgame.example.com)."
+  type        = string
+  default     = null
+}
+
+variable "route53_hosted_zone_id" {
+  description = "Optional Route 53 public hosted zone id (e.g. Z…) whose domain name equals custom_domain. When set with custom_domain + acm_certificate_arn, creates alias records: apex → CloudFront, api → HTTP API, ws → WebSocket API."
   type        = string
   default     = null
 }

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -35,7 +35,7 @@ variable "acm_certificate_arn" {
 }
 
 variable "allowed_origin" {
-  description = "Allowed browser origin for the HTTP API (defaults to CloudFront distribution)."
+  description = "Override browser Origin for API CORS + Lambda ALLOWED_ORIGIN. Leave null to use https://<custom_domain> when set, else the CloudFront *.cloudfront.net hostname."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## What this PR does
- **Terraform:** site_browser_origin drives API Gateway CORS + HTTP Lambda \ALLOWED_ORIGIN\ — defaults to \https://<custom_domain>\ when CloudFront uses a custom cert, so browsers loading \https://cardgame.michaelj43.dev\ pass CORS without a separate \llowed_origin\ variable.
- **GitHub Actions:** Deploy exports \TF_VAR_custom_domain\, \TF_VAR_acm_certificate_arn\, and optional \TF_VAR_allowed_origin\ only when repository **Variables** are non-empty.
- **Docs:** Expanded \deploy/terraform/aws/README.md\ with an end-to-end **\cardgame.michaelj43.dev\** checklist (ACM us-east-1, DNS CNAME, Variables, smoke test). \README\ + \AGENTS.md\ pointers. \AWS_SETUP.md\ is gitignored locally; mirror text lives in the deploy README.

## Your checklist (AWS + DNS + GitHub)
1. **ACM (us-east-1):** Public cert for \cardgame.michaelj43.dev\, DNS validation records at your DNS host for \michaelj43.dev\.
2. **GitHub → Settings → Secrets and variables → Actions → Variables:** \TF_CUSTOM_DOMAIN\ = \cardgame.michaelj43.dev\, \TF_ACM_CERTIFICATE_ARN\ = cert ARN.
3. **Merge + run Deploy** (or push to \main\).
4. **DNS:** CNAME \cardgame\ → CloudFront distribution hostname from AWS console.
5. **Optional:** Set \VITE_MULTIPLAYER_HTTP_URL\ / \VITE_MULTIPLAYER_WS_URL\ as Variables for stable multiplayer endpoints.

Made with [Cursor](https://cursor.com)