### PR TITLE
fix(lambda): PostToConnection endpoint for WebSocket custom domains

### DIFF
--- a/lambda/src/websocket.test.ts
+++ b/lambda/src/websocket.test.ts
@@ -1,0 +1,41 @@
+import type { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda'
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { managementApiEndpoint } from './websocket'
+
+describe('managementApiEndpoint', () => {
+  const prevRegion = process.env.AWS_REGION
+
+  beforeEach(() => {
+    process.env.AWS_REGION = 'us-east-1'
+  })
+
+  afterEach(() => {
+    if (prevRegion === undefined) delete process.env.AWS_REGION
+    else process.env.AWS_REGION = prevRegion
+  })
+
+  it('uses execute-api hostname when apiId and AWS_REGION are set (custom domain safe)', () => {
+    const event = {
+      requestContext: {
+        apiId: 'abc123def',
+        domainName: 'ws.example.com',
+        stage: 'prod',
+      },
+    } as unknown as APIGatewayProxyWebsocketEventV2
+    expect(managementApiEndpoint(event)).toBe(
+      'https://abc123def.execute-api.us-east-1.amazonaws.com/prod',
+    )
+  })
+
+  it('falls back to domainName/stage when apiId is missing', () => {
+    const event = {
+      requestContext: {
+        domainName: 'abc123def.execute-api.us-east-1.amazonaws.com',
+        stage: 'prod',
+      },
+    } as unknown as APIGatewayProxyWebsocketEventV2
+    expect(managementApiEndpoint(event)).toBe(
+      'https://abc123def.execute-api.us-east-1.amazonaws.com/prod',
+    )
+  })
+})

--- a/lambda/src/websocket.ts
+++ b/lambda/src/websocket.ts
@@ -20,10 +20,30 @@ import {
   type ConnectionRecord,
 } from './storage'
 
+/**
+ * API Gateway Management API (@connections) endpoint for PostToConnection.
+ * Must use the execute-api hostname (`{apiId}.execute-api.{region}.amazonaws.com/{stage}`),
+ * even when clients connected via a custom domain. Using `domainName` from the event with a
+ * vanity host + `/prod` breaks PostToConnection (welcome/relay never reach peers).
+ * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html
+ */
+export function managementApiEndpoint(event: APIGatewayProxyWebsocketEventV2): string {
+  const ctx = event.requestContext as {
+    apiId?: string
+    domainName: string
+    stage: string
+  }
+  const { domainName, stage } = ctx
+  const apiId = ctx.apiId
+  const region = process.env.AWS_REGION
+  if (apiId && region) {
+    return `https://${apiId}.execute-api.${region}.amazonaws.com/${stage}`
+  }
+  return `https://${domainName}/${stage}`
+}
+
 function mgmtClient(event: APIGatewayProxyWebsocketEventV2): ApiGatewayManagementApiClient {
-  const { domainName, stage } = event.requestContext
-  const endpoint = `https://${domainName}/${stage}`
-  return new ApiGatewayManagementApiClient({ endpoint })
+  return new ApiGatewayManagementApiClient({ endpoint: managementApiEndpoint(event) })
 }
 
 function getJwtSecret(): string {


### PR DESCRIPTION
## Problem
With a vanity WebSocket host (\ws.*\), the Lambda built the API Gateway Management API client as \https://\/\\ (e.g. \https://ws.example.com/prod\). That is not a valid \@connections\ base URL, so \PostToConnection\ failed and clients never received \welcome\ / relay messages after a successful 101 handshake.

## Change
Build the Management API endpoint from \equestContext.apiId\, \AWS_REGION\, and \stage\ (\https://{apiId}.execute-api.{region}.amazonaws.com/{stage}\), which works for both default and custom-domain connections.

## Testing
- \
pm test\ in \lambda/\ (includes new \websocket.test.ts\).

Made with [Cursor](https://cursor.com)