### PR TITLE
feat(multiplayer): TURN EC2 lifecycle, idle abandon, room-closing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,7 @@ jobs:
       - name: Lambda tests
         working-directory: lambda
         run: npm run test
+
+      - name: Lambda bundle (zips for deploy parity)
+        working-directory: lambda
+        run: npm run bundle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,7 @@ only on the Terraform step output in the same job:
 
 - `VITE_MULTIPLAYER_HTTP_URL` — same value as `terraform output -raw http_api_url` (no trailing slash).
 - `VITE_MULTIPLAYER_WS_URL` — same value as `terraform output -raw ws_api_url` (with a custom domain this is `wss://ws.<custom_domain>` with **no** `/prod` path; the default execute-api URL still uses `/prod`).
+- Optional **coturn on EC2** (Terraform `turn_ec2_enabled`): after apply, set **`VITE_MULTIPLAYER_TURN_HOST`** (see `terraform output turn_hostname`), **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`, **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**=`terraform output -raw turn_coturn_static_password`. Or **`VITE_MULTIPLAYER_ICE_JSON`** for full `RTCIceServer[]` control.
 
 Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for that run. Copy the two lines from the last successful **Deploy** job summary into Variables once, then re-run **Deploy** (or push) so CloudFront serves a bundle with multiplayer enabled.
 
@@ -304,9 +305,7 @@ Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable
 
 ### Future backlog (not in this PR)
 
-- **TURN relay** for symmetric-NAT / strict-firewall peers (STUN-only may
-  fail). Plan is to add an env-configured managed TURN (Twilio, Cloudflare, or
-  self-hosted coturn) behind a feature flag.
+- **Managed third-party TURN** (Twilio, etc.) with short-lived credentials if you outgrow the optional **Terraform coturn EC2** path (`turn_ec2_enabled`).
 - **Per-game host-broadcast integration**: wire each supported game module’s
   `applyAction` output into `RoomHost.broadcastSnapshot` with per-seat
   redaction of hidden information (opponent hands).

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -15,7 +15,8 @@ Human-facing setup and CI are documented in the repository **README**, **`AGENTS
 | Custom TLS | When `custom_domain` + `acm_certificate_arn` are set: CloudFront **aliases** + viewer cert; `aws_apigatewayv2_domain_name` + `aws_apigatewayv2_api_mapping` for `api.<custom_domain>` and `ws.<custom_domain>` |
 | DNS | When `custom_domain` + `acm_certificate_arn` + `route53_hosted_zone_id` are set: `aws_route53_record` apex **A/AAAA** → CloudFront; `api` / `ws` **A** aliases → API Gateway regional domain targets |
 | Data | `aws_dynamodb_table.rooms` (TTL) |
-| Compute | `aws_lambda_function` **http** / **ws**, log groups, IAM role + inline policy |
+| Compute | `aws_lambda_function` **http** / **ws** (+ optional **turn-scheduled**), log groups, IAM role + inline policy (+ optional **turn** inline policy) |
+| Optional TURN | When **`turn_ec2_enabled`** and Route 53 are on: coturn **EC2** (default VPC), **`turn.<custom_domain>`** A record (placeholder `127.0.0.1`; **HTTP Lambda** overwrites with public IP after `/turn/start`), EventBridge **15m** → idle-stop Lambda. **No EIP** (avoids EIP hourly charge while instance is stopped). |
 
 **Certificate / region:** CloudFront requires an ACM cert in **`us-east-1`**. API Gateway regional custom domains use the same **`acm_certificate_arn`** in **`var.aws_region`** — use **`aws_region = "us-east-1"`** unless you split certs (not modeled as separate inputs). The cert must cover the site host and **`api.`** / **`ws.`** subdomains if those custom names are used.
 
@@ -35,6 +36,7 @@ Notable optional inputs:
 - **`route53_hosted_zone_id`** — manage the DNS records above (only with custom domain + cert).
 - **`allowed_origin`** — override browser origin string for CORS / Lambda when non-empty.
 - **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
+- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**.
 
 ---
 
@@ -57,6 +59,10 @@ Notable optional inputs:
 | `rooms_table` | DynamoDB table name |
 | `http_regional_domain_name` | `d-…execute-api…` target for the **HTTP** custom domain (compare to Route 53 `api` alias) |
 | `ws_regional_domain_name` | `d-…execute-api…` target for the **WebSocket** custom domain (compare to Route 53 `ws` alias) |
+| `turn_hostname` | e.g. `turn.<custom_domain>` when TURN stack is enabled; else `null` |
+| `turn_coturn_static_password` | Sensitive coturn password (user **`cardgame`** in user-data); set **`VITE_MULTIPLAYER_TURN_CREDENTIAL`** to match at site build |
+
+**TURN / DNS:** After `terraform apply` with TURN on, run **`terraform output -raw turn_coturn_static_password`** once, configure GitHub Variables **`VITE_MULTIPLAYER_TURN_HOST`** (= `turn_hostname`), **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`, **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**=that password, then redeploy the site. The HTTP Lambda waits for **EC2 status checks OK** before updating Route 53; the scheduled Lambda stops the instance only after **4h uptime** and **15m** without usage heartbeats (see app).
 
 The site build consumes **`http_api_url`** and **`ws_api_url`** as **`VITE_MULTIPLAYER_HTTP_URL`** / **`VITE_MULTIPLAYER_WS_URL`** when those env vars are not overridden in CI.
 
@@ -78,3 +84,4 @@ If **`wss://ws.<domain>/prod` returns 403** but **`wss://ws.<domain>` connects**
 | `lambda.tf` | Lambdas, env, log groups |
 | `iam.tf` | Execution role + policies |
 | `dynamodb.tf` | Rooms table |
+| `turn.tf` | Optional coturn EC2, SG, Route 53 `turn` A, IAM for EC2/R53, scheduled Lambda + EventBridge |

--- a/deploy/terraform/aws/apigateway.tf
+++ b/deploy/terraform/aws/apigateway.tf
@@ -5,7 +5,7 @@ resource "aws_apigatewayv2_api" "http" {
 
   cors_configuration {
     allow_origins = [local.site_browser_origin]
-    allow_methods = ["POST", "OPTIONS"]
+    allow_methods = ["GET", "POST", "OPTIONS"]
     allow_headers = ["content-type"]
     max_age       = 600
   }
@@ -30,6 +30,30 @@ resource "aws_apigatewayv2_route" "http_create" {
 resource "aws_apigatewayv2_route" "http_join" {
   api_id    = aws_apigatewayv2_api.http.id
   route_key = "POST /rooms/join"
+  target    = "integrations/${aws_apigatewayv2_integration.http.id}"
+}
+
+resource "aws_apigatewayv2_route" "http_turn_status" {
+  api_id    = aws_apigatewayv2_api.http.id
+  route_key = "GET /turn/status"
+  target    = "integrations/${aws_apigatewayv2_integration.http.id}"
+}
+
+resource "aws_apigatewayv2_route" "http_turn_start" {
+  api_id    = aws_apigatewayv2_api.http.id
+  route_key = "POST /turn/start"
+  target    = "integrations/${aws_apigatewayv2_integration.http.id}"
+}
+
+resource "aws_apigatewayv2_route" "http_turn_heartbeat" {
+  api_id    = aws_apigatewayv2_api.http.id
+  route_key = "POST /turn/heartbeat"
+  target    = "integrations/${aws_apigatewayv2_integration.http.id}"
+}
+
+resource "aws_apigatewayv2_route" "http_abandon_idle" {
+  api_id    = aws_apigatewayv2_api.http.id
+  route_key = "POST /rooms/abandon-idle"
   target    = "integrations/${aws_apigatewayv2_integration.http.id}"
 }
 

--- a/deploy/terraform/aws/lambda.tf
+++ b/deploy/terraform/aws/lambda.tf
@@ -10,6 +10,17 @@ resource "aws_cloudwatch_log_group" "ws" {
   tags              = local.common_tags
 }
 
+locals {
+  http_lambda_env_turn = local.turn_stack ? {
+    TURN_EC2_INSTANCE_ID     = aws_instance.turn[0].id
+    TURN_ROUTE53_ZONE_ID      = local.route53_zone_id
+    TURN_ROUTE53_RECORD_NAME  = "turn.${local.custom_domain_host}"
+    WS_MANAGEMENT_API_URL     = "https://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+    TURN_MAX_UPTIME_SECONDS   = "14400"
+    TURN_USAGE_GRACE_SECONDS   = "900"
+  } : {}
+}
+
 resource "aws_lambda_function" "http" {
   function_name = "${local.name}-http"
   role          = aws_iam_role.lambda.arn
@@ -20,16 +31,19 @@ resource "aws_lambda_function" "http" {
   source_code_hash = filebase64sha256(var.http_lambda_zip)
 
   memory_size = 256
-  timeout     = 10
+  timeout     = local.turn_stack ? 180 : 10
 
   environment {
-    variables = {
-      ROOMS_TABLE     = aws_dynamodb_table.rooms.name
-      ROOM_JWT_SECRET = var.room_jwt_secret
-      WS_PUBLIC_URL = local.use_custom_domain ? "wss://ws.${local.custom_domain_host}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
-      ALLOWED_ORIGIN   = local.site_browser_origin
-      ROOM_TTL_SECONDS = tostring(var.room_ttl_seconds)
-    }
+    variables = merge(
+      {
+        ROOMS_TABLE     = aws_dynamodb_table.rooms.name
+        ROOM_JWT_SECRET = var.room_jwt_secret
+        WS_PUBLIC_URL = local.use_custom_domain ? "wss://ws.${local.custom_domain_host}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+        ALLOWED_ORIGIN   = local.site_browser_origin
+        ROOM_TTL_SECONDS = tostring(var.room_ttl_seconds)
+      },
+      local.http_lambda_env_turn,
+    )
   }
 
   depends_on = [aws_cloudwatch_log_group.http]

--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -42,3 +42,14 @@ output "ws_regional_domain_name" {
   description = "Regional API Gateway hostname for the WebSocket custom domain (Route 53 `ws` alias target must match exactly)."
   value       = local.use_custom_domain ? aws_apigatewayv2_domain_name.ws[0].domain_name_configuration[0].target_domain_name : null
 }
+
+output "turn_hostname" {
+  description = "FQDN for coturn when turn_ec2_enabled (use as VITE_MULTIPLAYER_TURN_HOST); null otherwise."
+  value       = local.turn_stack ? "turn.${local.custom_domain_host}" : null
+}
+
+output "turn_coturn_static_password" {
+  description = "Static coturn long-term credential password (sensitive). Set VITE_MULTIPLAYER_TURN_CREDENTIAL to match at build time; user is cardgame."
+  value       = try(random_password.turn_coturn[0].result, null)
+  sensitive   = true
+}

--- a/deploy/terraform/aws/site.tf
+++ b/deploy/terraform/aws/site.tf
@@ -37,6 +37,8 @@ locals {
   use_custom_domain    = local.custom_domain_host != "" && var.acm_certificate_arn != null && trimspace(var.acm_certificate_arn) != ""
   route53_zone_id      = var.route53_hosted_zone_id != null ? trimspace(var.route53_hosted_zone_id) : ""
   create_route53_records = local.use_custom_domain && local.route53_zone_id != ""
+  /** Optional coturn EC2 + turn.* DNS + scheduled stop (requires Route 53 on custom domain). */
+  turn_stack = var.turn_ec2_enabled && local.create_route53_records
   # Never call trimspace(null): Terraform may evaluate both branches of a ternary / coalesce args.
   allowed_origin_trimmed = var.allowed_origin != null ? trimspace(var.allowed_origin) : ""
   # Browser Origin header for CORS / Lambda: explicit override, else HTTPS custom host, else CloudFront hostname.

--- a/deploy/terraform/aws/turn-user-data.sh.tpl
+++ b/deploy/terraform/aws/turn-user-data.sh.tpl
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+dnf install -y coturn
+cat >/etc/turnserver.conf <<TURNCONF
+listening-port=3478
+no-tls
+fingerprint
+lt-cred-mech
+no-cli
+no-tlsv1
+no-tlsv1_1
+realm=${realm}
+user=${turn_user}:${turn_password}
+min-port=49152
+max-port=65535
+simple-log
+log-file=/var/log/turnserver.log
+TURNCONF
+systemctl enable coturn
+systemctl restart coturn

--- a/deploy/terraform/aws/turn.tf
+++ b/deploy/terraform/aws/turn.tf
@@ -1,0 +1,189 @@
+# Optional coturn EC2 + turn.<custom_domain> A record + EventBridge idle scheduler.
+# Requires: custom_domain, Route 53 zone, turn_ec2_enabled = true.
+
+data "aws_vpc" "default" {
+  count   = local.turn_stack ? 1 : 0
+  default = true
+}
+
+data "aws_subnets" "default" {
+  count = local.turn_stack ? 1 : 0
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default[0].id]
+  }
+}
+
+data "aws_ami" "al2023_x86" {
+  count       = local.turn_stack ? 1 : 0
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-202*-kernel-6.1-x86_64"]
+  }
+}
+
+resource "random_password" "turn_coturn" {
+  count   = local.turn_stack ? 1 : 0
+  length  = 24
+  special = false
+}
+
+resource "aws_security_group" "turn" {
+  count       = local.turn_stack ? 1 : 0
+  name        = "${local.name}-coturn"
+  description = "coturn STUN/TURN for card-game multiplayer"
+  vpc_id      = data.aws_vpc.default[0].id
+
+  ingress {
+    description = "TURN/STUN"
+    from_port   = 3478
+    to_port     = 3478
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    description = "TURN/STUN TCP"
+    from_port   = 3478
+    to_port     = 3478
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    description = "TURN relay UDP range"
+    from_port   = 49152
+    to_port     = 65535
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { CARDGAME_TURN_LINK = "coturn" })
+}
+
+resource "aws_instance" "turn" {
+  count                       = local.turn_stack ? 1 : 0
+  ami                         = data.aws_ami.al2023_x86[0].id
+  instance_type               = var.turn_instance_type
+  subnet_id                   = sort(tolist(data.aws_subnets.default[0].ids))[0]
+  vpc_security_group_ids      = [aws_security_group.turn[0].id]
+  associate_public_ip_address = true
+
+  user_data = base64encode(templatefile("${path.module}/turn-user-data.sh.tpl", {
+    realm         = local.custom_domain_host
+    turn_user     = "cardgame"
+    turn_password = random_password.turn_coturn[0].result
+  }))
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = merge(local.common_tags, {
+    Name               = "${local.name}-coturn"
+    CARDGAME_TURN_LINK = "coturn"
+  })
+}
+
+# Placeholder A; Lambda overwrites with live public IP on /turn/start (ignore drift).
+resource "aws_route53_record" "turn_a" {
+  count   = local.turn_stack ? 1 : 0
+  zone_id = local.route53_zone_id
+  name    = "turn"
+  type    = "A"
+  ttl     = 60
+  records = ["127.0.0.1"]
+
+  lifecycle {
+    ignore_changes = [records]
+  }
+}
+
+data "aws_iam_policy_document" "lambda_turn" {
+  count = local.turn_stack ? 1 : 0
+  statement {
+    sid = "TurnEc2"
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+    ]
+    resources = [aws_instance.turn[0].arn]
+  }
+  statement {
+    sid       = "TurnRoute53"
+    actions   = ["route53:ChangeResourceRecordSets"]
+    resources = ["arn:aws:route53:::hostedzone/${local.route53_zone_id}"]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_turn" {
+  count  = local.turn_stack ? 1 : 0
+  name   = "${local.name}-lambda-turn"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda_turn[0].json
+}
+
+resource "aws_cloudwatch_log_group" "turn_scheduled" {
+  count             = local.turn_stack ? 1 : 0
+  name              = "/aws/lambda/${local.name}-turn-scheduled"
+  retention_in_days = 14
+  tags              = local.common_tags
+}
+
+resource "aws_lambda_function" "turn_scheduled" {
+  count = local.turn_stack ? 1 : 0
+
+  function_name = "${local.name}-turn-scheduled"
+  role          = aws_iam_role.lambda.arn
+  runtime       = "nodejs20.x"
+  handler       = "turnScheduled.handler"
+
+  filename         = var.scheduled_lambda_zip
+  source_code_hash = filebase64sha256(var.scheduled_lambda_zip)
+
+  memory_size = 128
+  timeout     = 60
+
+  environment {
+    variables = {
+      ROOMS_TABLE               = aws_dynamodb_table.rooms.name
+      TURN_EC2_INSTANCE_ID      = aws_instance.turn[0].id
+      TURN_MAX_UPTIME_SECONDS     = "14400"
+      TURN_USAGE_GRACE_SECONDS    = "900"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.turn_scheduled]
+  tags       = local.common_tags
+}
+
+resource "aws_cloudwatch_event_rule" "turn_poll" {
+  count               = local.turn_stack ? 1 : 0
+  name                = "${local.name}-turn-poll"
+  schedule_expression = "rate(15 minutes)"
+  tags                = local.common_tags
+}
+
+resource "aws_cloudwatch_event_target" "turn_scheduled" {
+  count = local.turn_stack ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.turn_poll[0].name
+  arn   = aws_lambda_function.turn_scheduled[0].arn
+}
+
+resource "aws_lambda_permission" "turn_scheduled_events" {
+  count         = local.turn_stack ? 1 : 0
+  statement_id  = "AllowEventBridgeTurnPoll"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.turn_scheduled[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.turn_poll[0].arn
+}

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -87,3 +87,21 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "turn_ec2_enabled" {
+  description = "When true (and custom_domain + Route 53 are configured), provisions a coturn EC2, turn.* A record (placeholder; Lambda updates IP on start), scheduled idle-stop Lambda, and extends HTTP Lambda IAM for EC2/Route53."
+  type        = bool
+  default     = false
+}
+
+variable "turn_instance_type" {
+  description = "Instance type for the optional coturn EC2 (e.g. t3.micro)."
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "scheduled_lambda_zip" {
+  description = "Path to turnScheduled.zip from lambda/scripts/bundle.mjs."
+  type        = string
+  default     = "../../../lambda/dist/turnScheduled.zip"
+}

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -48,6 +48,10 @@ The inline display-name input uses theme-aligned borders/background (`--border`,
 
 **Open chat** (compact and expanded multiplayer rows) uses the same button classes. It is available whenever you are in a room (host or joined client); it stays disabled only while **spectating**. Behavior of the chat window and main-window toasts is documented in [`multiplayer-chat.md`](multiplayer-chat.md).
 
+## Multiplayer idle warning (inactivity)
+
+When online play is active, a full-screen **`.multiplayerIdleModal__*`** overlay can appear after extended **keyboard/pointer** inactivity. It shows a **countdown**, a **Dismiss** button using **`app__btnSecondary` + `app__btnToolbar`**, and **backdrop click** dismisses the same way as Dismiss (resets the idle timer). See [`MultiplayerIdleModal.tsx`](../src/ui/MultiplayerIdleModal.tsx).
+
 ## When you change something
 
 1. Prefer reusing **`app__btnSecondary` + `app__btnToolbar`** for new shell-adjacent buttons instead of one-off panel button styles.

--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.651.0",
         "@aws-sdk/client-dynamodb": "^3.651.0",
+        "@aws-sdk/client-ec2": "^3.651.0",
+        "@aws-sdk/client-route-53": "^3.651.0",
         "@aws-sdk/lib-dynamodb": "^3.651.0",
         "jsonwebtoken": "^9.0.2"
       },
@@ -250,10 +252,114 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ec2": {
+      "version": "3.1033.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1033.0.tgz",
+      "integrity": "sha512-IxLs8wMJtM+HprEsZedNfJlriPGj4FRfTjogYhUAWz6uPgFKEHOq6o6/86EXjipJZC8wM8mVAI4a1/bRWoT2lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/credential-provider-node": "^3.972.33",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-ec2": "^3.972.20",
+        "@aws-sdk/middleware-user-agent": "^3.972.32",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.18",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53": {
+      "version": "3.1033.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.1033.0.tgz",
+      "integrity": "sha512-GBuNmP8lgC4lTDvCFlnP0LulrYvfH2im7u/iokug32p7t6P8RQl/+1NIo4zpxEzR6KMcMHul8s7c1GpFWjHyyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/credential-provider-node": "^3.972.33",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-route53": "^3.972.12",
+        "@aws-sdk/middleware-user-agent": "^3.972.32",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.18",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.1.tgz",
-      "integrity": "sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.2.tgz",
+      "integrity": "sha512-oav5AOAz+1XkwUfp6SrEm42UPDpUP5D4jNYXkDwFR1VfWqYX62+jpytdfzURmJ9McSoJIQwi0OJlC4oCi6t0VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -275,12 +381,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.27.tgz",
-      "integrity": "sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.28.tgz",
+      "integrity": "sha512-87GdRJ2OR0qR4VkMjXN/SZi66DZsunW2qQCbtw9rKw3Y7JurFi6tQWYKOSLY/gOADrU6OxGqFmdw3hKzZqDZOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -291,12 +397,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.29.tgz",
-      "integrity": "sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.30.tgz",
+      "integrity": "sha512-6quozmW2PKwBJTUQLb+lk1q8w5Pm45qaqhx4Tld9EIqYYQOVGj+MT0a8NRVS7QgWJj7rzGlB7rQu3KYBFHemJw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/node-http-handler": "^4.5.3",
@@ -312,19 +418,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.31.tgz",
-      "integrity": "sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.32.tgz",
+      "integrity": "sha512-Nkr+UKtczZlocUjc6g96WzQadZSIZO/HVXPki4qbfaVOZYSbfLQKWKfADtJ0kGYsCvSYOZrO66tSc9dkboUt/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/credential-provider-env": "^3.972.27",
-        "@aws-sdk/credential-provider-http": "^3.972.29",
-        "@aws-sdk/credential-provider-login": "^3.972.31",
-        "@aws-sdk/credential-provider-process": "^3.972.27",
-        "@aws-sdk/credential-provider-sso": "^3.972.31",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/credential-provider-env": "^3.972.28",
+        "@aws-sdk/credential-provider-http": "^3.972.30",
+        "@aws-sdk/credential-provider-login": "^3.972.32",
+        "@aws-sdk/credential-provider-process": "^3.972.28",
+        "@aws-sdk/credential-provider-sso": "^3.972.32",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -337,13 +443,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.31.tgz",
-      "integrity": "sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.32.tgz",
+      "integrity": "sha512-UxgwT1HmZz1QPXuBy5ZUPJNFXOSlhwdQL61eGhWRthF0xRrT02BCOVJ1p5Ejg5AXfnESTWoKPJ7v/sCkNUtB9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -356,17 +462,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.32.tgz",
-      "integrity": "sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.33.tgz",
+      "integrity": "sha512-6pGQnEdSeRvBViTQh/FwaRKB38a3Th+W2mVxuvqAd2Z1Ayo3e6eJ5QqJoZwEMwR6xoxkl3wz3qAfiB1xRhMC+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.27",
-        "@aws-sdk/credential-provider-http": "^3.972.29",
-        "@aws-sdk/credential-provider-ini": "^3.972.31",
-        "@aws-sdk/credential-provider-process": "^3.972.27",
-        "@aws-sdk/credential-provider-sso": "^3.972.31",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+        "@aws-sdk/credential-provider-env": "^3.972.28",
+        "@aws-sdk/credential-provider-http": "^3.972.30",
+        "@aws-sdk/credential-provider-ini": "^3.972.32",
+        "@aws-sdk/credential-provider-process": "^3.972.28",
+        "@aws-sdk/credential-provider-sso": "^3.972.32",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -379,12 +485,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.27.tgz",
-      "integrity": "sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.28.tgz",
+      "integrity": "sha512-CRAlD8u6oNBhjnX/3ekVGocarD+lFmEn/qeDzytgIdmwrmwMJGFPqS9lGwEfhOTihZKrQ0xSp3z6paX+iXJJhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -396,14 +502,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.31.tgz",
-      "integrity": "sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.32.tgz",
+      "integrity": "sha512-whhmQghRYOt9mJxFyVMhX7eB8n0oA25OCvqoR7dzFAZjmioCkf7WVB22Bc6llM5cFpBXFX7s4Jv+xVq32VPGWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
-        "@aws-sdk/token-providers": "3.1032.0",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/token-providers": "3.1033.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -415,13 +521,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.31.tgz",
-      "integrity": "sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.32.tgz",
+      "integrity": "sha512-Z0Y0LDaqyQDznlmr9gv6n4+eWKKWNgmi9j5L6RENr6wyOCguhO8FRPmqDbVLSw0DPdMqICKnA3PurJiS8bD6Cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -543,13 +649,71 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.31.tgz",
-      "integrity": "sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==",
+    "node_modules/@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.20.tgz",
+      "integrity": "sha512-nmkwdX9ImAvVtzBl65GzttDUV6GUL3KNbDs0nk3XYQS6KdQnxuGnvirw1CTCsDrMJOQgMmKY3TEHc0r+zZGc0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-route53": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.972.12.tgz",
+      "integrity": "sha512-nj08j4q/Rp8zb3SqwxE+dex22NdXoSKJAh445x0SLGAI23lYfDTujFDG1JRYLRc1uR2/FPPr76L/ki/VE4J9ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.31.tgz",
+      "integrity": "sha512-5hS08Fp0Rm+59uGCmkWhZmveXiA7OUV7Wa+IARejdzf9JTZ1qAVeIOE9JoBpsLPvUgEjmsGNHBuFbtGmYyqiqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.32.tgz",
+      "integrity": "sha512-HQ0x9DDKqLZOGhDiL2eicYXXkYT5dogE4mw0lAfHCpJ6t7MM0PNIsJl2TZzWKU9SpBzOMXHRa7K6ZLKUJu1y0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.7",
         "@smithy/core": "^3.23.15",
@@ -563,23 +727,24 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.21.tgz",
-      "integrity": "sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==",
+      "version": "3.997.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.0.tgz",
+      "integrity": "sha512-4bI5GHjUiY5R8N6PtchpG6tW2Dl8I2IcZNg3JwqwxHRXjfvQlPoo4VMknG4qkd5W0t3Y20rQ6C7pSR561YG5JQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/middleware-user-agent": "^3.972.32",
         "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.19",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.7",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.17",
+        "@aws-sdk/util-user-agent-node": "^3.973.18",
         "@smithy/config-resolver": "^4.4.16",
         "@smithy/core": "^3.23.15",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -627,14 +792,31 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1032.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1032.0.tgz",
-      "integrity": "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==",
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.19.tgz",
+      "integrity": "sha512-7Sy8+GhfwUi06NQNLplxuJuXMKJURDsNQfK8yTW6E9wN2J1B+8S5dWZG7vg3InvPPhaXqkcYTr8pzeE+dLjMbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.31",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1033.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1033.0.tgz",
+      "integrity": "sha512-/TsXhqjyRAFb0xVgmbFAha3cJfZdWjnyn6ohJ3AB4E3peLgxNcmKfYr45hruHymyJAydiHoXC3N1a8qgl41cog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -652,6 +834,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -689,6 +883,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
@@ -714,12 +923,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.17.tgz",
-      "integrity": "sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==",
+      "version": "3.973.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.18.tgz",
+      "integrity": "sha512-Nh4YvAL0Mzv5jBvzXLFL0tLf7WPrRMnYZQ5jlFuyS0xiVJQsObMUKAkbYjmt/e04wpQqUaa+Is7k+mBr89A9yA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/middleware-user-agent": "^3.972.32",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.651.0",
+    "@aws-sdk/client-ec2": "^3.651.0",
+    "@aws-sdk/client-route-53": "^3.651.0",
     "@aws-sdk/client-dynamodb": "^3.651.0",
     "@aws-sdk/lib-dynamodb": "^3.651.0",
     "jsonwebtoken": "^9.0.2"

--- a/lambda/scripts/bundle.mjs
+++ b/lambda/scripts/bundle.mjs
@@ -1,6 +1,6 @@
 // Produces deployable zip bundles for each Lambda handler.
 // Run after `npm run build` (creates dist/).
-// Output: dist/http.zip, dist/websocket.zip
+// Output: dist/http.zip, dist/websocket.zip, dist/turnScheduled.zip
 
 import { execSync } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
@@ -20,7 +20,6 @@ if (!existsSync(dist)) {
 
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
 
-// Write a minimal package.json inside dist so node_modules resolves at runtime.
 writeFileSync(
   resolve(dist, 'package.json'),
   JSON.stringify(
@@ -35,19 +34,16 @@ writeFileSync(
   ) + '\n',
 )
 
-// Install production deps into dist/node_modules
 execSync('npm install --omit=dev --silent --no-audit --no-fund', { cwd: dist, stdio: 'inherit' })
 
-async function zipHandler(entry, zipName) {
+async function zipPackage(files, zipName) {
   const out = resolve(dist, zipName)
   const output = createWriteStream(out)
   const archive = archiver('zip', { zlib: { level: 9 } })
   archive.pipe(output)
-  archive.file(resolve(dist, entry), { name: entry })
-  archive.file(resolve(dist, 'auth.js'), { name: 'auth.js' })
-  archive.file(resolve(dist, 'storage.js'), { name: 'storage.js' })
-  archive.file(resolve(dist, 'roomCode.js'), { name: 'roomCode.js' })
-  archive.file(resolve(dist, 'package.json'), { name: 'package.json' })
+  for (const f of files) {
+    archive.file(resolve(dist, f), { name: f })
+  }
   archive.directory(resolve(dist, 'node_modules'), 'node_modules')
   await new Promise((res, rej) => {
     output.on('close', res)
@@ -59,5 +55,27 @@ async function zipHandler(entry, zipName) {
 
 mkdirSync(dist, { recursive: true })
 
-await zipHandler('http.js', 'http.zip')
-await zipHandler('websocket.js', 'websocket.zip')
+const common = ['package.json']
+
+await zipPackage(
+  [
+    'http.js',
+    'auth.js',
+    'storage.js',
+    'roomCode.js',
+    'turnHttpHandlers.js',
+    'turnState.js',
+    'turnEc2Ops.js',
+    'wsRoomNotify.js',
+    'turnBackoff.js',
+    ...common,
+  ],
+  'http.zip',
+)
+
+await zipPackage(['websocket.js', 'auth.js', 'storage.js', 'roomCode.js', ...common], 'websocket.zip')
+
+await zipPackage(
+  ['turnScheduled.js', 'turnState.js', 'turnEc2Ops.js', 'turnBackoff.js', 'storage.js', ...common],
+  'turnScheduled.zip',
+)

--- a/lambda/src/http.ts
+++ b/lambda/src/http.ts
@@ -3,11 +3,12 @@ import { randomBytes } from 'node:crypto'
 import { signRoomToken } from './auth'
 import { generateRoomCode } from './roomCode'
 import {
-  getRoom,
-  putRoom,
-  ttlSecondsFromNow,
-  type RoomMeta,
-} from './storage'
+  handleGetTurnStatus,
+  handlePostAbandonIdle,
+  handlePostTurnHeartbeat,
+  handlePostTurnStart,
+} from './turnHttpHandlers'
+import { getRoom, putRoom, ttlSecondsFromNow, type RoomMeta } from './storage'
 
 const JSON_HEADERS = {
   'content-type': 'application/json',
@@ -18,7 +19,7 @@ function cors(origin?: string) {
   const match = allowed === '*' || !origin ? allowed : allowed.split(',').map((o) => o.trim()).includes(origin) ? origin : allowed
   return {
     'access-control-allow-origin': match,
-    'access-control-allow-methods': 'POST,OPTIONS',
+    'access-control-allow-methods': 'GET,POST,OPTIONS',
     'access-control-allow-headers': 'content-type',
     vary: 'Origin',
   }
@@ -67,7 +68,6 @@ interface JoinRoomRequest {
   roomCode?: string
 }
 
-/** URL-safe ~12-char suffix; avoids nanoid (ESM-only in v5) under Lambda CommonJS `require`. */
 function randomPeerSuffix(): string {
   return randomBytes(9).toString('base64url').slice(0, 12)
 }
@@ -81,20 +81,28 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
     return { statusCode: 204, headers: { ...cors(origin) } }
   }
 
-  if (method !== 'POST') return bad(405, 'Method not allowed', origin)
-
-  let body: unknown = {}
-  if (event.body) {
-    try {
-      body = JSON.parse(event.body)
-    } catch {
-      return bad(400, 'Malformed JSON', origin)
-    }
-  }
-
   try {
-    if (path.endsWith('/rooms')) return await handleCreateRoom(body as CreateRoomRequest, origin)
+    if (method === 'GET' && path.endsWith('/turn/status')) {
+      return await handleGetTurnStatus(origin)
+    }
+
+    if (method !== 'POST') return bad(405, 'Method not allowed', origin)
+
+    let body: unknown = {}
+    if (event.body) {
+      try {
+        body = JSON.parse(event.body)
+      } catch {
+        return bad(400, 'Malformed JSON', origin)
+      }
+    }
+
+    if (path.endsWith('/rooms/abandon-idle')) return await handlePostAbandonIdle(body as { token?: string }, origin)
     if (path.endsWith('/rooms/join')) return await handleJoinRoom(body as JoinRoomRequest, origin)
+    if (path.endsWith('/rooms')) return await handleCreateRoom(body as CreateRoomRequest, origin)
+    if (path.endsWith('/turn/start')) return await handlePostTurnStart(origin)
+    if (path.endsWith('/turn/heartbeat')) return await handlePostTurnHeartbeat(body as { token?: string }, origin)
+
     return bad(404, 'Not found', origin)
   } catch (err) {
     console.error('http handler error', err)

--- a/lambda/src/storage.ts
+++ b/lambda/src/storage.ts
@@ -151,3 +151,17 @@ export async function listConnections(roomCode: string): Promise<ConnectionRecor
 export function ttlSecondsFromNow(seconds: number): number {
   return Math.floor(Date.now() / 1000) + seconds
 }
+
+/** Delete all CONN rows for a room, index rows, and ROOM META (after optional WS notify). */
+export async function deleteRoomCascade(roomCode: string): Promise<void> {
+  const peers = await listConnections(roomCode)
+  for (const p of peers) {
+    await deleteConnection(roomCode, p.connectionId)
+  }
+  await ddb.send(
+    new DeleteCommand({
+      TableName: TABLE(),
+      Key: { pk: roomPk(roomCode), sk: 'META' },
+    }),
+  )
+}

--- a/lambda/src/turnBackoff.test.ts
+++ b/lambda/src/turnBackoff.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { backoffDelayMs } from './turnBackoff'
+
+describe('backoffDelayMs', () => {
+  it('doubles with stage and caps at 24h', () => {
+    expect(backoffDelayMs(0)).toBe(15 * 60 * 1000)
+    expect(backoffDelayMs(1)).toBe(30 * 60 * 1000)
+    expect(backoffDelayMs(10)).toBe(24 * 60 * 60 * 1000)
+  })
+})

--- a/lambda/src/turnBackoff.ts
+++ b/lambda/src/turnBackoff.ts
@@ -1,0 +1,4 @@
+/** Next delay before another poll while TURN EC2 is stopped (capped at 24h). */
+export function backoffDelayMs(stage: number): number {
+  return Math.min(15 * 60 * 1000 * 2 ** stage, 24 * 60 * 60 * 1000)
+}

--- a/lambda/src/turnEc2Ops.ts
+++ b/lambda/src/turnEc2Ops.ts
@@ -1,0 +1,92 @@
+import {
+  DescribeInstanceStatusCommand,
+  DescribeInstancesCommand,
+  EC2Client,
+  StartInstancesCommand,
+  StopInstancesCommand,
+} from '@aws-sdk/client-ec2'
+import { ChangeResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53'
+
+const ec2 = () => new EC2Client({})
+const r53 = () => new Route53Client({})
+
+export function turnInstanceId(): string | undefined {
+  const id = process.env.TURN_EC2_INSTANCE_ID?.trim()
+  return id && id.length > 0 ? id : undefined
+}
+
+export function turnRoute53Config(): { hostedZoneId: string; recordName: string } | undefined {
+  const z = process.env.TURN_ROUTE53_ZONE_ID?.trim()
+  const n = process.env.TURN_ROUTE53_RECORD_NAME?.trim()
+  if (!z || !n) return undefined
+  return { hostedZoneId: z, recordName: n.endsWith('.') ? n.slice(0, -1) : n }
+}
+
+export async function describeInstanceState(
+  instanceId: string,
+): Promise<{ state: string | undefined; publicIp: string | undefined; launchTime: Date | undefined }> {
+  const res = await ec2().send(new DescribeInstancesCommand({ InstanceIds: [instanceId] }))
+  const inst = res.Reservations?.[0]?.Instances?.[0]
+  return {
+    state: inst?.State?.Name,
+    publicIp: inst?.PublicIpAddress,
+    launchTime: inst?.LaunchTime,
+  }
+}
+
+export async function instanceStatusChecksOk(instanceId: string): Promise<boolean> {
+  const res = await ec2().send(new DescribeInstanceStatusCommand({ InstanceIds: [instanceId], IncludeAllInstances: true }))
+  const st = res.InstanceStatuses?.[0]
+  if (!st) return false
+  const sys = st.SystemStatus?.Status
+  const ins = st.InstanceStatus?.Status
+  return sys === 'ok' && ins === 'ok'
+}
+
+export async function startTurnInstance(instanceId: string): Promise<void> {
+  await ec2().send(new StartInstancesCommand({ InstanceIds: [instanceId] }))
+}
+
+export async function stopTurnInstance(instanceId: string): Promise<void> {
+  await ec2().send(new StopInstancesCommand({ InstanceIds: [instanceId] }))
+}
+
+/** Poll until running, has public IP, and status checks ok (or timeout). */
+export async function waitForRunningReady(
+  instanceId: string,
+  opts: { maxWaitMs: number; pollMs: number },
+): Promise<{ publicIp: string } | { error: string }> {
+  const deadline = Date.now() + opts.maxWaitMs
+  while (Date.now() < deadline) {
+    const { state, publicIp } = await describeInstanceState(instanceId)
+    if (state === 'running' && publicIp) {
+      const ok = await instanceStatusChecksOk(instanceId)
+      if (ok) return { publicIp }
+    }
+    await new Promise((r) => setTimeout(r, opts.pollMs))
+  }
+  return { error: 'timeout waiting for instance ready' }
+}
+
+export async function upsertTurnARecord(hostedZoneId: string, recordName: string, ipv4: string): Promise<void> {
+  const name = recordName.endsWith('.') ? recordName : `${recordName}.`
+  await r53().send(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Comment: 'card-game TURN EC2 public IP',
+        Changes: [
+          {
+            Action: 'UPSERT',
+            ResourceRecordSet: {
+              Name: name,
+              Type: 'A',
+              TTL: 60,
+              ResourceRecords: [{ Value: ipv4 }],
+            },
+          },
+        ],
+      },
+    }),
+  )
+}

--- a/lambda/src/turnHttpHandlers.ts
+++ b/lambda/src/turnHttpHandlers.ts
@@ -1,0 +1,180 @@
+import { verifyRoomToken } from './auth'
+import { deleteRoomCascade, getRoom, listConnections } from './storage'
+import {
+  describeInstanceState,
+  instanceStatusChecksOk,
+  startTurnInstance,
+  turnInstanceId,
+  turnRoute53Config,
+  upsertTurnARecord,
+  waitForRunningReady,
+} from './turnEc2Ops'
+import {
+  ensureLiveRow,
+  ensureSchedulerRowExists,
+  getSchedulerState,
+  putSchedulerState,
+  resetSchedulerBackoff,
+  TURN_SCHEDULER_PK,
+  TURN_SCHEDULER_SK,
+  touchUsageHeartbeat,
+  type TurnSchedulerState,
+} from './turnState'
+import { broadcastRoomClosingToConnections } from './wsRoomNotify'
+
+const JSON_HEADERS = { 'content-type': 'application/json' }
+
+function cors(origin: string | undefined, allowed: string) {
+  const match =
+    allowed === '*' || !origin
+      ? allowed
+      : allowed.split(',').map((o) => o.trim()).includes(origin)
+        ? origin
+        : allowed
+  return {
+    'access-control-allow-origin': match,
+    'access-control-allow-methods': 'GET,POST,OPTIONS',
+    'access-control-allow-headers': 'content-type',
+    vary: 'Origin',
+  }
+}
+
+function bad(status: number, message: string, origin?: string) {
+  const allowed = process.env.ALLOWED_ORIGIN ?? '*'
+  return {
+    statusCode: status,
+    headers: { ...JSON_HEADERS, ...cors(origin, allowed) },
+    body: JSON.stringify({ message }),
+  }
+}
+
+function ok(body: unknown, origin?: string) {
+  const allowed = process.env.ALLOWED_ORIGIN ?? '*'
+  return {
+    statusCode: 200,
+    headers: { ...JSON_HEADERS, ...cors(origin, allowed) },
+    body: JSON.stringify(body),
+  }
+}
+
+function jwtSecret(): string {
+  const s = process.env.ROOM_JWT_SECRET
+  if (!s) throw new Error('ROOM_JWT_SECRET env var not set')
+  return s
+}
+
+export async function handleGetTurnStatus(origin?: string) {
+  const instanceId = turnInstanceId()
+  if (!instanceId) return ok({ enabled: false, reason: 'not_configured' }, origin)
+  try {
+    await ensureSchedulerRowExists()
+    const sched = await getSchedulerState()
+    const { state, publicIp } = await describeInstanceState(instanceId)
+    if (state !== 'running') {
+      return ok(
+        {
+          enabled: true,
+          state: state ?? 'unknown',
+          ready: false,
+          publicIp: publicIp ?? null,
+        },
+        origin,
+      )
+    }
+    const checksOk = await instanceStatusChecksOk(instanceId)
+    const dnsTarget = sched?.lastDnsIpv4
+    const dnsAligned = !dnsTarget || !publicIp || dnsTarget === publicIp
+    return ok(
+      {
+        enabled: true,
+        state: 'running',
+        ready: checksOk && !!publicIp && dnsAligned,
+        publicIp: publicIp ?? null,
+      },
+      origin,
+    )
+  } catch (e) {
+    console.error('turn status', e)
+    return ok({ enabled: true, state: 'error', ready: false }, origin)
+  }
+}
+
+export async function handlePostTurnStart(origin?: string) {
+  const instanceId = turnInstanceId()
+  if (!instanceId) return bad(400, 'TURN EC2 not configured', origin)
+  await ensureSchedulerRowExists()
+  await resetSchedulerBackoff()
+  try {
+    await startTurnInstance(instanceId)
+  } catch (e) {
+    console.error('start instance', e)
+    return bad(500, 'Failed to start instance', origin)
+  }
+  const ready = await waitForRunningReady(instanceId, { maxWaitMs: 180_000, pollMs: 3000 })
+  if ('error' in ready) {
+    return ok({ enabled: true, state: 'pending', ready: false, message: ready.error }, origin)
+  }
+  const r53 = turnRoute53Config()
+  if (r53) {
+    try {
+      await upsertTurnARecord(r53.hostedZoneId, r53.recordName, ready.publicIp)
+    } catch (e) {
+      console.error('route53', e)
+      return bad(500, 'Instance is up but DNS update failed', origin)
+    }
+  }
+  const prev = await getSchedulerState()
+  const next: TurnSchedulerState = {
+    pk: TURN_SCHEDULER_PK,
+    sk: TURN_SCHEDULER_SK,
+    nextPollAt: Date.now(),
+    backoffStage: 0,
+    lastInstanceState: 'running',
+    lastDnsIpv4: ready.publicIp,
+  }
+  if (prev?.lastStopAt) next.lastStopAt = prev.lastStopAt
+  await putSchedulerState(next)
+  return ok({ enabled: true, state: 'running', ready: true, publicIp: ready.publicIp, estimatedSeconds: 120 }, origin)
+}
+
+interface HeartbeatBody {
+  token?: string
+}
+
+export async function handlePostTurnHeartbeat(body: HeartbeatBody, origin?: string) {
+  const token = typeof body.token === 'string' ? body.token : ''
+  if (!token) return bad(400, 'Missing token', origin)
+  try {
+    verifyRoomToken(token, jwtSecret())
+  } catch {
+    return bad(401, 'Invalid token', origin)
+  }
+  await ensureLiveRow()
+  await touchUsageHeartbeat()
+  return ok({ ok: true }, origin)
+}
+
+interface AbandonBody {
+  token?: string
+}
+
+export async function handlePostAbandonIdle(body: AbandonBody, origin?: string) {
+  const token = typeof body.token === 'string' ? body.token : ''
+  if (!token) return bad(400, 'Missing token', origin)
+  let claims
+  try {
+    claims = verifyRoomToken(token, jwtSecret())
+  } catch {
+    return bad(401, 'Invalid token', origin)
+  }
+  if (claims.role !== 'host') return bad(403, 'Host only', origin)
+  const roomCode = claims.roomCode
+  const meta = await getRoom(roomCode)
+  if (!meta) return bad(404, 'Room not found', origin)
+  if (meta.hostPeerId !== claims.peerId) return bad(403, 'Not the room host', origin)
+
+  const peers = await listConnections(roomCode)
+  await broadcastRoomClosingToConnections(peers, { type: 'room-closing', reason: 'idle_timeout' })
+  await deleteRoomCascade(roomCode)
+  return ok({ ok: true }, origin)
+}

--- a/lambda/src/turnScheduled.ts
+++ b/lambda/src/turnScheduled.ts
@@ -1,0 +1,86 @@
+import {
+  advanceBackoffWhenInstanceOff,
+  ensureSchedulerRowExists,
+  getLiveAggregate,
+  getSchedulerState,
+  updateSchedulerAfterStopPoll,
+} from './turnState'
+import {
+  describeInstanceState,
+  instanceStatusChecksOk,
+  stopTurnInstance,
+  turnInstanceId,
+} from './turnEc2Ops'
+
+function maxUptimeMs(): number {
+  const raw = process.env.TURN_MAX_UPTIME_SECONDS
+  const n = raw ? Number(raw) : 60 * 60 * 4
+  return Number.isFinite(n) && n > 0 ? n * 1000 : 60 * 60 * 4 * 1000
+}
+
+function usageGraceMs(): number {
+  const raw = process.env.TURN_USAGE_GRACE_SECONDS
+  const n = raw ? Number(raw) : 15 * 60
+  return Number.isFinite(n) && n > 0 ? n * 1000 : 15 * 60 * 1000
+}
+
+/**
+ * EventBridge scheduled handler: cheap no-op when nextPollAt is in the future;
+ * may stop the TURN EC2 when uptime and idle conditions match (prefer staying on).
+ */
+export const handler = async (): Promise<void> => {
+  const instanceId = turnInstanceId()
+  if (!instanceId) return
+
+  await ensureSchedulerRowExists()
+  const sched = await getSchedulerState()
+  const nextAt = sched?.nextPollAt ?? 0
+  if (Date.now() < nextAt) return
+
+  let liveLast = 0
+  try {
+    const live = await getLiveAggregate()
+    liveLast = live?.lastUsageAt ?? 0
+  } catch (e) {
+    console.warn('turn scheduled: skip stop; live read failed', e)
+    return
+  }
+
+  let state: string | undefined
+  let launchTime: Date | undefined
+  try {
+    const d = await describeInstanceState(instanceId)
+    state = d.state
+    launchTime = d.launchTime
+  } catch (e) {
+    console.warn('turn scheduled: describe failed', e)
+    return
+  }
+
+  if (state === 'stopping') return
+
+  if (state === 'stopped') {
+    await advanceBackoffWhenInstanceOff(sched?.backoffStage ?? 0)
+    return
+  }
+
+  if (state !== 'running') return
+
+  const checksOk = await instanceStatusChecksOk(instanceId)
+  if (!checksOk) return
+
+  const launchMs = launchTime?.getTime()
+  if (launchMs == null || !Number.isFinite(launchMs)) return
+
+  const now = Date.now()
+  if (now - launchMs < maxUptimeMs()) return
+
+  if (liveLast > 0 && now - liveLast < usageGraceMs()) return
+
+  try {
+    await stopTurnInstance(instanceId)
+    await updateSchedulerAfterStopPoll()
+  } catch (e) {
+    console.error('turn scheduled: stop failed', e)
+  }
+}

--- a/lambda/src/turnState.ts
+++ b/lambda/src/turnState.ts
@@ -1,0 +1,145 @@
+import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { backoffDelayMs } from './turnBackoff'
+import { ddb } from './storage'
+
+const TABLE = () => {
+  const name = process.env.ROOMS_TABLE
+  if (!name) throw new Error('ROOMS_TABLE env var is not set')
+  return name
+}
+
+export const TURN_SCHEDULER_PK = 'TURN#SCHEDULER'
+export const TURN_SCHEDULER_SK = 'STATE'
+export const TURN_LIVE_PK = 'TURN#LIVE'
+export const TURN_LIVE_SK = 'AGG'
+
+export interface TurnSchedulerState {
+  pk: typeof TURN_SCHEDULER_PK
+  sk: typeof TURN_SCHEDULER_SK
+  /** Epoch ms — Lambda returns immediately if Date.now() < nextPollAt */
+  nextPollAt: number
+  backoffStage: number
+  /** Last observed EC2 state name (pending, running, stopped, …) */
+  lastInstanceState?: string
+  /** Epoch ms when we last successfully issued StopInstances */
+  lastStopAt?: number
+  /** Last public IPv4 we wrote to Route 53 (for ready check) */
+  lastDnsIpv4?: string
+}
+
+export interface TurnLiveAggregate {
+  pk: typeof TURN_LIVE_PK
+  sk: typeof TURN_LIVE_SK
+  /** Max of all client usage heartbeats */
+  lastUsageAt: number
+}
+
+export async function getSchedulerState(): Promise<TurnSchedulerState | undefined> {
+  const res = await ddb.send(
+    new GetCommand({
+      TableName: TABLE(),
+      Key: { pk: TURN_SCHEDULER_PK, sk: TURN_SCHEDULER_SK },
+    }),
+  )
+  return res.Item as TurnSchedulerState | undefined
+}
+
+export async function putSchedulerState(state: TurnSchedulerState): Promise<void> {
+  await ddb.send(new PutCommand({ TableName: TABLE(), Item: state }))
+}
+
+/** Reset backoff after user starts EC2 (or first deploy). */
+export async function resetSchedulerBackoff(): Promise<void> {
+  const now = Date.now()
+  await ddb.send(
+    new UpdateCommand({
+      TableName: TABLE(),
+      Key: { pk: TURN_SCHEDULER_PK, sk: TURN_SCHEDULER_SK },
+      UpdateExpression: 'SET nextPollAt = :n, backoffStage = :z',
+      ExpressionAttributeValues: { ':n': now, ':z': 0 },
+    }),
+  )
+}
+
+export async function ensureSchedulerRowExists(): Promise<void> {
+  const existing = await getSchedulerState()
+  if (existing) return
+  const initial: TurnSchedulerState = {
+    pk: TURN_SCHEDULER_PK,
+    sk: TURN_SCHEDULER_SK,
+    nextPollAt: 0,
+    backoffStage: 0,
+  }
+  await ddb.send(
+    new PutCommand({
+      TableName: TABLE(),
+      Item: initial,
+      ConditionExpression: 'attribute_not_exists(pk)',
+    }),
+  ).catch(() => {})
+}
+
+export async function updateSchedulerAfterStopPoll(): Promise<void> {
+  const now = Date.now()
+  await ddb.send(
+    new UpdateCommand({
+      TableName: TABLE(),
+      Key: { pk: TURN_SCHEDULER_PK, sk: TURN_SCHEDULER_SK },
+      UpdateExpression: 'SET nextPollAt = :n',
+      ExpressionAttributeValues: { ':n': now + 15 * 60 * 1000 },
+    }),
+  )
+}
+
+/** While EC2 is off, space out future polls, then bump stage. */
+export async function advanceBackoffWhenInstanceOff(stage: number): Promise<void> {
+  const delayMs = backoffDelayMs(stage)
+  const nextPollAt = Date.now() + delayMs
+  const nextStage = Math.min(stage + 1, 10)
+  await ddb.send(
+    new UpdateCommand({
+      TableName: TABLE(),
+      Key: { pk: TURN_SCHEDULER_PK, sk: TURN_SCHEDULER_SK },
+      UpdateExpression: 'SET nextPollAt = :n, backoffStage = :s',
+      ExpressionAttributeValues: { ':n': nextPollAt, ':s': nextStage },
+    }),
+  )
+}
+
+export async function getLiveAggregate(): Promise<TurnLiveAggregate | undefined> {
+  const res = await ddb.send(
+    new GetCommand({
+      TableName: TABLE(),
+      Key: { pk: TURN_LIVE_PK, sk: TURN_LIVE_SK },
+    }),
+  )
+  return res.Item as TurnLiveAggregate | undefined
+}
+
+export async function touchUsageHeartbeat(): Promise<void> {
+  const now = Date.now()
+  await ddb.send(
+    new UpdateCommand({
+      TableName: TABLE(),
+      Key: { pk: TURN_LIVE_PK, sk: TURN_LIVE_SK },
+      UpdateExpression: 'SET lastUsageAt = :t',
+      ExpressionAttributeValues: { ':t': now },
+    }),
+  )
+}
+
+export async function ensureLiveRow(): Promise<void> {
+  const existing = await getLiveAggregate()
+  if (existing) return
+  await ddb.send(
+    new PutCommand({
+      TableName: TABLE(),
+      Item: {
+        pk: TURN_LIVE_PK,
+        sk: TURN_LIVE_SK,
+        lastUsageAt: 0,
+      } satisfies TurnLiveAggregate,
+      ConditionExpression: 'attribute_not_exists(pk)',
+    }),
+  ).catch(() => {})
+}

--- a/lambda/src/wsRoomNotify.ts
+++ b/lambda/src/wsRoomNotify.ts
@@ -1,0 +1,35 @@
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi'
+import type { ConnectionRecord } from './storage'
+
+function wsMgmtClient(): ApiGatewayManagementApiClient | null {
+  const base = process.env.WS_MANAGEMENT_API_URL?.trim()
+  if (!base) return null
+  return new ApiGatewayManagementApiClient({ endpoint: base.replace(/\/$/, '') })
+}
+
+export async function postJsonToConnection(client: ApiGatewayManagementApiClient, connectionId: string, data: unknown) {
+  try {
+    await client.send(
+      new PostToConnectionCommand({
+        ConnectionId: connectionId,
+        Data: Buffer.from(JSON.stringify(data)),
+      }),
+    )
+  } catch (err) {
+    const code = (err as { name?: string })?.name
+    if (code !== 'GoneException') console.warn('postToConnection', code, err)
+  }
+}
+
+/** Notify every signaling connection in the room, then caller deletes Dynamo rows. */
+export async function broadcastRoomClosingToConnections(
+  peers: ConnectionRecord[],
+  message: { type: 'room-closing'; reason: string },
+): Promise<void> {
+  const client = wsMgmtClient()
+  if (!client) {
+    console.warn('WS_MANAGEMENT_API_URL not set; skipping room-closing push')
+    return
+  }
+  await Promise.all(peers.map((p) => postJsonToConnection(client, p.connectionId, message)))
+}

--- a/src/App.css
+++ b/src/App.css
@@ -851,3 +851,53 @@ fieldset.app__houseRules {
   align-items: center;
   margin-top: 0.35rem;
 }
+
+.multiplayerIdleModal__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.multiplayerIdleModal__dialog {
+  max-width: 24rem;
+  width: 100%;
+  background: var(--bg, #16171d);
+  border: 1px solid var(--border, #2e303a);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.35rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  outline: none;
+}
+
+.multiplayerIdleModal__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.multiplayerIdleModal__body {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: var(--text-h, #e8e9ef);
+}
+
+.multiplayerIdleModal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.multiplayerPanel__turnBtn--ready {
+  border-color: var(--accent-border, #6b9fff);
+  color: var(--accent-bg, #6b9fff);
+}
+
+.multiplayerPanel__turnBtn--off {
+  border-color: #f87171;
+  color: #f87171;
+}

--- a/src/net/api.ts
+++ b/src/net/api.ts
@@ -15,10 +15,23 @@ export interface JoinRoomResponse {
   wsUrl: string
 }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
+export interface TurnStatusResponse {
+  enabled: boolean
+  reason?: string
+  state?: string
+  ready?: boolean
+  publicIp?: string | null
+  message?: string
+}
+
+function httpBase(): string {
   const { httpUrl } = getMultiplayerConfig()
   if (!httpUrl) throw new Error('Multiplayer HTTP URL not configured')
-  const res = await fetch(`${httpUrl.replace(/\/$/, '')}${path}`, {
+  return httpUrl.replace(/\/$/, '')
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${httpBase()}${path}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body ?? {}),
@@ -31,11 +44,31 @@ async function post<T>(path: string, body: unknown): Promise<T> {
         message = String((data as { message: unknown }).message ?? message)
       }
     } catch {
-      // ignore JSON parse errors; fall back to status
+      // ignore
     }
     throw new Error(message)
   }
   return (await res.json()) as T
+}
+
+export async function getTurnStatus(): Promise<TurnStatusResponse> {
+  const res = await fetch(`${httpBase()}/turn/status`, { method: 'GET' })
+  if (!res.ok) {
+    return { enabled: false, reason: 'http_error' }
+  }
+  return (await res.json()) as TurnStatusResponse
+}
+
+export function startTurnServer(): Promise<TurnStatusResponse> {
+  return post<TurnStatusResponse>('/turn/start', {})
+}
+
+export function turnHeartbeat(body: { token: string }): Promise<{ ok: boolean }> {
+  return post<{ ok: boolean }>('/turn/heartbeat', body)
+}
+
+export function abandonIdleRoom(body: { token: string }): Promise<{ ok: boolean }> {
+  return post<{ ok: boolean }>('/rooms/abandon-idle', body)
 }
 
 export function createRoom(input: { gameId: string; maxClients: number }): Promise<CreateRoomResponse> {

--- a/src/net/client.ts
+++ b/src/net/client.ts
@@ -23,6 +23,8 @@ export interface RoomClientOptions {
   onAck?: (nonce: string, ok: boolean, error: string | undefined) => void
   /** Host closed the room or disconnected; stop signaling and data channel. */
   onHostEnded?: () => void
+  /** Server closed the room (e.g. idle); stop signaling and data channel. */
+  onRoomClosing?: () => void
   /** Host broadcast room chat line. */
   onChatLine?: (line: PeerHostChatLine) => void
 }
@@ -45,7 +47,9 @@ export class RoomClient {
       peerId: opts.clientPeerId,
       onStateChange: (s) => opts.onSignalingState?.(s),
       onMessage: (msg) => {
-        if (msg.type === 'welcome') {
+        if (msg.type === 'room-closing') {
+          opts.onRoomClosing?.()
+        } else if (msg.type === 'welcome') {
           this.ensureLink()
         } else if (msg.type === 'relay' && msg.to === opts.clientPeerId) {
           this.ensureLink().acceptSignal(msg.payload)

--- a/src/net/config.ts
+++ b/src/net/config.ts
@@ -4,6 +4,8 @@
  *   - VITE_MULTIPLAYER_HTTP_URL   → e.g. https://abc123.execute-api.us-east-1.amazonaws.com
  *   - VITE_MULTIPLAYER_WS_URL     → e.g. wss://def456.execute-api.us-east-1.amazonaws.com/prod, or wss://ws.example.com (no path) with API Gateway custom domain + mapping
  *   - VITE_MULTIPLAYER_STUN_URLS  → comma-separated STUN urls (default: Google public STUN)
+ *   - VITE_MULTIPLAYER_ICE_JSON   → optional JSON array of RTCIceServer objects (overrides STUN-only default)
+ *   - VITE_MULTIPLAYER_TURN_HOST / TURN_USER / TURN_CREDENTIAL → optional long-term TURN (coturn) in addition to STUN
  *
  * If HTTP/WS URLs are missing, multiplayer is disabled at runtime and the UI hides join/host.
  *
@@ -22,6 +24,37 @@ export interface MultiplayerConfig {
   httpUrl: string | undefined
   wsUrl: string | undefined
   stunUrls: string[]
+  /** Effective ICE servers for WebRTC (STUN + optional TURN). */
+  iceServers: RTCIceServer[]
+}
+
+function parseIceServersJson(): RTCIceServer[] | null {
+  const raw = envString(import.meta.env.VITE_MULTIPLAYER_ICE_JSON)
+  if (!raw) return null
+  try {
+    const v = JSON.parse(raw) as unknown
+    if (!Array.isArray(v)) return null
+    return v as RTCIceServer[]
+  } catch {
+    return null
+  }
+}
+
+function buildDefaultIceServers(stunUrls: string[]): RTCIceServer[] {
+  const fromJson = parseIceServersJson()
+  if (fromJson && fromJson.length > 0) return fromJson
+  const out: RTCIceServer[] = stunUrls.map((url) => ({ urls: url }))
+  const host = envString(import.meta.env.VITE_MULTIPLAYER_TURN_HOST)
+  const user = envString(import.meta.env.VITE_MULTIPLAYER_TURN_USER)
+  const cred = envString(import.meta.env.VITE_MULTIPLAYER_TURN_CREDENTIAL)
+  if (host && user && cred) {
+    out.push({
+      urls: [`turn:${host}:3478`],
+      username: user,
+      credential: cred,
+    })
+  }
+  return out
 }
 
 export function getMultiplayerConfig(): MultiplayerConfig {
@@ -36,6 +69,7 @@ export function getMultiplayerConfig(): MultiplayerConfig {
     httpUrl: envString(import.meta.env.VITE_MULTIPLAYER_HTTP_URL),
     wsUrl: envString(import.meta.env.VITE_MULTIPLAYER_WS_URL),
     stunUrls,
+    iceServers: buildDefaultIceServers(stunUrls),
   }
 }
 

--- a/src/net/host.ts
+++ b/src/net/host.ts
@@ -24,6 +24,8 @@ export interface RoomHostOptions {
   token: string
   onRosterChange?: (peers: HostedPeer[]) => void
   onSignalingState?: (state: SignalingState) => void
+  /** Server closed the room (idle policy); tear down multiplayer UI. */
+  onRoomClosing?: () => void
   /** Game intents, seat labels, and room chat from clients. */
   onIntent?: (
     msg: PeerClientIntent | PeerClientSetDisplayName | PeerClientChatSend,
@@ -58,7 +60,9 @@ export class RoomHost {
       peerId: opts.hostPeerId,
       onStateChange: (s) => opts.onSignalingState?.(s),
       onMessage: (msg) => {
-        if (msg.type === 'peer-joined') {
+        if (msg.type === 'room-closing') {
+          opts.onRoomClosing?.()
+        } else if (msg.type === 'peer-joined') {
           this.addClient(msg.peerId)
         } else if (msg.type === 'peer-left') {
           this.removeClient(msg.peerId)

--- a/src/net/peer.ts
+++ b/src/net/peer.ts
@@ -30,10 +30,8 @@ export class PeerLink {
 
   constructor(opts: PeerLinkOptions) {
     this.opts = opts
-    const { stunUrls } = getMultiplayerConfig()
-    this.pc = new RTCPeerConnection({
-      iceServers: stunUrls.map((url) => ({ urls: url })),
-    })
+    const { iceServers } = getMultiplayerConfig()
+    this.pc = new RTCPeerConnection({ iceServers })
 
     this.pc.addEventListener('icecandidate', (ev) => {
       if (ev.candidate) {

--- a/src/net/protocol.test.ts
+++ b/src/net/protocol.test.ts
@@ -63,6 +63,7 @@ describe('message type guards', () => {
   it('isSignalingMessage', () => {
     expect(isSignalingMessage({ type: 'hello' })).toBe(true)
     expect(isSignalingMessage({ type: 'relay' })).toBe(true)
+    expect(isSignalingMessage({ type: 'room-closing', reason: 'idle' })).toBe(true)
     expect(isSignalingMessage({ type: 'nope' })).toBe(false)
     expect(isSignalingMessage(null)).toBe(false)
   })

--- a/src/net/protocol.ts
+++ b/src/net/protocol.ts
@@ -74,6 +74,12 @@ export interface SignalingPeerLeft {
   peerId: string
 }
 
+/** Server is tearing down the room (e.g. host idle timeout); close signaling and UI session. */
+export interface SignalingRoomClosing {
+  type: 'room-closing'
+  reason: string
+}
+
 export interface SignalingError {
   type: 'error'
   code:
@@ -93,6 +99,7 @@ export type SignalingMessage =
   | SignalingRelay
   | SignalingPeerJoined
   | SignalingPeerLeft
+  | SignalingRoomClosing
   | SignalingError
 
 // ---------- Peer-to-peer (WebRTC DataChannel) ----------
@@ -227,6 +234,7 @@ export function isSignalingMessage(value: unknown): value is SignalingMessage {
     t === 'relay' ||
     t === 'peer-joined' ||
     t === 'peer-left' ||
+    t === 'room-closing' ||
     t === 'error'
   )
 }

--- a/src/ui/MultiplayerIdleModal.tsx
+++ b/src/ui/MultiplayerIdleModal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useId, useRef } from 'react'
+
+export interface MultiplayerIdleModalProps {
+  open: boolean
+  /** Seconds remaining in the countdown (e.g. 300 down to 0). */
+  secondsRemaining: number
+  onDismiss: () => void
+}
+
+/**
+ * Full-screen dimmed overlay: inactivity countdown, Dismiss, backdrop closes.
+ * Matches shell dialog styling (see docs/ui-design.md).
+ */
+export function MultiplayerIdleModal({ open, secondsRemaining, onDismiss }: MultiplayerIdleModalProps) {
+  const titleId = useId()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onDismiss])
+
+  useEffect(() => {
+    if (!open) return
+    panelRef.current?.focus()
+  }, [open])
+
+  if (!open) return null
+
+  const m = Math.floor(secondsRemaining / 60)
+  const s = secondsRemaining % 60
+  const label = `${m}:${s.toString().padStart(2, '0')}`
+
+  return (
+    <div
+      className="multiplayerIdleModal__backdrop"
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onDismiss()
+      }}
+    >
+      <div
+        ref={panelRef}
+        className="multiplayerIdleModal__dialog"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <h2 id={titleId} className="multiplayerIdleModal__title">
+          Still here?
+        </h2>
+        <p className="multiplayerIdleModal__body">
+          No activity for a while. This online session will end in <strong>{label}</strong> unless you continue playing
+          or dismiss this message.
+        </p>
+        <div className="multiplayerIdleModal__actions">
+          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => onDismiss()}>
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/MultiplayerPanel.tsx
+++ b/src/ui/MultiplayerPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { createRoom, joinRoom } from '../net/api'
+import { abandonIdleRoom, createRoom, getTurnStatus, joinRoom, startTurnServer, turnHeartbeat } from '../net/api'
 import { isMultiplayerConfigured } from '../net/config'
 import { RoomClient } from '../net/client'
 import { RoomHost, type HostedPeer } from '../net/host'
@@ -13,6 +13,7 @@ import {
 } from '../net/protocol'
 import type { PeerState } from '../net/peer'
 import type { SignalingState } from '../net/signaling'
+import { MultiplayerIdleModal } from './MultiplayerIdleModal'
 
 export interface MultiplayerNameplateProps {
   seat: number
@@ -63,6 +64,9 @@ export interface MultiplayerPanelProps {
 
 type Mode = 'idle' | 'hosting' | 'client'
 
+const IDLE_WARN_MS = 60 * 60 * 1000
+const IDLE_COUNTDOWN_SEC = 5 * 60
+
 export function MultiplayerPanel({
   gameId,
   maxClients,
@@ -92,8 +96,16 @@ export function MultiplayerPanel({
   const [peerState, setPeerState] = useState<PeerState>('new')
   const [roster, setRoster] = useState<HostedPeer[]>([])
   const [error, setError] = useState<string>('')
+  const [idleModalOpen, setIdleModalOpen] = useState(false)
+  const [idleSecondsLeft, setIdleSecondsLeft] = useState(IDLE_COUNTDOWN_SEC)
+  const [turnControlAvailable, setTurnControlAvailable] = useState(false)
+  const [turnReady, setTurnReady] = useState(false)
+  const [turnStarting, setTurnStarting] = useState(false)
   const hostRef = useRef<RoomHost | null>(null)
   const clientRef = useRef<RoomClient | null>(null)
+  const hostJwtRef = useRef<string | null>(null)
+  const clientJwtRef = useRef<string | null>(null)
+  const lastShellActivityRef = useRef(0)
 
   const configured = isMultiplayerConfigured()
 
@@ -104,24 +116,147 @@ export function MultiplayerPanel({
     else if (s === 'closed') setStatus('Disconnected from host.')
   }, [])
 
-  const teardown = useCallback((opts?: { clientKickedByHost?: boolean }) => {
+  const teardown = useCallback((opts?: { clientKickedByHost?: boolean; idleTimeout?: boolean }) => {
     const wasHost = hostRef.current !== null
     hostRef.current?.close()
     hostRef.current = null
     clientRef.current?.close()
     clientRef.current = null
+    hostJwtRef.current = null
+    clientJwtRef.current = null
     setMode('idle')
     setRoomCode('')
     setRoster([])
     setSignalingState('closed')
     setPeerState('new')
-    setStatus(opts?.clientKickedByHost ? 'Host closed the room or disconnected.' : '')
+    setIdleModalOpen(false)
+    setIdleSecondsLeft(IDLE_COUNTDOWN_SEC)
+    setStatus(
+      opts?.idleTimeout
+        ? 'Session ended after inactivity.'
+        : opts?.clientKickedByHost
+          ? 'Host closed the room or disconnected.'
+          : '',
+    )
     setError('')
+    lastShellActivityRef.current = 0
     onTeardown?.(wasHost)
     onClosed?.()
   }, [onClosed, onTeardown])
 
   useEffect(() => () => teardown(), [teardown])
+
+  useEffect(() => {
+    if (mode === 'idle') return
+    if (lastShellActivityRef.current === 0) {
+      lastShellActivityRef.current = Date.now()
+    }
+  }, [mode])
+
+  const touchShellActivity = useCallback(() => {
+    lastShellActivityRef.current = Date.now()
+    if (idleModalOpen) {
+      setIdleModalOpen(false)
+      setIdleSecondsLeft(IDLE_COUNTDOWN_SEC)
+    }
+  }, [idleModalOpen])
+
+  useEffect(() => {
+    if (mode === 'idle') return
+    const onAct = () => touchShellActivity()
+    window.addEventListener('pointerdown', onAct, true)
+    window.addEventListener('keydown', onAct, true)
+    return () => {
+      window.removeEventListener('pointerdown', onAct, true)
+      window.removeEventListener('keydown', onAct, true)
+    }
+  }, [mode, touchShellActivity])
+
+  useEffect(() => {
+    if (mode === 'idle' || idleModalOpen) return
+    const t = window.setInterval(() => {
+      if (Date.now() - lastShellActivityRef.current >= IDLE_WARN_MS) {
+        setIdleModalOpen(true)
+        setIdleSecondsLeft(IDLE_COUNTDOWN_SEC)
+      }
+    }, 15_000)
+    return () => window.clearInterval(t)
+  }, [mode, idleModalOpen])
+
+  const onIdleExpire = useCallback(async () => {
+    setIdleModalOpen(false)
+    const token = hostJwtRef.current
+    if (hostRef.current && token) {
+      try {
+        await abandonIdleRoom({ token })
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e))
+      }
+    }
+    teardown({ idleTimeout: true })
+  }, [teardown])
+
+  const wakeTurnServer = useCallback(async () => {
+    setTurnStarting(true)
+    setError('')
+    try {
+      await startTurnServer()
+      const st = await getTurnStatus()
+      setTurnReady(Boolean(st.ready))
+      setStatus(st.message ? String(st.message) : 'Relay server is starting — try again in a minute if needed.')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setTurnStarting(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!idleModalOpen) return
+    setIdleSecondsLeft(IDLE_COUNTDOWN_SEC)
+    let s = IDLE_COUNTDOWN_SEC
+    const id = window.setInterval(() => {
+      s -= 1
+      setIdleSecondsLeft(s)
+      if (s <= 0) {
+        window.clearInterval(id)
+        void onIdleExpire()
+      }
+    }, 1000)
+    return () => window.clearInterval(id)
+  }, [idleModalOpen, onIdleExpire])
+
+  useEffect(() => {
+    if (mode !== 'hosting' && mode !== 'client') return
+    const tick = () => {
+      const token = mode === 'hosting' ? hostJwtRef.current : clientJwtRef.current
+      if (!token) return
+      void turnHeartbeat({ token }).catch(() => {})
+    }
+    tick()
+    const t = window.setInterval(tick, 60_000)
+    return () => window.clearInterval(t)
+  }, [mode])
+
+  useEffect(() => {
+    if (mode !== 'hosting') return
+    const poll = async () => {
+      try {
+        const st = await getTurnStatus()
+        if (!st.enabled) {
+          setTurnControlAvailable(false)
+          return
+        }
+        setTurnControlAvailable(true)
+        setTurnReady(Boolean(st.ready))
+      } catch {
+        setTurnControlAvailable(false)
+      }
+    }
+    void poll()
+    const t = window.setInterval(poll, 20_000)
+    return () => window.clearInterval(t)
+  }, [mode])
 
   const startHost = useCallback(async () => {
     setError('')
@@ -131,12 +266,17 @@ export function MultiplayerPanel({
         gameId,
         maxClients,
       })
+      hostJwtRef.current = token
+      lastShellActivityRef.current = Date.now()
       const host = new RoomHost({
         wsUrl,
         roomCode: code,
         hostPeerId,
         token,
         onSignalingState: setSignalingState,
+        onRoomClosing: () => {
+          teardown({ idleTimeout: true })
+        },
         onRosterChange: (peers) => {
           setRoster(peers)
           onHostingRosterChange?.(peers)
@@ -164,6 +304,7 @@ export function MultiplayerPanel({
     onRemoteIntent,
     onRemoteSetDisplayName,
     onRemoteChatSend,
+    teardown,
   ])
 
   const startClient = useCallback(async () => {
@@ -178,6 +319,8 @@ export function MultiplayerPanel({
       const { roomCode: rc, hostPeerId, clientPeerId, token, wsUrl } = await joinRoom({
         roomCode: code,
       })
+      clientJwtRef.current = token
+      lastShellActivityRef.current = Date.now()
       const client = new RoomClient({
         wsUrl,
         roomCode: rc,
@@ -192,6 +335,9 @@ export function MultiplayerPanel({
         onChatLine: (line) => onRoomChatLine?.(line),
         onHostEnded: () => {
           teardown({ clientKickedByHost: true })
+        },
+        onRoomClosing: () => {
+          teardown({ idleTimeout: true })
         },
       })
       clientRef.current = client
@@ -281,6 +427,21 @@ export function MultiplayerPanel({
                   Open chat
                 </button>
               )}
+              {turnControlAvailable && (
+                <button
+                  type="button"
+                  className={`app__btnSecondary app__btnToolbar multiplayerPanel__turnBtn${turnReady ? ' multiplayerPanel__turnBtn--ready' : ' multiplayerPanel__turnBtn--off'}`}
+                  disabled={turnReady || turnStarting}
+                  title={
+                    turnReady
+                      ? 'Relay server is ready.'
+                      : 'Start the optional TURN relay VM (may take 1–3 minutes).'
+                  }
+                  onClick={() => void wakeTurnServer()}
+                >
+                  {turnReady ? 'Relay ready' : turnStarting ? 'Starting relay…' : 'Start relay'}
+                </button>
+              )}
               <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
                 Close room
               </button>
@@ -357,6 +518,21 @@ export function MultiplayerPanel({
                 Open chat
               </button>
             )}
+            {turnControlAvailable && (
+              <button
+                type="button"
+                className={`app__btnSecondary app__btnToolbar multiplayerPanel__turnBtn${turnReady ? ' multiplayerPanel__turnBtn--ready' : ' multiplayerPanel__turnBtn--off'}`}
+                disabled={turnReady || turnStarting}
+                title={
+                  turnReady
+                    ? 'Relay server is ready.'
+                    : 'Start the optional TURN relay VM (may take 1–3 minutes).'
+                }
+                onClick={() => void wakeTurnServer()}
+              >
+                {turnReady ? 'Relay ready' : turnStarting ? 'Starting relay…' : 'Start relay'}
+              </button>
+            )}
             <button type="button" className="app__btnSecondary app__btnToolbar" onClick={() => teardown()}>
               Close room
             </button>
@@ -398,6 +574,14 @@ export function MultiplayerPanel({
         </p>
       )}
       {chatOpenFailed ? <p className="multiplayerPanel__chatFail">{chatOpenFailed}</p> : null}
+
+      <MultiplayerIdleModal
+        open={idleModalOpen}
+        secondsRemaining={idleSecondsLeft}
+        onDismiss={() => {
+          touchShellActivity()
+        }}
+      />
     </section>
   )
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,10 @@ interface ImportMetaEnv {
   readonly VITE_MULTIPLAYER_HTTP_URL?: string
   readonly VITE_MULTIPLAYER_WS_URL?: string
   readonly VITE_MULTIPLAYER_STUN_URLS?: string
+  readonly VITE_MULTIPLAYER_ICE_JSON?: string
+  readonly VITE_MULTIPLAYER_TURN_HOST?: string
+  readonly VITE_MULTIPLAYER_TURN_USER?: string
+  readonly VITE_MULTIPLAYER_TURN_CREDENTIAL?: string
 }
 
 declare module '*.yaml?raw' {


### PR DESCRIPTION
## Summary

Adds an **optional coturn-on-EC2** path behind Terraform (`turn_ec2_enabled`), with **Dynamo-backed scheduling/backoff**, **HTTP control and status** endpoints, **idle room abandonment** (host + API), **`room-closing`** over signaling, and **client ICE configuration** via Vite env (or JSON). Includes **multiplayer inactivity UI** (1h → 5m countdown modal) and a **Start relay** affordance when the API reports TURN controls are available.

## Terraform / infra

- New `turn.tf`: default VPC subnet, AL2023 AMI, security group (3478 + relay UDP range), EC2 user-data installs coturn; Route 53 `turn` A record with lifecycle ignore on records (Lambda updates A after start).
- `turn-scheduled` Lambda + EventBridge `rate(15 minutes)` for describe/stop when idle per stored state.
- Outputs: `turn_hostname`, sensitive `turn_coturn_static_password` (when stack enabled).
- HTTP Lambda: extended timeout and env for EC2/Route53/API GW management when TURN stack is on.

## Lambda

- `GET /turn/status`, `POST /turn/start`, `POST /turn/heartbeat`, `POST /rooms/abandon-idle`.
- Cascade room delete + WebSocket `room-closing` notify where applicable.
- `npm run bundle` now emits `turnScheduled.zip` for deploy parity; CI runs bundle after lambda tests.

## App

- `PeerLink` uses `iceServers` from `VITE_MULTIPLAYER_ICE_JSON` or STUN + optional `VITE_MULTIPLAYER_TURN_*`.
- `MultiplayerPanel`: TURN polling / start relay, JWT heartbeats, idle detection + `MultiplayerIdleModal`, `onRoomClosing` on host/client.

## Tests

- `lambda/src/turnBackoff.test.ts`
- `src/net/protocol.test.ts` extended for `room-closing`

## Docs

- `deploy/terraform/aws/README.md`, `AGENTS.md`, `docs/ui-design.md`
