### PR TITLE
ci(deploy): enable TURN stack via TF_TURN_EC2_ENABLED

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,8 @@ jobs:
           if [ -n "${{ secrets.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ secrets.TF_ACM_CERTIFICATE_ARN }}"; fi
           if [ -n "${{ vars.TF_ALLOWED_ORIGIN }}" ]; then export TF_VAR_allowed_origin="${{ vars.TF_ALLOWED_ORIGIN }}"; fi
           if [ -n "${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}" ]; then export TF_VAR_route53_hosted_zone_id="${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}"; fi
+          # Optional coturn EC2 + turn.* DNS + turn-scheduled Lambda (only when Route 53 is also configured).
+          if [ "${{ vars.TF_TURN_EC2_ENABLED }}" = "true" ]; then export TF_VAR_turn_ec2_enabled=true; fi
           terraform apply -auto-approve
 
       - name: Capture Terraform outputs
@@ -164,3 +166,5 @@ jobs:
           WR=$(terraform output -raw ws_regional_domain_name 2>/dev/null || true)
           if [ -n "$HR" ]; then echo "- Route 53 alias target (api → HTTP API): \`$HR\`" >> "$GITHUB_STEP_SUMMARY"; fi
           if [ -n "$WR" ]; then echo "- Route 53 alias target (ws → WebSocket API): \`$WR\`" >> "$GITHUB_STEP_SUMMARY"; fi
+          TH="$(terraform output -raw turn_hostname 2>/dev/null || true)"
+          if [ -n "$TH" ] && [ "$TH" != "null" ]; then echo "- TURN hostname (coturn): \`$TH\` — set \`VITE_MULTIPLAYER_TURN_*\` and redeploy if newly enabled." >> "$GITHUB_STEP_SUMMARY"; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,8 @@ Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for 
 
 Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable** `TF_CUSTOM_DOMAIN` and **Secret** `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). Optional **Secret** `TF_ROUTE53_HOSTED_ZONE_ID` for Terraform-managed Route 53 aliases. See **`AWS_SETUP.md`** §7 and **`.github/workflows/deploy.yml`**; **`deploy/terraform/aws/README.md`** documents what Terraform creates.
 
+Optional **coturn on EC2** (separate Lambda `turn-scheduled`, `turn.<domain>` A record, EC2 instance): set repository **Variable** `TF_TURN_EC2_ENABLED` to the literal string **`true`** (same repo **Variables** UI as `TF_CUSTOM_DOMAIN`). This sets **`TF_VAR_turn_ec2_enabled`** on deploy. It has no effect unless **`TF_ROUTE53_HOSTED_ZONE_ID`** is also set (TURN stack requires managed apex/api/ws DNS). Defaults stay **off** so merges do not surprise-bill EC2.
+
 ### Future backlog (not in this PR)
 
 - **Managed third-party TURN** (Twilio, etc.) with short-lived credentials if you outgrow the optional **Terraform coturn EC2** path (`turn_ec2_enabled`).

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -36,7 +36,7 @@ Notable optional inputs:
 - **`route53_hosted_zone_id`** — manage the DNS records above (only with custom domain + cert).
 - **`allowed_origin`** — override browser origin string for CORS / Lambda when non-empty.
 - **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
-- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**.
+- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**. **GitHub Deploy** does not turn this on unless you set repository **Variable** **`TF_TURN_EC2_ENABLED`**=`true` (workflow exports `TF_VAR_turn_ec2_enabled`); otherwise apply only updates the existing **http** / **ws** Lambdas and APIs—no new EC2 or `turn.*` record.
 
 ---
 


### PR DESCRIPTION
## Why

After merging the TURN lifecycle work, production still had **no EC2**, no **`turn.*`** DNS record, and no **`turn-scheduled`** Lambda because Terraform only creates those when `local.turn_stack` is true:

```hcl
turn_stack = var.turn_ec2_enabled && local.create_route53_records
```

`turn_ec2_enabled` defaults to **false**, and **Deploy never exported `TF_VAR_turn_ec2_enabled`**, so every apply kept the optional stack off. The **http** Lambda is still the same AWS resource (e.g. `card-game-http`); only its deployment package updates, so there is no separate “new” HTTP Lambda to look for.

## What changed

- **`.github/workflows/deploy.yml`**: if repository **Variable** `TF_TURN_EC2_ENABLED` is exactly `true`, export `TF_VAR_turn_ec2_enabled=true` before `terraform apply`. The deploy job summary prints `turn_hostname` when that output is non-null.
- **`AGENTS.md`** / **`deploy/terraform/aws/README.md`**: document the flag and that infra stays off by default to avoid surprise EC2 cost.

## What you do

1. Merge this PR (or apply the workflow change manually).
2. In the repo **Settings → Secrets and variables → Actions → Variables**, add **`TF_TURN_EC2_ENABLED`** = **`true`** (literal string).
3. Ensure **`TF_ROUTE53_HOSTED_ZONE_ID`** (secret) and custom domain / cert vars are already set (required for `create_route53_records`).
4. Re-run **Deploy** (or push to **`main`** with a deploy-triggering path). Then expect EC2, a **`turn.<apex>`** A record, and the **`turn-scheduled`** Lambda.
5. Set **`VITE_MULTIPLAYER_TURN_*`** (and redeploy the site if needed) per **`deploy/terraform/aws/README.md`** outputs.
