### PR TITLE
ci(deploy): bake VITE TURN_* in build; document TURN host

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,7 @@ jobs:
           if [ -n "${{ secrets.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ secrets.TF_ACM_CERTIFICATE_ARN }}"; fi
           if [ -n "${{ vars.TF_ALLOWED_ORIGIN }}" ]; then export TF_VAR_allowed_origin="${{ vars.TF_ALLOWED_ORIGIN }}"; fi
           if [ -n "${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}" ]; then export TF_VAR_route53_hosted_zone_id="${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}"; fi
+          if [ "${{ vars.TF_TURN_EC2_ENABLED }}" = "true" ]; then export TF_VAR_turn_ec2_enabled=true; fi
           terraform apply -auto-approve
 
       - name: Capture Terraform outputs
@@ -134,6 +135,10 @@ jobs:
         env:
           VITE_MULTIPLAYER_HTTP_URL: ${{ steps.mp.outputs.http }}
           VITE_MULTIPLAYER_WS_URL: ${{ steps.mp.outputs.ws }}
+          # Optional coturn (hostname only, no https:// — see src/net/config.ts).
+          VITE_MULTIPLAYER_TURN_HOST: ${{ vars.VITE_MULTIPLAYER_TURN_HOST }}
+          VITE_MULTIPLAYER_TURN_USER: ${{ vars.VITE_MULTIPLAYER_TURN_USER }}
+          VITE_MULTIPLAYER_TURN_CREDENTIAL: ${{ secrets.VITE_MULTIPLAYER_TURN_CREDENTIAL }}
         run: npm run build
 
       # 4. Sync static assets to S3 + invalidate CloudFront.
@@ -164,3 +169,5 @@ jobs:
           WR=$(terraform output -raw ws_regional_domain_name 2>/dev/null || true)
           if [ -n "$HR" ]; then echo "- Route 53 alias target (api → HTTP API): \`$HR\`" >> "$GITHUB_STEP_SUMMARY"; fi
           if [ -n "$WR" ]; then echo "- Route 53 alias target (ws → WebSocket API): \`$WR\`" >> "$GITHUB_STEP_SUMMARY"; fi
+          TH="$(terraform output -raw turn_hostname 2>/dev/null || true)"
+          if [ -n "$TH" ] && [ "$TH" != "null" ]; then echo "- TURN hostname (coturn): \`$TH\` — set \`VITE_MULTIPLAYER_TURN_HOST\` / user / credential secret, then redeploy." >> "$GITHUB_STEP_SUMMARY"; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,11 +297,13 @@ only on the Terraform step output in the same job:
 
 - `VITE_MULTIPLAYER_HTTP_URL` — same value as `terraform output -raw http_api_url` (no trailing slash).
 - `VITE_MULTIPLAYER_WS_URL` — same value as `terraform output -raw ws_api_url` (with a custom domain this is `wss://ws.<custom_domain>` with **no** `/prod` path; the default execute-api URL still uses `/prod`).
-- Optional **coturn on EC2** (Terraform `turn_ec2_enabled`): after apply, set **`VITE_MULTIPLAYER_TURN_HOST`** (see `terraform output turn_hostname`), **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`, **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**=`terraform output -raw turn_coturn_static_password`. Or **`VITE_MULTIPLAYER_ICE_JSON`** for full `RTCIceServer[]` control.
+- Optional **coturn on EC2** (Terraform `turn_ec2_enabled`): after apply, set **`VITE_MULTIPLAYER_TURN_HOST`** to the **hostname only** (e.g. `turn.cardgame.michaelj43.dev` from `terraform output -raw turn_hostname` — not `https://…`), **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`, and **`VITE_MULTIPLAYER_TURN_CREDENTIAL`** via an Actions **Secret** (value from `terraform output -raw turn_coturn_static_password`). Deploy passes these into the Vite build. Or **`VITE_MULTIPLAYER_ICE_JSON`** for full `RTCIceServer[]` control.
 
 Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for that run. Copy the two lines from the last successful **Deploy** job summary into Variables once, then re-run **Deploy** (or push) so CloudFront serves a bundle with multiplayer enabled.
 
 Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable** `TF_CUSTOM_DOMAIN` and **Secret** `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). Optional **Secret** `TF_ROUTE53_HOSTED_ZONE_ID` for Terraform-managed Route 53 aliases. See **`AWS_SETUP.md`** §7 and **`.github/workflows/deploy.yml`**; **`deploy/terraform/aws/README.md`** documents what Terraform creates.
+
+Optional **coturn EC2** (Terraform `turn_ec2_enabled`): set repository **Variable** `TF_TURN_EC2_ENABLED` to **`true`** so deploy exports `TF_VAR_turn_ec2_enabled` (no effect without `TF_ROUTE53_HOSTED_ZONE_ID`). Defaults stay off to avoid surprise EC2 cost.
 
 ### Future backlog (not in this PR)
 

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -36,7 +36,7 @@ Notable optional inputs:
 - **`route53_hosted_zone_id`** — manage the DNS records above (only with custom domain + cert).
 - **`allowed_origin`** — override browser origin string for CORS / Lambda when non-empty.
 - **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
-- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**.
+- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**. **GitHub Deploy** sets `TF_VAR_turn_ec2_enabled` when repository **Variable** **`TF_TURN_EC2_ENABLED`** is `true`.
 
 ---
 
@@ -62,7 +62,15 @@ Notable optional inputs:
 | `turn_hostname` | e.g. `turn.<custom_domain>` when TURN stack is enabled; else `null` |
 | `turn_coturn_static_password` | Sensitive coturn password (user **`cardgame`** in user-data); set **`VITE_MULTIPLAYER_TURN_CREDENTIAL`** to match at site build |
 
-**TURN / DNS:** After `terraform apply` with TURN on, run **`terraform output -raw turn_coturn_static_password`** once, configure GitHub Variables **`VITE_MULTIPLAYER_TURN_HOST`** (= `turn_hostname`), **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`, **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**=that password, then redeploy the site. The HTTP Lambda waits for **EC2 status checks OK** before updating Route 53; the scheduled Lambda stops the instance only after **4h uptime** and **15m** without usage heartbeats (see app).
+**TURN / DNS:** After `terraform apply` with TURN on, run **`terraform output -raw turn_coturn_static_password`** once. There is **no** `VITE_MULTIPLAYER_TURN_URL` — WebRTC uses a `turn:` URL, which the app builds from the host. Configure for the **Deploy** “Build site” step:
+
+| GitHub Actions | Value |
+|----------------|--------|
+| **Variable** `VITE_MULTIPLAYER_TURN_HOST` | Hostname only, e.g. `turn.cardgame.michaelj43.dev` (same as `terraform output -raw turn_hostname`). **Do not** use `https://` or a path. |
+| **Variable** `VITE_MULTIPLAYER_TURN_USER` | `cardgame` (matches Terraform user-data). |
+| **Secret** `VITE_MULTIPLAYER_TURN_CREDENTIAL` | Output of `terraform output -raw turn_coturn_static_password` (sensitive). |
+
+Then redeploy the site. The HTTP Lambda waits for **EC2 status checks OK** before updating Route 53; the scheduled Lambda stops the instance only after **4h uptime** and **15m** without usage heartbeats (see app).
 
 The site build consumes **`http_api_url`** and **`ws_api_url`** as **`VITE_MULTIPLAYER_HTTP_URL`** / **`VITE_MULTIPLAYER_WS_URL`** when those env vars are not overridden in CI.
 


### PR DESCRIPTION
## Summary

- **Operators:** there is no `VITE_MULTIPLAYER_TURN_URL`. Use **Variable** `VITE_MULTIPLAYER_TURN_HOST` = **hostname only** (e.g. `turn.cardgame.michaelj43.dev`), **not** `https://turn.cardgame.michaelj43.dev`. The app builds `turn:${host}:3478` in `src/net/config.ts`.
- **Deploy workflow:** pass `vars.VITE_MULTIPLAYER_TURN_HOST`, `vars.VITE_MULTIPLAYER_TURN_USER`, and `secrets.VITE_MULTIPLAYER_TURN_CREDENTIAL` into the **Build site** step so Vite can bake them into the bundle.
- **Docs:** README table + AGENTS (`TF_TURN_EC2_ENABLED` + hostname note).
- **Terraform:** `TF_TURN_EC2_ENABLED=true` export before `terraform apply`, and deploy summary line for `turn_hostname` when present.
