### PR TITLE
feat(turn): operator coturn password from one GitHub secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,12 +89,20 @@ jobs:
       # Empty GitHub vars must not export TF_VAR_* or Terraform sees "" instead of null.
       - name: Terraform apply
         working-directory: deploy/terraform/aws
+        env:
+          # Same secret as VITE_MULTIPLAYER_TURN_CREDENTIAL on the Build site step (coturn + browser).
+          TURN_COTURN_STATIC_PASSWORD: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
         run: |
           set -e
           if [ -n "${{ vars.TF_CUSTOM_DOMAIN }}" ]; then export TF_VAR_custom_domain="${{ vars.TF_CUSTOM_DOMAIN }}"; fi
           if [ -n "${{ secrets.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ secrets.TF_ACM_CERTIFICATE_ARN }}"; fi
           if [ -n "${{ vars.TF_ALLOWED_ORIGIN }}" ]; then export TF_VAR_allowed_origin="${{ vars.TF_ALLOWED_ORIGIN }}"; fi
           if [ -n "${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}" ]; then export TF_VAR_route53_hosted_zone_id="${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}"; fi
+          # Optional coturn EC2 + turn.* DNS + turn-scheduled Lambda (only when Route 53 is also configured).
+          if [ "${{ vars.TF_TURN_EC2_ENABLED }}" = "true" ]; then
+            export TF_VAR_turn_ec2_enabled=true
+            export TF_VAR_turn_coturn_static_password="${TURN_COTURN_STATIC_PASSWORD}"
+          fi
           terraform apply -auto-approve
 
       - name: Capture Terraform outputs
@@ -134,6 +142,10 @@ jobs:
         env:
           VITE_MULTIPLAYER_HTTP_URL: ${{ steps.mp.outputs.http }}
           VITE_MULTIPLAYER_WS_URL: ${{ steps.mp.outputs.ws }}
+          # Optional coturn (hostname only, no https:// — see src/net/config.ts).
+          VITE_MULTIPLAYER_TURN_HOST: ${{ vars.VITE_MULTIPLAYER_TURN_HOST }}
+          VITE_MULTIPLAYER_TURN_USER: ${{ vars.VITE_MULTIPLAYER_TURN_USER }}
+          VITE_MULTIPLAYER_TURN_CREDENTIAL: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
         run: npm run build
 
       # 4. Sync static assets to S3 + invalidate CloudFront.
@@ -164,3 +176,5 @@ jobs:
           WR=$(terraform output -raw ws_regional_domain_name 2>/dev/null || true)
           if [ -n "$HR" ]; then echo "- Route 53 alias target (api → HTTP API): \`$HR\`" >> "$GITHUB_STEP_SUMMARY"; fi
           if [ -n "$WR" ]; then echo "- Route 53 alias target (ws → WebSocket API): \`$WR\`" >> "$GITHUB_STEP_SUMMARY"; fi
+          TH="$(terraform output -raw turn_hostname 2>/dev/null || true)"
+          if [ -n "$TH" ] && [ "$TH" != "null" ]; then echo "- TURN hostname (coturn): \`$TH\` — set Variables \`VITE_MULTIPLAYER_TURN_HOST\` / \`VITE_MULTIPLAYER_TURN_USER\` and Secret \`TURN_COTURN_STATIC_PASSWORD\` (shared with Terraform), then redeploy." >> "$GITHUB_STEP_SUMMARY"; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,7 @@ sweeper process.
 Required repository **Secrets** for deploy:
 
 - `AWS_ROLE_ARN`, `ROOM_JWT_SECRET`, `AWS_REGION`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`.
+- Optional coturn: **`TURN_COTURN_STATIC_PASSWORD`** — required when **`TF_TURN_EC2_ENABLED`** is `true` (same value for Terraform `turn_coturn_static_password` and `VITE_MULTIPLAYER_TURN_CREDENTIAL` in the site build).
 
 Optional repository **Variables** (plaintext) for Vite — set these so every
 `npm run build` (CI and deploy) bakes in stable API endpoints without depending
@@ -297,11 +298,13 @@ only on the Terraform step output in the same job:
 
 - `VITE_MULTIPLAYER_HTTP_URL` — same value as `terraform output -raw http_api_url` (no trailing slash).
 - `VITE_MULTIPLAYER_WS_URL` — same value as `terraform output -raw ws_api_url` (with a custom domain this is `wss://ws.<custom_domain>` with **no** `/prod` path; the default execute-api URL still uses `/prod`).
-- Optional **coturn on EC2** (Terraform `turn_ec2_enabled`): after apply, set **`VITE_MULTIPLAYER_TURN_HOST`** (see `terraform output turn_hostname`), **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`, **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**=`terraform output -raw turn_coturn_static_password`. Or **`VITE_MULTIPLAYER_ICE_JSON`** for full `RTCIceServer[]` control.
+- Optional **coturn on EC2** (Terraform `turn_ec2_enabled`): create one strong password and store it as Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`** — deploy passes it to **Terraform** (`turn_coturn_static_password` / EC2 user-data) and to **Vite** as **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**. Set **`VITE_MULTIPLAYER_TURN_HOST`** (hostname only, e.g. `turn.…` — not `https://…`) and **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`. Or **`VITE_MULTIPLAYER_ICE_JSON`** for full `RTCIceServer[]` control.
 
 Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for that run. Copy the two lines from the last successful **Deploy** job summary into Variables once, then re-run **Deploy** (or push) so CloudFront serves a bundle with multiplayer enabled.
 
 Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable** `TF_CUSTOM_DOMAIN` and **Secret** `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). Optional **Secret** `TF_ROUTE53_HOSTED_ZONE_ID` for Terraform-managed Route 53 aliases. See **`AWS_SETUP.md`** §7 and **`.github/workflows/deploy.yml`**; **`deploy/terraform/aws/README.md`** documents what Terraform creates.
+
+Optional **coturn EC2** (Terraform `turn_ec2_enabled`: EC2, `turn.<domain>` A record, `turn-scheduled` Lambda): set repository **Variable** `TF_TURN_EC2_ENABLED` to **`true`** so deploy exports `TF_VAR_turn_ec2_enabled`. No effect unless **`TF_ROUTE53_HOSTED_ZONE_ID`** is also set. Defaults stay **off** so merges do not surprise-bill EC2.
 
 ### Future backlog (not in this PR)
 

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -36,7 +36,8 @@ Notable optional inputs:
 - **`route53_hosted_zone_id`** — manage the DNS records above (only with custom domain + cert).
 - **`allowed_origin`** — override browser origin string for CORS / Lambda when non-empty.
 - **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
-- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**.
+- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**. **GitHub Deploy** exports `TF_VAR_turn_ec2_enabled` when repository **Variable** **`TF_TURN_EC2_ENABLED`** is `true`; otherwise apply only updates the existing **http** / **ws** Lambdas and APIs (no EC2 or `turn.*` record).
+- **`turn_coturn_static_password`** (default `""`, sensitive) — **required** when the TURN stack applies: long-term coturn password for user **`cardgame`**. You choose it once (e.g. password generator); pass the same value as GitHub Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`** so Terraform user-data and the Vite build both use it. Min **8** characters (after trim).
 
 ---
 
@@ -60,9 +61,23 @@ Notable optional inputs:
 | `http_regional_domain_name` | `d-…execute-api…` target for the **HTTP** custom domain (compare to Route 53 `api` alias) |
 | `ws_regional_domain_name` | `d-…execute-api…` target for the **WebSocket** custom domain (compare to Route 53 `ws` alias) |
 | `turn_hostname` | e.g. `turn.<custom_domain>` when TURN stack is enabled; else `null` |
-| `turn_coturn_static_password` | Sensitive coturn password (user **`cardgame`** in user-data); set **`VITE_MULTIPLAYER_TURN_CREDENTIAL`** to match at site build |
+| `turn_coturn_static_password` | Sensitive echo of the configured coturn password when TURN is on (avoid printing in CI); user **`cardgame`** in user-data |
 
-**TURN / DNS:** After `terraform apply` with TURN on, run **`terraform output -raw turn_coturn_static_password`** once, configure GitHub Variables **`VITE_MULTIPLAYER_TURN_HOST`** (= `turn_hostname`), **`VITE_MULTIPLAYER_TURN_USER`**=`cardgame`, **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**=that password, then redeploy the site. The HTTP Lambda waits for **EC2 status checks OK** before updating Route 53; the scheduled Lambda stops the instance only after **4h uptime** and **15m** without usage heartbeats (see app).
+**TURN / DNS:** There is **no** `VITE_MULTIPLAYER_TURN_URL` — WebRTC uses a `turn:` URL, which the app builds from the host. **One password, one secret:** create a strong password (min 8 characters), store it as GitHub Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`**. The **Deploy** workflow passes it to Terraform as **`TF_VAR_turn_coturn_static_password`** (coturn on EC2) and to Vite as **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**, so you never copy values out of `terraform output` after each apply.
+
+| GitHub Actions | Value |
+|----------------|--------|
+| **Secret** `TURN_COTURN_STATIC_PASSWORD` | Your chosen coturn password (same value for Terraform + browser bundle). |
+| **Variable** `VITE_MULTIPLAYER_TURN_HOST` | Hostname only, e.g. `turn.cardgame.michaelj43.dev` (same as `terraform output -raw turn_hostname`). **Do not** use `https://` or a path. |
+| **Variable** `VITE_MULTIPLAYER_TURN_USER` | `cardgame` (matches Terraform user-data). |
+
+If you previously used **`VITE_MULTIPLAYER_TURN_CREDENTIAL`** as a separate Actions secret, remove it and use **`TURN_COTURN_STATIC_PASSWORD`** only (both Terraform and Vite read that name in deploy).
+
+**Why a Secret?** The password must exist in **two** places: EC2 user-data (via Terraform) and the static site (via Vite). CI supplies one GitHub **Secret** to both steps. It still ends up in client JS for anyone who inspects the bundle; **short-lived / on-demand credentials** (e.g. TURN REST API) remain a future improvement for stricter threat models.
+
+**Migrating from older Terraform that used `random_password`:** the coturn instance **user-data** changes; Terraform will typically **replace** the EC2 instance once. Put the password you want to keep (or a new one) in **`TURN_COTURN_STATIC_PASSWORD`** before apply.
+
+Then redeploy the site. The HTTP Lambda waits for **EC2 status checks OK** before updating Route 53; the scheduled Lambda stops the instance only after **4h uptime** and **15m** without usage heartbeats (see app).
 
 The site build consumes **`http_api_url`** and **`ws_api_url`** as **`VITE_MULTIPLAYER_HTTP_URL`** / **`VITE_MULTIPLAYER_WS_URL`** when those env vars are not overridden in CI.
 

--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -49,7 +49,7 @@ output "turn_hostname" {
 }
 
 output "turn_coturn_static_password" {
-  description = "Static coturn long-term credential password (sensitive). Set VITE_MULTIPLAYER_TURN_CREDENTIAL to match at build time; user is cardgame."
-  value       = try(random_password.turn_coturn[0].result, null)
+  description = "Echo of turn_coturn_static_password when TURN stack is on (sensitive). Prefer defining the password only in CI/GitHub secret TURN_COTURN_STATIC_PASSWORD; do not log this output in pipelines."
+  value       = local.turn_stack && length(trimspace(var.turn_coturn_static_password)) > 0 ? trimspace(var.turn_coturn_static_password) : null
   sensitive   = true
 }

--- a/deploy/terraform/aws/turn.tf
+++ b/deploy/terraform/aws/turn.tf
@@ -24,12 +24,6 @@ data "aws_ami" "al2023_x86" {
   }
 }
 
-resource "random_password" "turn_coturn" {
-  count   = local.turn_stack ? 1 : 0
-  length  = 24
-  special = false
-}
-
 resource "aws_security_group" "turn" {
   count       = local.turn_stack ? 1 : 0
   name        = "${local.name}-coturn"
@@ -79,8 +73,15 @@ resource "aws_instance" "turn" {
   user_data = base64encode(templatefile("${path.module}/turn-user-data.sh.tpl", {
     realm         = local.custom_domain_host
     turn_user     = "cardgame"
-    turn_password = random_password.turn_coturn[0].result
+    turn_password = trimspace(var.turn_coturn_static_password)
   }))
+
+  lifecycle {
+    precondition {
+      condition     = !local.turn_stack || length(trimspace(var.turn_coturn_static_password)) >= 8
+      error_message = "When the TURN EC2 stack is enabled, set turn_coturn_static_password (e.g. TF_VAR_turn_coturn_static_password from GitHub secret TURN_COTURN_STATIC_PASSWORD) to a shared password (min 8 characters) used by both Terraform user-data and VITE_MULTIPLAYER_TURN_CREDENTIAL."
+    }
+  }
 
   metadata_options {
     http_tokens = "required"

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -94,6 +94,13 @@ variable "turn_ec2_enabled" {
   default     = false
 }
 
+variable "turn_coturn_static_password" {
+  description = "Long-term coturn credential (username fixed as cardgame in user-data). Required when the TURN EC2 stack applies — use the same value as the site build secret (e.g. GitHub Actions secret TURN_COTURN_STATIC_PASSWORD). Min 8 characters after trim. Leave empty when turn_ec2_enabled is false."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "turn_instance_type" {
   description = "Instance type for the optional coturn EC2 (e.g. t3.micro)."
   type        = string

--- a/src/net/config.ts
+++ b/src/net/config.ts
@@ -5,7 +5,7 @@
  *   - VITE_MULTIPLAYER_WS_URL     → e.g. wss://def456.execute-api.us-east-1.amazonaws.com/prod, or wss://ws.example.com (no path) with API Gateway custom domain + mapping
  *   - VITE_MULTIPLAYER_STUN_URLS  → comma-separated STUN urls (default: Google public STUN)
  *   - VITE_MULTIPLAYER_ICE_JSON   → optional JSON array of RTCIceServer objects (overrides STUN-only default)
- *   - VITE_MULTIPLAYER_TURN_HOST / TURN_USER / TURN_CREDENTIAL → optional long-term TURN (coturn) in addition to STUN
+ *   - VITE_MULTIPLAYER_TURN_HOST / TURN_USER / TURN_CREDENTIAL → optional long-term TURN (coturn) in addition to STUN (in GitHub Deploy, TURN_CREDENTIAL is set from secret TURN_COTURN_STATIC_PASSWORD alongside TF_VAR_turn_coturn_static_password)
  *
  * If HTTP/WS URLs are missing, multiplayer is disabled at runtime and the UI hides join/host.
  *


### PR DESCRIPTION
## Summary

Coturn’s long-term password is **no longer generated by Terraform** (`random_password` removed). You **choose the password once**, store it as GitHub Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`**, and the **Deploy** workflow passes the same value to:

- **Terraform** as `TF_VAR_turn_coturn_static_password` (EC2 user-data / coturn), when `TF_TURN_EC2_ENABLED` is `true`
- **Vite** as `VITE_MULTIPLAYER_TURN_CREDENTIAL` on every site build

So CI and Terraform always pull from the **same** secret; there is nothing to paste from `terraform output` after each apply.

## Terraform

- New variable **`turn_coturn_static_password`** (sensitive, default `""`).
- **`aws_instance.turn`** precondition: when the TURN stack is on, password must be at least **8** characters (after trim).
- **`turn_coturn_static_password` output**: still available as a sensitive echo for local debugging; avoid printing it in CI logs.

## Migrating

- If you already had a Terraform-generated password on a running instance, either set **`TURN_COTURN_STATIC_PASSWORD`** to that value before apply, or set a new password and allow Terraform to **replace** the EC2 instance (user-data change).
- If you used a separate secret **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**, switch to **`TURN_COTURN_STATIC_PASSWORD`** only (see `deploy/terraform/aws/README.md`).

## Future

Short-lived / on-demand TURN credentials (e.g. TURN REST API) can replace static long-term creds in a follow-up without changing the “single operator-controlled secret” idea for the static-password path.
