### PR TITLE
docs: architecture guide (multiplayer, WebRTC, AWS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ This document summarizes how the **card-game** repository is structured, how gam
 | `src/ui/GameHouseRulesPanel.tsx` | Per-game toggles/inputs saved to **`houseRules`** storage. |
 | `src/ui/CardView.tsx` | Card face/back, Skyjo tiers, standard ranks/suits. |
 | `docs/*.md` | Longer **repo documentation** per game (can diverge slightly from modal text). |
+| `docs/architecture.md` | **System architecture**: multiplayer, WebRTC vs signaling, optional TURN, Lambdas; references **`deploy/terraform/aws/README.md`**. |
 | `docs/ui-design.md` | **Shell UI**: header toolbar button classes (`app__btn*`), multiplayer compact row layout (`multiplayerPanel__compact*` in `App.css`). |
 | `README.md` | User-facing run instructions and game table linking to `docs/`. |
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A **browser-only** card table built with **React**, **TypeScript**, and **Vite**. Games load **YAML** deck definitions and per-game manifests; each title is implemented as a TypeScript **game module** that drives table zones, legal actions, and optional **multi-round match** scoring (points or chip-style bankrolls).
 
+## Architecture
+
+End-to-end flows (browser shell, **WebRTC** game channel vs **WebSocket** signaling relay, optional **TURN/coturn**, AWS **Lambdas** / **DynamoDB**, and how they connect to deploy) are described in **[`docs/architecture.md`](docs/architecture.md)**. For Terraform inputs, DNS/TLS, and CI deploy steps, that doc points at **[`deploy/terraform/aws/README.md`](deploy/terraform/aws/README.md)**.
+
 ## Requirements
 
 - **Node.js** (20+ or current LTS recommended)
@@ -88,6 +92,7 @@ Pick a game from the in-app **Game** menu. Each row links to a short note in [`d
 | [`src/data/manifests.ts`](src/data/manifests.ts) | Wires game and deck ids to bundled YAML. |
 | [`src/rules/`](src/rules/) | In-app rules copy (markdown) shown in the **Rules** modal; see [`src/data/rulesSources.ts`](src/data/rulesSources.ts). |
 | [`docs/`](docs/) | Longer per-game notes (repo docs; can diverge slightly from the modal text). |
+| [`docs/architecture.md`](docs/architecture.md) | System architecture: multiplayer, WebRTC, signaling, optional TURN, Lambdas; links to **[`deploy/terraform/aws/README.md`](deploy/terraform/aws/README.md)**. |
 | [`docs/ui-design.md`](docs/ui-design.md) | Shared shell UI (toolbar buttons, online multiplayer strip layout). |
 | [`docs/multiplayer-chat.md`](docs/multiplayer-chat.md) | Room chat (DataChannel + chat popout + toasts). |
 | [`docs/audio-cues.md`](docs/audio-cues.md) | Optional chat / turn / card sounds (`public/sounds/*.wav`). |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,202 @@
+# Architecture — card-game
+
+This document explains how the **browser app**, **AWS multiplayer stack**, **WebRTC peer-to-peer game channel**, **signaling relay**, and **optional TURN relay** fit together. It is a narrative map; implementation details live in code and in **[`AGENTS.md`](../AGENTS.md)**.
+
+**Infrastructure and deploy** (Terraform inputs/outputs, S3/CloudFront, API Gateway, Lambdas, DynamoDB, optional coturn EC2) are documented in:
+
+- **[`deploy/terraform/aws/README.md`](../deploy/terraform/aws/README.md)** — treat that file as the **deployment reference** for this doc.
+
+Other useful links:
+
+- **[`docs/ui-design.md`](ui-design.md)** — shell + multiplayer strip UI.
+- **[`docs/multiplayer-chat.md`](multiplayer-chat.md)** — room chat over the data channel + popout.
+
+---
+
+## 1. Big picture (what runs where)
+
+```mermaid
+flowchart TB
+  subgraph Browser["Browser (each player)"]
+    App["React shell + TableView"]
+    Net["src/net/* — RoomHost / RoomClient / PeerLink / SignalingClient"]
+    App --> Net
+  end
+
+  subgraph AWS["AWS (deployed)"]
+    CF["CloudFront + S3 — static site"]
+    HTTP["API Gateway HTTP — /rooms, /turn/*, …"]
+    WS["API Gateway WebSocket — signaling"]
+    LHttp["Lambda: card-game-*-http"]
+    LWs["Lambda: card-game-*-ws"]
+    DDB["DynamoDB — rooms + connections + TURN scheduler rows"]
+    subgraph OptionalTURN["Optional: TURN stack (Terraform flag)"]
+      EC2["EC2 — coturn"]
+      R53["Route 53 — turn.<apex> A record"]
+      LSched["Lambda: turn-scheduled + EventBridge"]
+    end
+  end
+
+  Browser -->|HTTPS GET assets| CF
+  Browser -->|HTTPS REST| HTTP
+  Browser -->|WSS signaling| WS
+  HTTP --> LHttp
+  WS --> LWs
+  LHttp --> DDB
+  LWs --> DDB
+  LHttp -->|Start / Describe / R53 update| EC2
+  LHttp --> R53
+  LSched --> EC2
+  LSched --> DDB
+```
+
+- **Game logic** (rules, table state) stays **in the browser** — there is no game server process in AWS.
+- **AWS** provides **room metadata**, **short-lived JWTs**, **WebSocket signaling relay**, and **optional coturn** for strict NATs.
+
+---
+
+## 2. Planes of traffic (three different channels)
+
+| Plane | Technology | Purpose |
+|--------|------------|---------|
+| **A. Signaling** | `wss://…` WebSocket to API Gateway → **WebSocket Lambda** | Carry **non-game** control: hello, roster, **SDP offers/answers**, **ICE candidates** between peers. Server **relays** opaque JSON; it does not parse WebRTC. |
+| **B. Game data** | **WebRTC `RTCDataChannel`** (P2P between host and each client) | **Authoritative table snapshots** (host → clients), **intents** (client → host), optional **room chat**. This is the actual **multiplayer game** path. |
+| **C. TURN / STUN (optional)** | `RTCPeerConnection` ICE (`src/net/config.ts`) | **NAT traversal** for plane B. **STUN** discovers public reflexive candidates; **TURN** relays media when direct UDP fails. Configured at **build time** via `VITE_*` (see deploy README). |
+
+Planes **A** and **B** are independent: signaling can be “up” while the data channel is still **connecting** until ICE completes.
+
+---
+
+## 3. Multiplayer lifecycle (high level)
+
+### 3.1 Host creates a room
+
+```mermaid
+sequenceDiagram
+  participant H as Host browser
+  participant API as HTTP API + Lambda
+  participant DB as DynamoDB
+
+  H->>API: POST /rooms { gameId, maxClients }
+  API->>DB: PutItem ROOM#CODE / META
+  API-->>H: { roomCode, hostPeerId, token, wsUrl }
+  Note over H: RoomHost opens WebSocket with token
+```
+
+- **`createRoom`** (`src/net/api.ts`) → **`RoomHost`** (`src/net/host.ts`) uses returned **`wsUrl`** and **`token`**.
+- JWT proves the caller is the **host** for that `roomCode` (see `lambda/src/auth.ts`).
+
+### 3.2 Client joins
+
+```mermaid
+sequenceDiagram
+  participant C as Client browser
+  participant API as HTTP API + Lambda
+  participant DB as DynamoDB
+
+  C->>API: POST /rooms/join { roomCode }
+  API->>DB: Read META, assign seat, store CONN#…
+  API-->>C: { token, wsUrl, hostPeerId, … }
+  Note over C: RoomClient opens WebSocket, waits for host SDP path
+```
+
+- **`RoomClient`** (`src/net/client.ts`) connects signaling and participates in WebRTC as **non-initiator** (host creates the data channel).
+
+### 3.3 WebRTC: signaling relay vs P2P data
+
+```mermaid
+flowchart LR
+  subgraph Host["Host browser"]
+    HS["SignalingClient"]
+    HP["PeerLink (initiator)"]
+  end
+  subgraph Relay["AWS WebSocket Lambda"]
+    R["Relay SignalingRelay { to, from, payload }"]
+  end
+  subgraph Client["Client browser"]
+    CS["SignalingClient"]
+    CP["PeerLink"]
+  end
+
+  HP -- SDP/ICE JSON --> HS
+  HS -->|WSS send| R
+  R -->|WSS push| CS
+  CS --> CP
+  CP -. optional TURN path .- HP
+```
+
+1. **`PeerLink`** (`src/net/peer.ts`) creates **`RTCPeerConnection`** with **`iceServers`** from **`getMultiplayerConfig()`** (STUN + optional TURN).
+2. ICE candidates and SDP are wrapped as app messages and sent via **`SignalingClient`** (`src/net/signaling.ts`) over the **WebSocket**.
+3. The **WebSocket Lambda** (`lambda/src/websocket.ts`) looks up the target connection in **DynamoDB** and uses **API Gateway Management API** `PostToConnection` to deliver the envelope — that is the **“signaling relay”**.
+4. Once ICE + DTLS succeed, **`RTCDataChannel`** is **peer-to-peer** (host ↔ each client). **Game state** does not flow through Lambda.
+
+**Why Management API endpoint matters:** `PostToConnection` must target the **execute-api** URL for the WebSocket API (see comment in `lambda/src/websocket.ts`). Custom domains for clients are fine; the **server-side** post URL is special — details in **[`deploy/terraform/aws/README.md`](../deploy/terraform/aws/README.md)**.
+
+---
+
+## 4. Optional TURN / coturn (when enabled in Terraform)
+
+When **`turn_ec2_enabled`** + Route 53 + GitHub flags/secrets are set (see deploy README):
+
+```mermaid
+sequenceDiagram
+  participant U as User (host UI)
+  participant Site as Static site bundle
+  participant API as HTTP Lambda
+  participant EC2 as coturn EC2
+  participant DNS as Route 53 turn.*
+
+  U->>Site: Start relay
+  Site->>API: POST /turn/start
+  API->>EC2: StartInstances + wait healthy
+  API->>DNS: UPSERT turn A → public IPv4
+  API-->>Site: { ready, publicIp, … }
+  Note over Site: WebRTC may now use TURN candidate in ICE
+```
+
+- **`GET /turn/status`** — cheap poll for “is instance running / DNS aligned / checks OK”.
+- **`POST /turn/heartbeat`** — usage signal for scheduled idle-stop (Dynamo scheduler).
+- **`turn-scheduled` Lambda** — periodic **DescribeInstances** / optional **StopInstances** (see `lambda/src/turnScheduled.ts`, `turn.tf`).
+- Terraform leaves **`turn.<domain>`** at **`127.0.0.1`** until the HTTP path updates it — see deploy README.
+
+---
+
+## 5. Lambdas (what each is for)
+
+| Lambda | Trigger | Role |
+|--------|---------|------|
+| **`…-http`** | API Gateway HTTP routes | **Rooms** (`/rooms`, `/join`), **TURN control** (`/turn/*`), **idle abandon** (`/rooms/abandon-idle`), JWT mint/verify helpers. |
+| **`…-ws`** | API Gateway WebSocket `$connect`, `$default`, `$disconnect` | **Signaling relay** only: `hello`, roster, **`SignalingRelay`** forwarding between `connectionId`s stored in DynamoDB. |
+| **`turn-scheduled`** (optional) | EventBridge rate | **EC2 lifecycle** for coturn when idle / backoff (no browser traffic). |
+
+DynamoDB is a **single table** for room meta, WebSocket connection rows, reverse index for disconnect, and TURN scheduler aggregates — see **`lambda/src/storage.ts`**.
+
+---
+
+## 6. Shell integration (where this meets the table)
+
+- **`src/ui/MultiplayerPanel.tsx`** — host/join UI, signaling + peer status, optional **Start relay**, idle modal, JWT for heartbeats.
+- **`src/App.tsx`** — wires **`RoomHost`** / **`RoomClient`** to **`GameSession`**: host applies intents, broadcasts snapshots.
+- **Online multiplayer** is **host-authoritative**: clients never mutate table state directly; they send **intents** over the data channel.
+
+---
+
+## 7. CI / deploy (reference only)
+
+- **CI** — lint, tests, site build, lambda bundle (see `.github/workflows/ci.yml`).
+- **Deploy** — Terraform apply → build site with baked `VITE_*` → S3 sync → CloudFront invalidation (see `.github/workflows/deploy.yml`).
+
+For **variables, secrets, custom domains, TURN secrets, and outputs**, use:
+
+- **[`deploy/terraform/aws/README.md`](../deploy/terraform/aws/README.md)**
+
+---
+
+## 8. Further reading
+
+| Topic | Location |
+|--------|----------|
+| Per-game modules, `GameModule`, AI | [`AGENTS.md`](../AGENTS.md) |
+| Room chat UX + protocol | [`docs/multiplayer-chat.md`](multiplayer-chat.md) |
+| Wire protocol types | `src/net/protocol.ts` |
+| Terraform resource list | [`deploy/terraform/aws/README.md`](../deploy/terraform/aws/README.md) |


### PR DESCRIPTION
## Summary

Adds **[`docs/architecture.md`](docs/architecture.md)** — a single place for **system-level** flows: browser vs AWS, **HTTP** vs **WebSocket** vs **WebRTC data channel**, signaling relay vs **P2P** game traffic, optional **TURN/coturn** and Route 53, and what each **Lambda** is for. Uses **Mermaid** diagrams for quick orientation.

The doc **prominently references** **[`deploy/terraform/aws/README.md`](deploy/terraform/aws/README.md)** for Terraform resources, env vars, DNS/TLS, and deploy/CI — so deployment detail stays in one canonical file.

## README / AGENTS

- **`README.md`**: new **Architecture** section + table row linking `docs/architecture.md`.
- **`AGENTS.md`**: repository layout row for discoverability.

## Notes

- Per-game rules and `GameModule` depth remain in **`AGENTS.md`**; this doc is the **network + multiplayer + AWS** map only.
