### PR TITLE
fix(net): TURN UDP + TCP for VPN-restrictive networks

### DIFF
--- a/src/net/config.ts
+++ b/src/net/config.ts
@@ -48,8 +48,9 @@ function buildDefaultIceServers(stunUrls: string[]): RTCIceServer[] {
   const user = envString(import.meta.env.VITE_MULTIPLAYER_TURN_USER)
   const cred = envString(import.meta.env.VITE_MULTIPLAYER_TURN_CREDENTIAL)
   if (host && user && cred) {
+    // UDP first; TCP fallback helps VPNs / networks that block UDP to TURN (coturn listens on 3478/tcp too).
     out.push({
-      urls: [`turn:${host}:3478`],
+      urls: [`turn:${host}:3478?transport=udp`, `turn:${host}:3478?transport=tcp`],
       username: user,
       credential: cred,
     })


### PR DESCRIPTION
## Summary

Advertises coturn on **both** `turn:…:3478?transport=udp` and `…?transport=tcp`. Many VPNs and corporate networks block **UDP** to arbitrary hosts; TCP to 3478 often still works (Terraform SG already allows TCP/UDP 3478).

## Context

WebRTC **signaling** (`Signaling: open`) only means the **WebSocket** to API Gateway works. **`Peer: connecting` → `closed`** means the **RTCPeerConnection** never reached `connected` (ICE/DTLS failed or timed out). This change targets a common cause when one side is on a VPN.
