### PR TITLE
feat(shell): allow 0 AI opponents on supported games

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This document summarizes how the **card-game** repository is structured, how gam
 |------|--------|
 | `src/App.tsx` | Game picker, session lifecycle, match panel, table intents (Go Fish, Skyjo, etc.), **Rules** modal, AI timers, optional **audio cues** (see `docs/audio-cues.md`, `src/audio/`). |
 | `src/session.ts` | **`createSession`**, **`startNextMatchRound`**, **`continuationOptionsFromSession`** (preserve house rules between match rounds). |
-| `src/session/playerConfig.ts` | **`CreateSessionOptions`** (AI count/difficulties, `skipMatch`, house-rule fields), **`gameSupportsConfigurableAi`**, **`clampAiOpponentCount`**, manifest AI count normalization. |
+| `src/session/playerConfig.ts` | **`CreateSessionOptions`** (AI count **0…8** on supported games, difficulties, `skipMatch`, house-rule fields), **`gameSupportsConfigurableAi`**, **`clampAiOpponentCount`**, **`configurableAiOpponentLimits`**, manifest AI count normalization. |
 | `src/core/` | **`GameModule`** contract, **`TableState`**, **`GameAction`**, **`MatchState`**, deck/build helpers, **`registerGameModule`**, shuffle, YAML parsing entry points. |
 | `src/core/discardRecycle.ts` | When the draw pile is empty, optionally **shuffle the discard pile into a new draw pile**; **`isDeckDrawAvailableAfterOptionalRecycle`** for legal-action checks without mutating the table. Used by games with both **`draw`** and **`discard`** when **`reshuffleDiscardWhenDrawEmpty`** is on. |
 | `src/core/types.ts` | Shared types: **`CardInstance`**, **`CardTemplate`**, zones, **`GameManifestYaml`**, **`MatchManifestYaml`**, **`GameAction`** variants. |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,10 @@ import { GAME_IDS, GAME_SOURCES } from './data/manifests'
 import { rulesTextForGame, type RulesGameId } from './data/rulesSources'
 import {
   clampAiOpponentCount,
+  configurableAiOpponentLimits,
   gameSupportsConfigurableAi,
   gameSupportsOnlineMultiplayer,
   gameSupportsPerSeatAiDifficulty,
-  MAX_AI_OPPONENTS,
   MAX_REMOTE_HUMANS,
   normalizeAiDifficultiesForCount,
 } from './session/playerConfig'
@@ -376,6 +376,7 @@ function App() {
   }, [hostClientRoster])
 
   const selectedManifest = useMemo(() => parseGameManifestYaml(GAME_SOURCES[gameId]), [gameId])
+  const aiOpponentLimits = useMemo(() => configurableAiOpponentLimits(gameId), [gameId])
 
   const onlineClientShell = joinedAsClient || !!session?.net
   const networkSpectator = !!session?.net?.spectator
@@ -536,6 +537,7 @@ function App() {
 
   const onGameIdChange = useCallback((id: (typeof GAME_IDS)[number]) => {
     setGameId(id)
+    setAiOpponents((prev) => clampAiOpponentCount(id, prev))
     setSession(null)
     setGfAwaitingOpponent(false)
     setGfRank('A')
@@ -593,7 +595,7 @@ function App() {
     setSession(parsed)
     setGameId(parsed.manifest.id as (typeof GAME_IDS)[number])
     if (gameSupportsConfigurableAi(parsed.manifest.id)) {
-      setAiOpponents(parsed.manifest.players.ai)
+      setAiOpponents(clampAiOpponentCount(parsed.manifest.id, parsed.manifest.players.ai))
     }
     if (parsed.aiPlayerConfig?.difficulties?.length) {
       setAiDifficulties(parsed.aiPlayerConfig.difficulties)
@@ -1413,8 +1415,8 @@ function App() {
                       <input
                         className="app__inputNumber"
                         type="number"
-                        min={1}
-                        max={MAX_AI_OPPONENTS}
+                        min={aiOpponentLimits.min}
+                        max={aiOpponentLimits.max}
                         value={aiOpponents}
                         disabled={aiCountLocked || onlineClientShell}
                         title={
@@ -1422,7 +1424,7 @@ function App() {
                             ? 'Player count is set by the host while you are in an online room.'
                             : aiCountLocked
                               ? 'Finish or advance the match before changing player count.'
-                              : `1–${MAX_AI_OPPONENTS} computer players (${1 + aiOpponents} total). Applies on Start deal / New deal.`
+                              : `${aiOpponentLimits.min}–${aiOpponentLimits.max} computer opponents (${1 + aiOpponents} seats including you). 0 = human-only where supported. Applies on Start deal / New deal.`
                         }
                         onChange={(e) => {
                           const n = clampAiOpponentCount(gameId, Number(e.target.value))

--- a/src/session/playerConfig.test.ts
+++ b/src/session/playerConfig.test.ts
@@ -3,6 +3,7 @@ import type { GameManifestYaml } from '../core/types'
 import {
   clampAiOpponentCount,
   clampRemoteHumanCount,
+  configurableAiOpponentLimits,
   gameSupportsOnlineMultiplayer,
   manifestWithPlayerCounts,
   MAX_AI_OPPONENTS,
@@ -24,9 +25,25 @@ describe('clampAiOpponentCount', () => {
     expect(clampAiOpponentCount('blackjack', 5)).toBe(1)
   })
 
-  it('clamps to 1..MAX for normal games', () => {
-    expect(clampAiOpponentCount('go-fish', 0)).toBe(1)
+  it('allows 0..MAX for multi-seat configurable games', () => {
+    expect(clampAiOpponentCount('go-fish', 0)).toBe(0)
+    expect(clampAiOpponentCount('go-fish', -3)).toBe(0)
     expect(clampAiOpponentCount('go-fish', 100)).toBe(MAX_AI_OPPONENTS)
+  })
+
+  it('forces at least 1 AI for heads-up configurable titles', () => {
+    expect(clampAiOpponentCount('poker-draw', 0)).toBe(1)
+    expect(clampAiOpponentCount('poker-draw', 2)).toBe(1)
+  })
+})
+
+describe('configurableAiOpponentLimits', () => {
+  it('exposes 0..MAX for go-fish', () => {
+    expect(configurableAiOpponentLimits('go-fish')).toEqual({ min: 0, max: MAX_AI_OPPONENTS })
+  })
+
+  it('exposes 1..1 for poker-draw', () => {
+    expect(configurableAiOpponentLimits('poker-draw')).toEqual({ min: 1, max: 1 })
   })
 })
 

--- a/src/session/playerConfig.ts
+++ b/src/session/playerConfig.ts
@@ -2,11 +2,11 @@ import type { AiDifficulty } from '../core/aiContext'
 import { normalizeAiDifficulty } from '../core/aiContext'
 import type { GameManifestYaml } from '../core/types'
 
-/** Max AI opponents (player 0 is always human). Total players = 1 + this value, max 9. */
+/** Max AI opponents when the table is not heads-up-only. Total seats = `human + ai` (see manifest). */
 export const MAX_AI_OPPONENTS = 8
 
 export interface CreateSessionOptions {
-  /** AI opponent count; only applied for games in {@link gameSupportsConfigurableAi}. */
+  /** AI opponent count; only applied for games in {@link gameSupportsConfigurableAi}. Use **0** for human-only on supported titles; heads-up-only games still require **1**. */
   aiCount?: number
   /** One per AI seat (players 1…N); locked when the deal is created. */
   aiDifficulties?: AiDifficulty[]
@@ -83,8 +83,16 @@ const HEADS_UP_GAME_IDS = new Set([
 export function clampAiOpponentCount(gameId: string, requested: number): number {
   let n = Math.floor(Number(requested))
   if (!Number.isFinite(n)) n = 1
-  const maxAi = HEADS_UP_GAME_IDS.has(gameId) ? 1 : MAX_AI_OPPONENTS
-  return Math.min(maxAi, Math.max(1, n))
+  const headsUp = HEADS_UP_GAME_IDS.has(gameId)
+  const minAi = headsUp ? 1 : 0
+  const maxAi = headsUp ? 1 : MAX_AI_OPPONENTS
+  return Math.min(maxAi, Math.max(minAi, n))
+}
+
+/** Min/max for the shell AI-opponent control when {@link gameSupportsConfigurableAi} is true. */
+export function configurableAiOpponentLimits(gameId: string): { min: number; max: number } {
+  const headsUp = HEADS_UP_GAME_IDS.has(gameId)
+  return { min: headsUp ? 1 : 0, max: headsUp ? 1 : MAX_AI_OPPONENTS }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **0 AI opponents** is allowed for games that already support configurable AI count and are not heads-up-only (e.g. Go Fish, Skyjo).
- **Heads-up-only** titles (e.g. `poker-draw`, `heads-up-poker`) still clamp to **1** AI so the table stays valid.
- Toolbar **AI opponents** number input uses **`min`/`max`** from **`configurableAiOpponentLimits`**. Changing game or applying a client snapshot reclamps the value.

## How to verify

1. Pick **Go Fish** or **Skyjo**, set **AI opponents** to **0**, start — you should get a human-only table (no AI timers / no AI seats).
2. Switch to **Heads-up poker** — count should snap to **1**.
