### PR TITLE
Fix multiplayer hand visibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import {
   type PeerHostChatLine,
   type PeerHostSnapshot,
 } from './net/protocol'
-import { parseSessionSnapshot, serializeSessionSnapshot } from './net/sessionSnapshot'
+import { parseSessionSnapshot, serializeSessionSnapshotForViewer } from './net/sessionSnapshot'
 import { ChatToastStack } from './ui/ChatToastStack'
 import { MultiplayerPanel } from './ui/MultiplayerPanel'
 import { openChatPopoutWindow } from './ui/openChatPopout'
@@ -476,14 +476,10 @@ function App() {
       if (!roster.some((r) => r.state === 'open')) return
       const sess = sessionRef.current
       if (!sess) return
-      const base = serializeSessionSnapshot(sess)
-      if (!base) return
       const remoteHumans = Math.max(0, sess.manifest.players.human - 1)
-      host.broadcastSnapshot((seat) => ({
-        ...base,
-        viewerSeat: seat,
-        spectator: seat > remoteHumans,
-      }))
+      host.broadcastSnapshot((seat) =>
+        serializeSessionSnapshotForViewer(sess, seat, seat > remoteHumans),
+      )
     }
     pushSnapshotRef.current()
   }, [session])

--- a/src/net/sessionSnapshot.test.ts
+++ b/src/net/sessionSnapshot.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { GameManifestYaml, TableState } from '../core/types'
 import {
+  HIDDEN_CARD_TEMPLATE_ID,
   gridSeatCountFromTable,
   parseWireSeatProfiles,
+  projectTableForViewer,
   reconcileManifestPlayersForTable,
 } from './sessionSnapshot'
 
@@ -74,5 +76,80 @@ describe('parseWireSeatProfiles', () => {
     expect(parseWireSeatProfiles(null)).toBeUndefined()
     expect(parseWireSeatProfiles([])).toBeUndefined()
     expect(parseWireSeatProfiles([{ seat: 0, displayName: 'x' }])).toBeUndefined()
+  })
+})
+
+describe('projectTableForViewer', () => {
+  it('reveals only the viewer hand among hidden hands', () => {
+    const t: TableState = {
+      templates: {
+        a: { id: 'a', rank: 'A', suit: 'spades' },
+        k: { id: 'k', rank: 'K', suit: 'hearts' },
+        q: { id: 'q', rank: 'Q', suit: 'clubs' },
+      },
+      zones: {
+        'hand:0': {
+          id: 'hand:0',
+          kind: 'spread',
+          defaultFaceUp: false,
+          ownerPlayerIndex: 0,
+          cards: [{ instanceId: 'c0', templateId: 'a', faceUp: false }],
+        },
+        'hand:1': {
+          id: 'hand:1',
+          kind: 'spread',
+          defaultFaceUp: false,
+          ownerPlayerIndex: 1,
+          cards: [{ instanceId: 'c1', templateId: 'k', faceUp: false }],
+        },
+        'books:0': {
+          id: 'books:0',
+          kind: 'spread',
+          defaultFaceUp: true,
+          ownerPlayerIndex: 0,
+          cards: [{ instanceId: 'c2', templateId: 'q', faceUp: true }],
+        },
+      },
+      zoneOrder: ['hand:0', 'hand:1', 'books:0'],
+    }
+
+    const projected = projectTableForViewer(t, 1)
+
+    expect(projected.zones['hand:1']!.cards[0]).toMatchObject({
+      templateId: 'k',
+      faceUp: true,
+    })
+    expect(projected.zones['hand:0']!.cards[0]).toMatchObject({
+      templateId: HIDDEN_CARD_TEMPLATE_ID,
+      faceUp: false,
+    })
+    expect(projected.zones['books:0']!.cards[0]).toMatchObject({
+      templateId: 'q',
+      faceUp: true,
+    })
+    expect(t.zones['hand:1']!.cards[0]!.faceUp).toBe(false)
+  })
+
+  it('does not reveal a hand to spectators', () => {
+    const t: TableState = {
+      templates: { a: { id: 'a', rank: 'A', suit: 'spades' } },
+      zones: {
+        'hand:1': {
+          id: 'hand:1',
+          kind: 'spread',
+          defaultFaceUp: false,
+          ownerPlayerIndex: 1,
+          cards: [{ instanceId: 'c1', templateId: 'a', faceUp: false }],
+        },
+      },
+      zoneOrder: ['hand:1'],
+    }
+
+    const projected = projectTableForViewer(t, 1, true)
+
+    expect(projected.zones['hand:1']!.cards[0]).toMatchObject({
+      templateId: HIDDEN_CARD_TEMPLATE_ID,
+      faceUp: false,
+    })
   })
 })

--- a/src/net/sessionSnapshot.ts
+++ b/src/net/sessionSnapshot.ts
@@ -2,10 +2,17 @@ import { parseGameManifestYaml } from '../core/loadYaml'
 import { getGameModule } from '../core/registry'
 import type { GameModule } from '../core/gameModule'
 import type { MatchState } from '../core/match'
-import type { GameManifestYaml, TableState } from '../core/types'
+import type { CardInstance, CardTemplate, GameManifestYaml, TableState, Zone } from '../core/types'
 import { GAME_SOURCES } from '../data/manifests'
 import type { AiPlayerConfig, GameSession } from '../session'
 import type { SeatProfile } from '../session/seatProfiles'
+
+export const HIDDEN_CARD_TEMPLATE_ID = '__hidden__'
+
+const HIDDEN_CARD_TEMPLATE: CardTemplate = {
+  id: HIDDEN_CARD_TEMPLATE_ID,
+  label: 'Hidden',
+}
 
 /**
  * When the client falls back to YAML-only manifests (older hosts omitting `manifest` on the wire),
@@ -81,6 +88,77 @@ export function isSessionSnapshotWire(value: unknown): value is SessionSnapshotW
   return typeof v.gameId === 'string' && v.table !== undefined && v.table !== null && 'gameState' in v
 }
 
+function handOwnerFromZone(zone: Zone): number | null {
+  if (!zone.id.startsWith('hand:')) return null
+  if (typeof zone.ownerPlayerIndex === 'number') return zone.ownerPlayerIndex
+  const m = /^hand:(\d+)$/.exec(zone.id)
+  return m ? Number(m[1]) : null
+}
+
+function cardVisibleToViewer(zone: Zone, card: CardInstance, viewerSeat: number, spectator: boolean): boolean {
+  if (card.faceUp) return true
+  if (spectator) return false
+  return handOwnerFromZone(zone) === viewerSeat
+}
+
+function hiddenCard(card: CardInstance): CardInstance {
+  return {
+    ...card,
+    templateId: HIDDEN_CARD_TEMPLATE_ID,
+    faceUp: false,
+  }
+}
+
+/**
+ * Build the table view a specific remote seat is allowed to render:
+ * visible public cards stay visible, the viewer's own hand is revealed, and
+ * other hidden cards are replaced with an opaque placeholder.
+ */
+export function projectTableForViewer(table: TableState, viewerSeat: number, spectator = false): TableState {
+  const projected = JSON.parse(JSON.stringify(table)) as TableState
+  let usedHiddenTemplate = false
+
+  for (const zone of Object.values(projected.zones)) {
+    zone.cards = zone.cards.map((card) => {
+      if (cardVisibleToViewer(zone, card, viewerSeat, spectator)) {
+        const owner = handOwnerFromZone(zone)
+        return owner === viewerSeat && !spectator ? { ...card, faceUp: true } : card
+      }
+      usedHiddenTemplate = true
+      return hiddenCard(card)
+    })
+  }
+
+  if (usedHiddenTemplate) {
+    projected.templates = {
+      ...projected.templates,
+      [HIDDEN_CARD_TEMPLATE_ID]: HIDDEN_CARD_TEMPLATE,
+    }
+  }
+
+  return projected
+}
+
+function projectGameStateForViewer(gameState: unknown, viewerSeat: number, spectator: boolean): unknown {
+  const projected = JSON.parse(JSON.stringify(gameState)) as unknown
+  if (!projected || typeof projected !== 'object') return projected
+
+  const state = projected as {
+    currentPlayer?: unknown
+    pendingDraw?: unknown
+  }
+  if (!state.pendingDraw || typeof state.pendingDraw !== 'object') return projected
+
+  const pending = state.pendingDraw as CardInstance
+  const currentPlayer = typeof state.currentPlayer === 'number' ? state.currentPlayer : null
+  if (!spectator && currentPlayer === viewerSeat) {
+    state.pendingDraw = { ...pending, faceUp: true }
+  } else {
+    state.pendingDraw = hiddenCard(pending)
+  }
+  return projected
+}
+
 /** JSON-safe clone for host → DataChannel (drops functions / cycles). */
 export function serializeSessionSnapshot(session: GameSession): SessionSnapshotWire | null {
   try {
@@ -100,6 +178,22 @@ export function serializeSessionSnapshot(session: GameSession): SessionSnapshotW
     return wire
   } catch {
     return null
+  }
+}
+
+export function serializeSessionSnapshotForViewer(
+  session: GameSession,
+  viewerSeat: number,
+  spectator = false,
+): SessionSnapshotWire | null {
+  const wire = serializeSessionSnapshot(session)
+  if (!wire) return null
+  return {
+    ...wire,
+    table: projectTableForViewer(session.table, viewerSeat, spectator),
+    gameState: projectGameStateForViewer(session.gameState, viewerSeat, spectator),
+    viewerSeat,
+    spectator,
   }
 }
 


### PR DESCRIPTION
## Summary
- Send multiplayer clients a per-seat table snapshot so each remote player can see their own hidden hand.
- Redact hidden cards for other seats and spectators with an opaque placeholder.
- Cover the projection behavior with snapshot tests.

## Test plan
- npm run test:ci
- npm run lint
- npm run build


Made with [Cursor](https://cursor.com)