### PR TITLE
Fix Blackjack showdown hand reveal

### DIFF
--- a/src/ui/TableView.test.tsx
+++ b/src/ui/TableView.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import type { CardInstance, Zone } from '../core/types'
+import { shouldShowFaceForViewer } from './cardVisibility'
+
+describe('shouldShowFaceForViewer', () => {
+  it('shows intentionally revealed cards in another player hand', () => {
+    const dealerHand: Zone = {
+      id: 'hand:1',
+      kind: 'spread',
+      defaultFaceUp: true,
+      ownerPlayerIndex: 1,
+      cards: [],
+    }
+    const card: CardInstance = {
+      instanceId: 'dealer-up-card',
+      templateId: 'AS',
+      faceUp: true,
+    }
+
+    expect(shouldShowFaceForViewer(dealerHand, card, 0, 0)).toBe(true)
+  })
+
+  it('keeps face-down cards hidden even in another player hand', () => {
+    const opponentHand: Zone = {
+      id: 'hand:1',
+      kind: 'spread',
+      defaultFaceUp: false,
+      ownerPlayerIndex: 1,
+      cards: [],
+    }
+    const card: CardInstance = {
+      instanceId: 'opponent-hidden-card',
+      templateId: 'KH',
+      faceUp: false,
+    }
+
+    expect(shouldShowFaceForViewer(opponentHand, card, 0, 0)).toBe(false)
+  })
+})

--- a/src/ui/TableView.tsx
+++ b/src/ui/TableView.tsx
@@ -2,6 +2,7 @@ import { Fragment, useMemo, type MouseEvent } from 'react'
 import { playerSeatLabel } from '../core/playerLabels'
 import type { CardInstance, TableState, Zone } from '../core/types'
 import { CardView } from './CardView'
+import { shouldShowFaceForViewer } from './cardVisibility'
 import type { TableIntent } from './tableIntent'
 import { pointerModifiersFromEvent } from './tableIntent'
 import type { SkyjoDumpUiStep } from './tableUiFlow'
@@ -85,20 +86,6 @@ function zoneLabel(zone: Zone, humanPlayerIndex: number, getSeatDisplayName?: (i
     return i === humanPlayerIndex ? 'Your grid (3×4)' : `${other(i)}'s grid`
   }
   return zone.id
-}
-
-/** For stacks: show depth indicator; last card is visually on top */
-function shouldShowFaceForViewer(
-  zone: Zone,
-  card: CardInstance,
-  _cardIndex: number,
-  humanPlayerIndex: number,
-): boolean {
-  if (!card.faceUp) return false
-  if (zone.ownerPlayerIndex !== undefined && zone.ownerPlayerIndex !== humanPlayerIndex) {
-    if (zone.id.startsWith('pile:') || zone.id.startsWith('hand:')) return false
-  }
-  return true
 }
 
 type LayoutGroup =

--- a/src/ui/cardVisibility.ts
+++ b/src/ui/cardVisibility.ts
@@ -1,0 +1,10 @@
+import type { CardInstance, Zone } from '../core/types'
+
+export function shouldShowFaceForViewer(
+  _zone: Zone,
+  card: CardInstance,
+  _cardIndex: number,
+  _humanPlayerIndex: number,
+): boolean {
+  return card.faceUp
+}


### PR DESCRIPTION
## Summary
- Let `TableView` show cards that game modules have intentionally flipped face-up, including the Blackjack dealer hand at showdown.
- Keep face-down cards hidden, with a focused regression test for opponent/dealer hand visibility.

## Test plan
- npm run test:ci
- npm run lint
- npm run build

Fixes #41

Made with [Cursor](https://cursor.com)