### PR TITLE
Add PR preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,291 @@
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  TF_STATE_BUCKET: ${{ secrets.TF_STATE_BUCKET }}
+  TF_STATE_LOCK_TABLE: ${{ secrets.TF_STATE_LOCK_TABLE }}
+  TF_STATE_KEY: card-game/previews/pr-${{ github.event.pull_request.number }}/terraform.tfstate
+  TF_VAR_room_jwt_secret: ${{ secrets.ROOM_JWT_SECRET }}
+  TF_VAR_environment: pr-${{ github.event.pull_request.number }}
+  TF_VAR_aws_region: ${{ secrets.AWS_REGION }}
+  TF_VAR_custom_domain: pr-${{ github.event.pull_request.number }}.cardgame.michaelj43.dev
+  TF_VAR_site_hostname: pr-${{ github.event.pull_request.number }}.cardgame.michaelj43.dev
+  TF_VAR_http_api_hostname: api-pr-${{ github.event.pull_request.number }}.cardgame.michaelj43.dev
+  TF_VAR_ws_api_hostname: ws-pr-${{ github.event.pull_request.number }}.cardgame.michaelj43.dev
+  TF_VAR_turn_hostname: turn-pr-${{ github.event.pull_request.number }}.cardgame.michaelj43.dev
+  TF_VAR_site_bucket_force_destroy: "true"
+  TF_VAR_acm_certificate_arn: ${{ secrets.TF_ACM_CERTIFICATE_ARN }}
+  TF_VAR_route53_hosted_zone_id: ${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}
+
+jobs:
+  deploy:
+    name: Deploy preview
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+
+      - name: Install site deps
+        run: npm ci
+
+      - name: Install Lambda deps
+        working-directory: lambda
+        run: npm ci
+
+      - name: Build Lambdas
+        working-directory: lambda
+        run: npm run build
+
+      - name: Bundle Lambda zips
+        working-directory: lambda
+        run: npm run bundle
+
+      - name: Terraform init
+        working-directory: deploy/terraform/aws
+        run: |
+          terraform init \
+            -backend-config="bucket=${TF_STATE_BUCKET}" \
+            -backend-config="key=${TF_STATE_KEY}" \
+            -backend-config="region=${AWS_REGION}" \
+            -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
+            -backend-config="encrypt=true"
+
+      - name: Terraform apply
+        working-directory: deploy/terraform/aws
+        env:
+          TF_PREVIEW_TURN_EC2_ENABLED: ${{ vars.TF_PREVIEW_TURN_EC2_ENABLED }}
+          TURN_COTURN_STATIC_PASSWORD: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
+        run: |
+          set -e
+          if [ "${TF_PREVIEW_TURN_EC2_ENABLED}" = "true" ]; then
+            export TF_VAR_turn_ec2_enabled=true
+            export TF_VAR_turn_coturn_static_password="${TURN_COTURN_STATIC_PASSWORD}"
+          fi
+          terraform apply -auto-approve
+
+      - name: Capture Terraform outputs
+        id: tf
+        working-directory: deploy/terraform/aws
+        run: |
+          echo "site_bucket=$(terraform output -raw site_bucket)" >> "$GITHUB_OUTPUT"
+          echo "cloudfront_distribution_id=$(terraform output -raw cloudfront_distribution_id)" >> "$GITHUB_OUTPUT"
+          echo "cloudfront_domain=$(terraform output -raw cloudfront_domain)" >> "$GITHUB_OUTPUT"
+          echo "site_url=$(terraform output -raw site_url)" >> "$GITHUB_OUTPUT"
+          echo "http_api_url=$(terraform output -raw http_api_url)" >> "$GITHUB_OUTPUT"
+          echo "ws_api_url=$(terraform output -raw ws_api_url)" >> "$GITHUB_OUTPUT"
+          TURN_HOST="$(terraform output -raw turn_hostname 2>/dev/null || true)"
+          if [ "$TURN_HOST" = "null" ]; then TURN_HOST=""; fi
+          echo "turn_hostname=${TURN_HOST}" >> "$GITHUB_OUTPUT"
+
+      - name: Build site
+        env:
+          VITE_MULTIPLAYER_HTTP_URL: ${{ steps.tf.outputs.http_api_url }}
+          VITE_MULTIPLAYER_WS_URL: ${{ steps.tf.outputs.ws_api_url }}
+          VITE_MULTIPLAYER_TURN_HOST: ${{ steps.tf.outputs.turn_hostname }}
+          VITE_MULTIPLAYER_TURN_USER: cardgame
+          VITE_MULTIPLAYER_TURN_CREDENTIAL: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
+        run: npm run build
+
+      - name: Sync assets to S3
+        run: |
+          aws s3 sync dist/ "s3://${{ steps.tf.outputs.site_bucket }}" \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html"
+          aws s3 cp dist/index.html "s3://${{ steps.tf.outputs.site_bucket }}/index.html" \
+            --cache-control "public, max-age=60, must-revalidate"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ steps.tf.outputs.cloudfront_distribution_id }}" \
+            --paths "/*"
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- card-game-preview -->';
+            const body = [
+              marker,
+              '### Preview deployment',
+              '',
+              '- Site: ${{ steps.tf.outputs.site_url }}',
+              '- HTTP API: ${{ steps.tf.outputs.http_api_url }}',
+              '- WebSocket API: ${{ steps.tf.outputs.ws_api_url }}',
+              '- CloudFront: https://${{ steps.tf.outputs.cloudfront_domain }}',
+              '',
+              'This preview is isolated to PR #${{ github.event.pull_request.number }} and will be destroyed when the PR closes.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Summary
+        run: |
+          echo "### Preview deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Site: ${{ steps.tf.outputs.site_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- HTTP API: ${{ steps.tf.outputs.http_api_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- WS API: ${{ steps.tf.outputs.ws_api_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Terraform state key: \`${TF_STATE_KEY}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  teardown:
+    name: Teardown preview
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+
+      - name: Install Lambda deps
+        working-directory: lambda
+        run: npm ci
+
+      - name: Build Lambdas
+        working-directory: lambda
+        run: npm run build
+
+      - name: Bundle Lambda zips
+        working-directory: lambda
+        run: npm run bundle
+
+      - name: Terraform init
+        working-directory: deploy/terraform/aws
+        run: |
+          terraform init \
+            -backend-config="bucket=${TF_STATE_BUCKET}" \
+            -backend-config="key=${TF_STATE_KEY}" \
+            -backend-config="region=${AWS_REGION}" \
+            -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
+            -backend-config="encrypt=true"
+
+      - name: Terraform destroy
+        working-directory: deploy/terraform/aws
+        env:
+          TF_PREVIEW_TURN_EC2_ENABLED: ${{ vars.TF_PREVIEW_TURN_EC2_ENABLED }}
+          TURN_COTURN_STATIC_PASSWORD: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
+        run: |
+          set -e
+          if [ "${TF_PREVIEW_TURN_EC2_ENABLED}" = "true" ]; then
+            export TF_VAR_turn_ec2_enabled=true
+            export TF_VAR_turn_coturn_static_password="${TURN_COTURN_STATIC_PASSWORD}"
+          fi
+          terraform destroy -auto-approve
+
+      - name: Delete preview Terraform state
+        run: aws s3 rm "s3://${TF_STATE_BUCKET}/${TF_STATE_KEY}" || true
+
+      - name: Comment teardown
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- card-game-preview -->';
+            const body = [
+              marker,
+              '### Preview deployment',
+              '',
+              'Preview environment for PR #${{ github.event.pull_request.number }} has been destroyed.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Summary
+        run: |
+          echo "### Preview teardown" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Destroyed PR #${PR_NUMBER} preview resources." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Removed Terraform state key: \`${TF_STATE_KEY}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,11 @@ sweeper process.
 - `.github/workflows/deploy.yml` — OIDC-assumed role; applies Terraform, builds
   the site with endpoint URLs baked in, syncs to S3 and invalidates CloudFront.
   The deploy job targets GitHub **Environment** `production` (deployment history + URL in the repo UI).
+- `.github/workflows/preview.yml` — same-repository PR previews; creates a
+  per-PR Terraform stack/state key on open/update and destroys it on PR close.
+  Preview hostnames are `pr-<n>.cardgame.michaelj43.dev`,
+  `api-pr-<n>.cardgame.michaelj43.dev`, `ws-pr-<n>.cardgame.michaelj43.dev`,
+  and optional `turn-pr-<n>.cardgame.michaelj43.dev`.
 
 Required repository **Secrets** for deploy:
 
@@ -306,6 +311,11 @@ Deploy resolves URLs as: **Variables if non-empty, else Terraform outputs** for 
 Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable** `TF_CUSTOM_DOMAIN` and **Secret** `TF_ACM_CERTIFICATE_ARN` (ACM cert must be in **us-east-1**). Optional **Secret** `TF_ROUTE53_HOSTED_ZONE_ID` for Terraform-managed Route 53 aliases. See **`AWS_SETUP.md`** §7 and **`.github/workflows/deploy.yml`**; **`deploy/terraform/aws/README.md`** documents what Terraform creates.
 
 Optional **coturn on EC2** (Terraform `turn_ec2_enabled`: EC2, `turn.<domain>` A record, `turn-scheduled` Lambda): set repository **Variable** `TF_TURN_EC2_ENABLED` to **`true`** so deploy exports `TF_VAR_turn_ec2_enabled`. No effect unless **`TF_ROUTE53_HOSTED_ZONE_ID`** is also set (TURN requires managed apex/api/ws DNS). Defaults stay **off** so merges do not surprise-bill EC2.
+
+PR previews reuse the deploy secrets and require the ACM certificate to cover
+`*.cardgame.michaelj43.dev`. Repository **Variable**
+`TF_PREVIEW_TURN_EC2_ENABLED` controls whether previews create a per-PR coturn
+EC2 instance; keep it **`false`** unless testing TURN specifically.
 
 ### Future backlog (not in this PR)
 

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -12,17 +12,17 @@ Human-facing setup and CI are documented in the repository **README**, **`AGENTS
 |------|-----------|
 | Site | `aws_s3_bucket.site`, OAC, bucket policy, `aws_cloudfront_distribution.site` |
 | APIs | `aws_apigatewayv2_api` (HTTP + WebSocket), integrations, routes, stages, Lambda invoke permissions |
-| Custom TLS | When `custom_domain` + `acm_certificate_arn` are set: CloudFront **aliases** + viewer cert; `aws_apigatewayv2_domain_name` + `aws_apigatewayv2_api_mapping` for `api.<custom_domain>` and `ws.<custom_domain>` |
-| DNS | When `custom_domain` + `acm_certificate_arn` + `route53_hosted_zone_id` are set: `aws_route53_record` apex **A/AAAA** → CloudFront; `api` / `ws` **A** aliases → API Gateway regional domain targets |
+| Custom TLS | When custom hostnames + `acm_certificate_arn` are set: CloudFront **aliases** + viewer cert; `aws_apigatewayv2_domain_name` + `aws_apigatewayv2_api_mapping` for the HTTP and WebSocket API hostnames |
+| DNS | When custom hostnames + `acm_certificate_arn` + `route53_hosted_zone_id` are set: site **A/AAAA** → CloudFront; HTTP / WebSocket **A** aliases → API Gateway regional domain targets |
 | Data | `aws_dynamodb_table.rooms` (TTL) |
 | Compute | `aws_lambda_function` **http** / **ws** (+ optional **turn-scheduled**), log groups, IAM role + inline policy (+ optional **turn** inline policy) |
-| Optional TURN | When **`turn_ec2_enabled`** and Route 53 are on: coturn **EC2** (default VPC), **`turn.<custom_domain>`** A record (placeholder `127.0.0.1`; **HTTP Lambda** overwrites with public IP after `/turn/start`), EventBridge **15m** → idle-stop Lambda. **No EIP** (avoids EIP hourly charge while instance is stopped). |
+| Optional TURN | When **`turn_ec2_enabled`** and Route 53 are on: coturn **EC2** (default VPC), the configured TURN A record (placeholder `127.0.0.1`; **HTTP Lambda** overwrites with public IP after `/turn/start`), EventBridge **15m** → idle-stop Lambda. **No EIP** (avoids EIP hourly charge while instance is stopped). |
 
-**Certificate / region:** CloudFront requires an ACM cert in **`us-east-1`**. API Gateway regional custom domains use the same **`acm_certificate_arn`** in **`var.aws_region`** — use **`aws_region = "us-east-1"`** unless you split certs (not modeled as separate inputs). The cert must cover the site host and **`api.`** / **`ws.`** subdomains if those custom names are used.
+**Certificate / region:** CloudFront requires an ACM cert in **`us-east-1`**. API Gateway regional custom domains use the same **`acm_certificate_arn`** in **`var.aws_region`** — use **`aws_region = "us-east-1"`** unless you split certs (not modeled as separate inputs). The cert must cover the configured site, HTTP API, WebSocket API, and optional TURN hostnames. PR previews use wildcard sibling names such as `pr-123.cardgame.michaelj43.dev`, `api-pr-123.cardgame.michaelj43.dev`, `ws-pr-123.cardgame.michaelj43.dev`, and `turn-pr-123.cardgame.michaelj43.dev`.
 
-**Route 53:** `route53_hosted_zone_id` must refer to a **public** hosted zone whose **zone name equals** `custom_domain` (Terraform creates relative names `""`, `api`, `ws` under that zone). Apex cannot be a plain CNAME; aliases use Route 53 **alias A/AAAA** to CloudFront and **alias A** to API Gateway `domain_name_configuration.target_domain_name` / `hosted_zone_id`.
+**Route 53:** `route53_hosted_zone_id` must refer to a **public** hosted zone containing the configured hostnames. Apex cannot be a plain CNAME; aliases use Route 53 **alias A/AAAA** to CloudFront and **alias A** to API Gateway `domain_name_configuration.target_domain_name` / `hosted_zone_id`.
 
-**Lambda env:** HTTP Lambda `ALLOWED_ORIGIN` / CORS follow `site_browser_origin` in `site.tf` (`allowed_origin` override, else `https://<custom_domain>`, else CloudFront URL). `WS_PUBLIC_URL` uses **`wss://ws.<custom_domain>`** (no path) when a custom domain is enabled—the stage is bound by API mapping; the default execute-api URL still uses **`/{stage}`** (`lambda.tf`).
+**Lambda env:** HTTP Lambda `ALLOWED_ORIGIN` / CORS follow `site_browser_origin` in `site.tf` (`allowed_origin` override, else `https://<site hostname>`, else CloudFront URL). `WS_PUBLIC_URL` uses the configured WebSocket hostname (no path) when a custom domain is enabled—the stage is bound by API mapping; the default execute-api URL still uses **`/{stage}`** (`lambda.tf`).
 
 ---
 
@@ -33,10 +33,11 @@ Defined in **`variables.tf`**. Required for any apply: **`room_jwt_secret`**; La
 Notable optional inputs:
 
 - **`custom_domain`**, **`acm_certificate_arn`** — enable CloudFront alternate name + API Gateway custom domains + vanity-oriented outputs.
+- **`site_hostname`**, **`http_api_hostname`**, **`ws_api_hostname`**, **`turn_hostname`** — optional explicit hostnames. These default to `custom_domain`, `api.<site hostname>`, `ws.<site hostname>`, and `turn.<site hostname>` for production compatibility, and let PR previews use sibling names such as `api-pr-123...`.
 - **`route53_hosted_zone_id`** — manage the DNS records above (only with custom domain + cert).
 - **`allowed_origin`** — override browser origin string for CORS / Lambda when non-empty.
-- **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
-- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires **`custom_domain`**, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**. **GitHub Deploy** exports `TF_VAR_turn_ec2_enabled` when repository **Variable** **`TF_TURN_EC2_ENABLED`** is `true`; otherwise apply only updates the existing **http** / **ws** Lambdas and APIs (no EC2 or `turn.*` record).
+- **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, **`site_bucket_force_destroy`** (preview teardown only), room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
+- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires configured custom hostnames, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**. **GitHub Deploy** exports `TF_VAR_turn_ec2_enabled` when repository **Variable** **`TF_TURN_EC2_ENABLED`** is `true`; otherwise apply only updates the existing **http** / **ws** Lambdas and APIs (no EC2 or TURN record).
 - **`turn_coturn_static_password`** (default `""`, sensitive) — **required** when the TURN stack applies: long-term coturn password for user **`cardgame`**. You choose it once (e.g. password generator); pass the same value as GitHub Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`** so Terraform user-data and the Vite build both use it. Min **8** characters (after trim).
 
 ---
@@ -55,8 +56,11 @@ Notable optional inputs:
 | `cloudfront_distribution_id` | For `create-invalidation` |
 | `cloudfront_domain` | `*.cloudfront.net` hostname |
 | `site_url` | `https://<custom_domain>` when configured, else `https://<cloudfront_domain>` |
-| `http_api_url` | `https://api.<custom_domain>` when custom domain is on, else HTTP API `api_endpoint` |
-| `ws_api_url` | `wss://ws.<custom_domain>` (no `/stage` path) when custom domain is on; else default **execute-api** `wss://…amazonaws.com/{stage}` |
+| `http_api_url` | `https://<http_api_hostname>` when custom domain is on, else HTTP API `api_endpoint` |
+| `ws_api_url` | `wss://<ws_api_hostname>` (no `/stage` path) when custom domain is on; else default **execute-api** `wss://…amazonaws.com/{stage}` |
+| `site_hostname` | Resolved custom site hostname when custom domain is on |
+| `http_api_hostname` | Resolved custom HTTP API hostname when custom domain is on |
+| `ws_api_hostname` | Resolved custom WebSocket API hostname when custom domain is on |
 | `rooms_table` | DynamoDB table name |
 | `http_regional_domain_name` | `d-…execute-api…` target for the **HTTP** custom domain (compare to Route 53 `api` alias) |
 | `ws_regional_domain_name` | `d-…execute-api…` target for the **WebSocket** custom domain (compare to Route 53 `ws` alias) |
@@ -92,6 +96,29 @@ Then redeploy the site. The HTTP Lambda waits for **EC2 status checks OK** befor
 The site build consumes **`http_api_url`** and **`ws_api_url`** as **`VITE_MULTIPLAYER_HTTP_URL`** / **`VITE_MULTIPLAYER_WS_URL`** when those env vars are not overridden in CI.
 
 If **`wss://ws.<domain>/prod` returns 403** but **`wss://ws.<domain>` connects**, the stage is already set by **API mapping**—use **no path** in the client URL (Terraform outputs match this). If **`wss://ws.<domain>`** still fails, check the **`ws`** Route 53 alias targets **`ws_regional_domain_name`**, not the HTTP API’s regional hostname.
+
+---
+
+## PR previews
+
+`.github/workflows/preview.yml` creates a full temporary environment for each same-repository PR and destroys it when the PR closes. Each preview uses its own S3 backend key:
+
+```bash
+card-game/previews/pr-<number>/terraform.tfstate
+```
+
+Preview hostnames are:
+
+| Endpoint | Hostname |
+|----------|----------|
+| Site | `pr-<number>.cardgame.michaelj43.dev` |
+| HTTP API | `api-pr-<number>.cardgame.michaelj43.dev` |
+| WebSocket API | `ws-pr-<number>.cardgame.michaelj43.dev` |
+| Optional TURN | `turn-pr-<number>.cardgame.michaelj43.dev` |
+
+The preview workflow reuses the production AWS secrets (`AWS_ROLE_ARN`, `AWS_REGION`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`, `ROOM_JWT_SECRET`, `TF_ACM_CERTIFICATE_ARN`, `TF_ROUTE53_HOSTED_ZONE_ID`). The ACM certificate must cover `*.cardgame.michaelj43.dev`. Per-PR TURN EC2 is controlled by repository Variable `TF_PREVIEW_TURN_EC2_ENABLED`; leave it `false` to avoid preview EC2 cost.
+
+On PR close, the workflow runs `terraform destroy` with the same state key and variables, then removes the preview state object from S3. `site_bucket_force_destroy` is set for previews so the temporary S3 bucket can be deleted after assets have been uploaded.
 
 ---
 

--- a/deploy/terraform/aws/apigateway.tf
+++ b/deploy/terraform/aws/apigateway.tf
@@ -120,12 +120,12 @@ resource "aws_lambda_permission" "ws_invoke" {
   source_arn    = "${aws_apigatewayv2_api.ws.execution_arn}/*/*"
 }
 
-# Regional custom hostnames (TLS) for api.<custom_domain> and ws.<custom_domain>.
+# Regional custom hostnames (TLS) for the HTTP and WebSocket APIs.
 # Certificate must be in the same region as var.aws_region (same ARN as CloudFront when aws_region = us-east-1).
 resource "aws_apigatewayv2_domain_name" "http" {
-  count = local.use_custom_domain ? 1 : 0
+  count = local.use_api_custom_domains ? 1 : 0
 
-  domain_name = "api.${local.custom_domain_host}"
+  domain_name = local.http_api_hostname
 
   domain_name_configuration {
     certificate_arn = trimspace(var.acm_certificate_arn)
@@ -137,9 +137,9 @@ resource "aws_apigatewayv2_domain_name" "http" {
 }
 
 resource "aws_apigatewayv2_domain_name" "ws" {
-  count = local.use_custom_domain ? 1 : 0
+  count = local.use_api_custom_domains ? 1 : 0
 
-  domain_name = "ws.${local.custom_domain_host}"
+  domain_name = local.ws_api_hostname
 
   domain_name_configuration {
     certificate_arn = trimspace(var.acm_certificate_arn)
@@ -151,7 +151,7 @@ resource "aws_apigatewayv2_domain_name" "ws" {
 }
 
 resource "aws_apigatewayv2_api_mapping" "http" {
-  count = local.use_custom_domain ? 1 : 0
+  count = local.use_api_custom_domains ? 1 : 0
 
   api_id      = aws_apigatewayv2_api.http.id
   domain_name = aws_apigatewayv2_domain_name.http[0].domain_name
@@ -159,7 +159,7 @@ resource "aws_apigatewayv2_api_mapping" "http" {
 }
 
 resource "aws_apigatewayv2_api_mapping" "ws" {
-  count = local.use_custom_domain ? 1 : 0
+  count = local.use_api_custom_domains ? 1 : 0
 
   api_id      = aws_apigatewayv2_api.ws.id
   domain_name = aws_apigatewayv2_domain_name.ws[0].domain_name

--- a/deploy/terraform/aws/iam.tf
+++ b/deploy/terraform/aws/iam.tf
@@ -21,7 +21,7 @@ resource "aws_iam_role_policy_attachment" "lambda_basic" {
 
 data "aws_iam_policy_document" "lambda_inline" {
   statement {
-    sid     = "Dynamo"
+    sid = "Dynamo"
     actions = [
       "dynamodb:GetItem",
       "dynamodb:PutItem",

--- a/deploy/terraform/aws/lambda.tf
+++ b/deploy/terraform/aws/lambda.tf
@@ -13,11 +13,11 @@ resource "aws_cloudwatch_log_group" "ws" {
 locals {
   http_lambda_env_turn = local.turn_stack ? {
     TURN_EC2_INSTANCE_ID     = aws_instance.turn[0].id
-    TURN_ROUTE53_ZONE_ID      = local.route53_zone_id
-    TURN_ROUTE53_RECORD_NAME  = "turn.${local.custom_domain_host}"
-    WS_MANAGEMENT_API_URL     = "https://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
-    TURN_MAX_UPTIME_SECONDS   = "14400"
-    TURN_USAGE_GRACE_SECONDS   = "900"
+    TURN_ROUTE53_ZONE_ID     = local.route53_zone_id
+    TURN_ROUTE53_RECORD_NAME = local.turn_hostname
+    WS_MANAGEMENT_API_URL    = "https://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+    TURN_MAX_UPTIME_SECONDS  = "14400"
+    TURN_USAGE_GRACE_SECONDS = "900"
   } : {}
 }
 
@@ -36,9 +36,9 @@ resource "aws_lambda_function" "http" {
   environment {
     variables = merge(
       {
-        ROOMS_TABLE     = aws_dynamodb_table.rooms.name
-        ROOM_JWT_SECRET = var.room_jwt_secret
-        WS_PUBLIC_URL = local.use_custom_domain ? "wss://ws.${local.custom_domain_host}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+        ROOMS_TABLE      = aws_dynamodb_table.rooms.name
+        ROOM_JWT_SECRET  = var.room_jwt_secret
+        WS_PUBLIC_URL    = local.use_api_custom_domains ? "wss://${local.ws_api_hostname}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
         ALLOWED_ORIGIN   = local.site_browser_origin
         ROOM_TTL_SECONDS = tostring(var.room_ttl_seconds)
       },
@@ -64,8 +64,8 @@ resource "aws_lambda_function" "ws" {
 
   environment {
     variables = {
-      ROOMS_TABLE              = aws_dynamodb_table.rooms.name
-      ROOM_JWT_SECRET          = var.room_jwt_secret
+      ROOMS_TABLE               = aws_dynamodb_table.rooms.name
+      ROOM_JWT_SECRET           = var.room_jwt_secret
       WS_CONNECTION_TTL_SECONDS = tostring(var.ws_connection_ttl_seconds)
     }
   }

--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -15,17 +15,32 @@ output "cloudfront_domain" {
 
 output "site_url" {
   description = "Public site URL."
-  value       = local.use_custom_domain ? "https://${local.custom_domain_host}" : "https://${aws_cloudfront_distribution.site.domain_name}"
+  value       = local.use_custom_domain ? "https://${local.site_hostname}" : "https://${aws_cloudfront_distribution.site.domain_name}"
 }
 
 output "http_api_url" {
-  description = "HTTP API base URL for VITE_MULTIPLAYER_HTTP_URL: vanity https://api.<custom_domain> when custom domain is enabled, else execute-api URL."
-  value       = local.use_custom_domain ? "https://api.${local.custom_domain_host}" : aws_apigatewayv2_api.http.api_endpoint
+  description = "HTTP API base URL for VITE_MULTIPLAYER_HTTP_URL: vanity custom hostname when custom domain is enabled, else execute-api URL."
+  value       = local.use_api_custom_domains ? "https://${local.http_api_hostname}" : aws_apigatewayv2_api.http.api_endpoint
 }
 
 output "ws_api_url" {
-  description = "WebSocket URL for VITE_MULTIPLAYER_WS_URL: vanity wss://ws.<custom_domain> (no path) when custom domain + API mapping bind the stage; default execute-api URL still uses /{stage}."
-  value       = local.use_custom_domain ? "wss://ws.${local.custom_domain_host}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+  description = "WebSocket URL for VITE_MULTIPLAYER_WS_URL: vanity custom hostname (no path) when custom domain + API mapping bind the stage; default execute-api URL still uses /{stage}."
+  value       = local.use_api_custom_domains ? "wss://${local.ws_api_hostname}" : "wss://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
+}
+
+output "site_hostname" {
+  description = "Resolved custom site hostname, if custom domain is enabled."
+  value       = local.use_custom_domain ? local.site_hostname : null
+}
+
+output "http_api_hostname" {
+  description = "Resolved custom HTTP API hostname, if API custom domains are enabled."
+  value       = local.use_api_custom_domains ? local.http_api_hostname : null
+}
+
+output "ws_api_hostname" {
+  description = "Resolved custom WebSocket API hostname, if API custom domains are enabled."
+  value       = local.use_api_custom_domains ? local.ws_api_hostname : null
 }
 
 output "rooms_table" {
@@ -45,7 +60,7 @@ output "ws_regional_domain_name" {
 
 output "turn_hostname" {
   description = "FQDN for coturn when turn_ec2_enabled (use as VITE_MULTIPLAYER_TURN_HOST); null otherwise."
-  value       = local.turn_stack ? "turn.${local.custom_domain_host}" : null
+  value       = local.turn_stack ? local.turn_hostname : null
 }
 
 output "turn_coturn_static_password" {

--- a/deploy/terraform/aws/route53.tf
+++ b/deploy/terraform/aws/route53.tf
@@ -1,11 +1,11 @@
-# Public DNS in Route 53 when the hosted zone domain equals custom_domain
-# (e.g. zone "cardgame.michaelj43.dev" for site https://cardgame.michaelj43.dev).
+# Public DNS in Route 53 for configured custom hostnames.
+# The hosted zone must contain the site/API/TURN hostnames.
 
 resource "aws_route53_record" "site_apex_a" {
   count = local.create_route53_records ? 1 : 0
 
   zone_id = local.route53_zone_id
-  name    = ""
+  name    = local.site_hostname
   type    = "A"
 
   alias {
@@ -19,7 +19,7 @@ resource "aws_route53_record" "site_apex_aaaa" {
   count = local.create_route53_records ? 1 : 0
 
   zone_id = local.route53_zone_id
-  name    = ""
+  name    = local.site_hostname
   type    = "AAAA"
 
   alias {
@@ -33,7 +33,7 @@ resource "aws_route53_record" "http_api_a" {
   count = local.create_route53_records ? 1 : 0
 
   zone_id = local.route53_zone_id
-  name    = "api"
+  name    = local.http_api_hostname
   type    = "A"
 
   alias {
@@ -47,7 +47,7 @@ resource "aws_route53_record" "ws_api_a" {
   count = local.create_route53_records ? 1 : 0
 
   zone_id = local.route53_zone_id
-  name    = "ws"
+  name    = local.ws_api_hostname
   type    = "A"
 
   alias {

--- a/deploy/terraform/aws/site.tf
+++ b/deploy/terraform/aws/site.tf
@@ -3,8 +3,9 @@ locals {
 }
 
 resource "aws_s3_bucket" "site" {
-  bucket = local.site_bucket_name
-  tags   = local.common_tags
+  bucket        = local.site_bucket_name
+  force_destroy = var.site_bucket_force_destroy
+  tags          = local.common_tags
 }
 
 resource "aws_s3_bucket_public_access_block" "site" {
@@ -33,18 +34,43 @@ resource "aws_cloudfront_origin_access_control" "site" {
 }
 
 locals {
-  custom_domain_host = var.custom_domain != null ? trimspace(var.custom_domain) : ""
-  use_custom_domain    = local.custom_domain_host != "" && var.acm_certificate_arn != null && trimspace(var.acm_certificate_arn) != ""
-  route53_zone_id      = var.route53_hosted_zone_id != null ? trimspace(var.route53_hosted_zone_id) : ""
-  create_route53_records = local.use_custom_domain && local.route53_zone_id != ""
+  custom_domain_host  = var.custom_domain != null ? trimspace(var.custom_domain) : ""
+  site_hostname_input = var.site_hostname != null ? trimspace(var.site_hostname) : ""
+  site_hostname = coalesce(
+    local.site_hostname_input != "" ? local.site_hostname_input : null,
+    local.custom_domain_host != "" ? local.custom_domain_host : null,
+    "",
+  )
+  http_api_hostname_input = var.http_api_hostname != null ? trimspace(var.http_api_hostname) : ""
+  http_api_hostname = coalesce(
+    local.http_api_hostname_input != "" ? local.http_api_hostname_input : null,
+    local.site_hostname != "" ? "api.${local.site_hostname}" : null,
+    "",
+  )
+  ws_api_hostname_input = var.ws_api_hostname != null ? trimspace(var.ws_api_hostname) : ""
+  ws_api_hostname = coalesce(
+    local.ws_api_hostname_input != "" ? local.ws_api_hostname_input : null,
+    local.site_hostname != "" ? "ws.${local.site_hostname}" : null,
+    "",
+  )
+  turn_hostname_input = var.turn_hostname != null ? trimspace(var.turn_hostname) : ""
+  turn_hostname = coalesce(
+    local.turn_hostname_input != "" ? local.turn_hostname_input : null,
+    local.site_hostname != "" ? "turn.${local.site_hostname}" : null,
+    "",
+  )
+  use_custom_domain      = local.site_hostname != "" && var.acm_certificate_arn != null && trimspace(var.acm_certificate_arn) != ""
+  use_api_custom_domains = local.use_custom_domain && local.http_api_hostname != "" && local.ws_api_hostname != ""
+  route53_zone_id        = var.route53_hosted_zone_id != null ? trimspace(var.route53_hosted_zone_id) : ""
+  create_route53_records = local.use_api_custom_domains && local.route53_zone_id != ""
   /** Optional coturn EC2 + turn.* DNS + scheduled stop (requires Route 53 on custom domain). */
-  turn_stack = var.turn_ec2_enabled && local.create_route53_records
+  turn_stack = var.turn_ec2_enabled && local.create_route53_records && local.turn_hostname != ""
   # Never call trimspace(null): Terraform may evaluate both branches of a ternary / coalesce args.
   allowed_origin_trimmed = var.allowed_origin != null ? trimspace(var.allowed_origin) : ""
   # Browser Origin header for CORS / Lambda: explicit override, else HTTPS custom host, else CloudFront hostname.
   site_browser_origin = coalesce(
     local.allowed_origin_trimmed != "" ? local.allowed_origin_trimmed : null,
-    local.use_custom_domain ? "https://${local.custom_domain_host}" : null,
+    local.use_custom_domain ? "https://${local.site_hostname}" : null,
     "https://${aws_cloudfront_distribution.site.domain_name}",
   )
 }
@@ -56,7 +82,7 @@ resource "aws_cloudfront_distribution" "site" {
   comment             = "${local.name} static site"
   price_class         = "PriceClass_100"
 
-  aliases = local.use_custom_domain ? [local.custom_domain_host] : []
+  aliases = local.use_custom_domain ? [local.site_hostname] : []
 
   origin {
     domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
@@ -109,8 +135,8 @@ resource "aws_cloudfront_distribution" "site" {
 
 data "aws_iam_policy_document" "site_bucket" {
   statement {
-    sid     = "CloudFrontRead"
-    actions = ["s3:GetObject"]
+    sid       = "CloudFrontRead"
+    actions   = ["s3:GetObject"]
     resources = ["${aws_s3_bucket.site.arn}/*"]
     principals {
       type        = "Service"

--- a/deploy/terraform/aws/turn.tf
+++ b/deploy/terraform/aws/turn.tf
@@ -1,5 +1,5 @@
-# Optional coturn EC2 + turn.<custom_domain> A record + EventBridge idle scheduler.
-# Requires: custom_domain, Route 53 zone, turn_ec2_enabled = true.
+# Optional coturn EC2 + TURN DNS record + EventBridge idle scheduler.
+# Requires: custom hostnames, Route 53 zone, turn_ec2_enabled = true.
 
 data "aws_vpc" "default" {
   count   = local.turn_stack ? 1 : 0
@@ -71,7 +71,7 @@ resource "aws_instance" "turn" {
   associate_public_ip_address = true
 
   user_data = base64encode(templatefile("${path.module}/turn-user-data.sh.tpl", {
-    realm         = local.custom_domain_host
+    realm         = local.turn_hostname
     turn_user     = "cardgame"
     turn_password = trimspace(var.turn_coturn_static_password)
   }))
@@ -97,7 +97,7 @@ resource "aws_instance" "turn" {
 resource "aws_route53_record" "turn_a" {
   count   = local.turn_stack ? 1 : 0
   zone_id = local.route53_zone_id
-  name    = "turn"
+  name    = local.turn_hostname
   type    = "A"
   ttl     = 60
   records = ["127.0.0.1"]
@@ -162,10 +162,10 @@ resource "aws_lambda_function" "turn_scheduled" {
 
   environment {
     variables = {
-      ROOMS_TABLE               = aws_dynamodb_table.rooms.name
-      TURN_EC2_INSTANCE_ID      = aws_instance.turn[0].id
-      TURN_MAX_UPTIME_SECONDS     = "14400"
-      TURN_USAGE_GRACE_SECONDS    = "900"
+      ROOMS_TABLE              = aws_dynamodb_table.rooms.name
+      TURN_EC2_INSTANCE_ID     = aws_instance.turn[0].id
+      TURN_MAX_UPTIME_SECONDS  = "14400"
+      TURN_USAGE_GRACE_SECONDS = "900"
     }
   }
 

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -22,20 +22,50 @@ variable "site_bucket_name" {
   default     = null
 }
 
+variable "site_bucket_force_destroy" {
+  description = "When true, delete all objects while destroying the site bucket. Intended for ephemeral preview environments."
+  type        = bool
+  default     = false
+}
+
 variable "custom_domain" {
-  description = "Optional CloudFront alias (e.g. card-game.example.com). Requires acm_certificate_arn."
+  description = "Optional default site hostname / CloudFront alias (e.g. card-game.example.com). Requires acm_certificate_arn."
+  type        = string
+  default     = null
+}
+
+variable "site_hostname" {
+  description = "Optional explicit site hostname. Defaults to custom_domain when unset."
+  type        = string
+  default     = null
+}
+
+variable "http_api_hostname" {
+  description = "Optional explicit HTTP API hostname. Defaults to api.<site hostname> when unset."
+  type        = string
+  default     = null
+}
+
+variable "ws_api_hostname" {
+  description = "Optional explicit WebSocket API hostname. Defaults to ws.<site hostname> when unset."
+  type        = string
+  default     = null
+}
+
+variable "turn_hostname" {
+  description = "Optional explicit TURN hostname. Defaults to turn.<site hostname> when unset."
   type        = string
   default     = null
 }
 
 variable "acm_certificate_arn" {
-  description = "ACM public cert ARN used for CloudFront (must be in us-east-1) and, when custom_domain is set, for API Gateway custom domains api./ws. (must be in the same region as aws_region — use us-east-1 for both). Must cover custom_domain and api.* / ws.* (e.g. include *.cardgame.example.com)."
+  description = "ACM public cert ARN used for CloudFront (must be in us-east-1) and, when custom hostnames are set, for API Gateway custom domains. (must be in the same region as aws_region — use us-east-1 for both). Must cover the site, HTTP API, WebSocket API, and optional TURN hostnames."
   type        = string
   default     = null
 }
 
 variable "route53_hosted_zone_id" {
-  description = "Optional Route 53 public hosted zone id (e.g. Z…) whose domain name equals custom_domain. When set with custom_domain + acm_certificate_arn, creates alias records: apex → CloudFront, api → HTTP API, ws → WebSocket API."
+  description = "Optional Route 53 public hosted zone id (e.g. Z…) that contains the configured hostnames. When set with hostnames + acm_certificate_arn, creates alias records for site, HTTP API, WebSocket API, and optional TURN."
   type        = string
   default     = null
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,6 +186,7 @@ DynamoDB is a **single table** for room meta, WebSocket connection rows, reverse
 
 - **CI** — lint, tests, site build, lambda bundle (see `.github/workflows/ci.yml`).
 - **Deploy** — Terraform apply → build site with baked `VITE_*` → S3 sync → CloudFront invalidation (see `.github/workflows/deploy.yml`).
+- **PR previews** — same AWS stack shape with per-PR Terraform state, preview DNS (`pr-<n>`, `api-pr-<n>`, `ws-pr-<n>`, optional `turn-pr-<n>`), and automatic `terraform destroy` on PR close (see `.github/workflows/preview.yml`).
 
 For **variables, secrets, custom domains, TURN secrets, and outputs**, use:
 


### PR DESCRIPTION
## Summary
- Add a PR preview workflow that provisions isolated AWS infrastructure per same-repository PR, builds the site with PR-specific endpoints, comments preview URLs, and destroys the stack on PR close.
- Parameterize Terraform custom hostnames so previews can use `pr-<n>`, `api-pr-<n>`, `ws-pr-<n>`, and optional `turn-pr-<n>` without changing production defaults.
- Document preview setup, wildcard certificate requirements, S3 force-destroy behavior, and the `TF_PREVIEW_TURN_EC2_ENABLED` toggle.

## Test plan
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/preview.yml"); puts "preview workflow yaml ok"'`
- `terraform fmt -check -recursive && terraform validate`
- `npm run lint && npm run test:ci && npm run build`
- `npm --prefix lambda run build && npm --prefix lambda run test && npm --prefix lambda run bundle`


Made with [Cursor](https://cursor.com)