### PR TITLE
Scale coturn relay infrastructure

### DIFF
--- a/.github/workflows/build-relay-ami.yml
+++ b/.github/workflows/build-relay-ami.yml
@@ -1,0 +1,126 @@
+name: Build relay AMI
+
+on:
+  workflow_call:
+    inputs:
+      promote:
+        description: Update TF_TURN_AMI_ID after a successful build.
+        required: false
+        type: boolean
+        default: false
+      force_build:
+        description: Build even when the Packer file did not change.
+        required: false
+        type: boolean
+        default: false
+      pr_number:
+        description: Pull request number for PR-scoped AMI tags.
+        required: false
+        type: string
+        default: ""
+    outputs:
+      ami_id:
+        description: AMI id produced by Packer, or empty when skipped.
+        value: ${{ jobs.build.outputs.ami_id }}
+  workflow_dispatch:
+    inputs:
+      promote:
+        description: Update TF_TURN_AMI_ID after a successful build.
+        required: true
+        type: boolean
+        default: false
+      pr_number:
+        description: Optional PR number for PR-scoped AMI tags.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      ami_id: ${{ steps.capture.outputs.ami_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect Packer changes
+        id: changes
+        env:
+          FORCE_BUILD: ${{ inputs.force_build || github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          elif [ -n "${{ github.event.before || '' }}" ] && [ "${{ github.event.before || '' }}" != "0000000000000000000000000000000000000000" ]; then
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          else
+            BASE="HEAD~1"
+            HEAD="HEAD"
+          fi
+
+          if git diff --name-only "$BASE" "$HEAD" | grep -Eq '^(packer/relay-coturn\.pkr\.hcl|\.github/workflows/build-relay-ami\.yml)$'; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.changes.outputs.build == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: hashicorp/setup-packer@v3
+        if: steps.changes.outputs.build == 'true'
+        with:
+          version: latest
+
+      - name: Build coturn AMI
+        if: steps.changes.outputs.build == 'true'
+        env:
+          PKR_VAR_aws_region: ${{ secrets.AWS_REGION }}
+          PKR_VAR_source_sha: ${{ github.sha }}
+          PKR_VAR_pr_number: ${{ inputs.pr_number || github.event.pull_request.number || '' }}
+        run: |
+          set -euo pipefail
+          packer init packer/relay-coturn.pkr.hcl
+          packer validate packer/relay-coturn.pkr.hcl
+          packer build -machine-readable packer/relay-coturn.pkr.hcl | tee packer-relay-ami.log
+
+      - name: Capture AMI id
+        id: capture
+        run: |
+          set -euo pipefail
+          if [ ! -f packer-relay-ami.log ]; then
+            echo "ami_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          AMI_ID="$(awk -F, '/artifact,0,id/ {print $6}' packer-relay-ami.log | tail -1 | sed 's/^.*://')"
+          if [ -z "$AMI_ID" ]; then
+            echo "::error::Could not parse AMI id from Packer output."
+            exit 1
+          fi
+          echo "ami_id=${AMI_ID}" >> "$GITHUB_OUTPUT"
+          echo "Built relay AMI: ${AMI_ID}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Promote AMI variable
+        if: inputs.promote && steps.capture.outputs.ami_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AMI_ID: ${{ steps.capture.outputs.ami_id }}
+        run: gh variable set TF_TURN_AMI_ID --body "$AMI_ID" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,10 @@ on:
       - 'src/**'
       - 'lambda/**'
       - 'deploy/terraform/**'
+      - 'terraform/**'
+      - 'packer/**'
       - '.github/workflows/deploy.yml'
+      - '.github/workflows/build-relay-ami.yml'
       - 'package.json'
       - 'package-lock.json'
 
@@ -21,13 +24,21 @@ permissions:
   id-token: write
   contents: read
   deployments: write
+  actions: write
 
 concurrency:
   group: deploy-${{ github.event.inputs.environment || 'prod' }}
   cancel-in-progress: false
 
 jobs:
+  build-relay-ami:
+    uses: ./.github/workflows/build-relay-ami.yml
+    with:
+      promote: true
+    secrets: inherit
+
   deploy:
+    needs: build-relay-ami
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -40,6 +51,8 @@ jobs:
       TF_VAR_room_jwt_secret: ${{ secrets.ROOM_JWT_SECRET }}
       TF_VAR_environment: ${{ github.event.inputs.environment || 'prod' }}
       TF_VAR_aws_region: ${{ secrets.AWS_REGION }}
+      PACKER_RELAY_AMI_ID: ${{ needs.build-relay-ami.outputs.ami_id }}
+      PROMOTED_RELAY_AMI_ID: ${{ vars.TF_TURN_AMI_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -98,12 +111,14 @@ jobs:
           if [ -n "${{ secrets.TF_ACM_CERTIFICATE_ARN }}" ]; then export TF_VAR_acm_certificate_arn="${{ secrets.TF_ACM_CERTIFICATE_ARN }}"; fi
           if [ -n "${{ vars.TF_ALLOWED_ORIGIN }}" ]; then export TF_VAR_allowed_origin="${{ vars.TF_ALLOWED_ORIGIN }}"; fi
           if [ -n "${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}" ]; then export TF_VAR_route53_hosted_zone_id="${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}"; fi
+          RELAY_AMI_ID="${PACKER_RELAY_AMI_ID:-${PROMOTED_RELAY_AMI_ID:-}}"
+          if [ -n "$RELAY_AMI_ID" ]; then export TF_VAR_turn_ami_id="$RELAY_AMI_ID"; fi
           # Optional coturn EC2 + turn.* DNS + turn-scheduled Lambda (only when Route 53 is also configured).
           if [ "${{ vars.TF_TURN_EC2_ENABLED }}" = "true" ]; then
             export TF_VAR_turn_ec2_enabled=true
             export TF_VAR_turn_coturn_static_password="${TURN_COTURN_STATIC_PASSWORD}"
           fi
-          terraform apply -auto-approve
+          terraform apply -auto-approve -var-file=../../../terraform/prod.tfvars
 
       - name: Capture Terraform outputs
         id: tf

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: preview-pr-${{ github.event.pull_request.number }}
@@ -33,10 +34,23 @@ env:
   TF_VAR_route53_hosted_zone_id: ${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}
 
 jobs:
+  build-relay-ami:
+    name: Build PR relay AMI
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/build-relay-ami.yml
+    with:
+      promote: false
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit
+
   deploy:
     name: Deploy preview
+    needs: build-relay-ami
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    env:
+      PACKER_RELAY_AMI_ID: ${{ needs.build-relay-ami.outputs.ami_id }}
+      PROMOTED_RELAY_AMI_ID: ${{ vars.TF_TURN_AMI_ID }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,11 +103,13 @@ jobs:
           TURN_COTURN_STATIC_PASSWORD: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
         run: |
           set -e
+          RELAY_AMI_ID="${PACKER_RELAY_AMI_ID:-${PROMOTED_RELAY_AMI_ID:-}}"
+          if [ -n "$RELAY_AMI_ID" ]; then export TF_VAR_turn_ami_id="$RELAY_AMI_ID"; fi
           if [ "${TF_PREVIEW_TURN_EC2_ENABLED}" = "true" ]; then
             export TF_VAR_turn_ec2_enabled=true
             export TF_VAR_turn_coturn_static_password="${TURN_COTURN_STATIC_PASSWORD}"
           fi
-          terraform apply -auto-approve
+          terraform apply -auto-approve -var-file=../../../terraform/preview.tfvars
 
       - name: Capture Terraform outputs
         id: tf
@@ -241,10 +257,26 @@ jobs:
             export TF_VAR_turn_ec2_enabled=true
             export TF_VAR_turn_coturn_static_password="${TURN_COTURN_STATIC_PASSWORD}"
           fi
-          terraform destroy -auto-approve
+          terraform destroy -auto-approve -var-file=../../../terraform/preview.tfvars
 
       - name: Delete preview Terraform state
         run: aws s3 rm "s3://${TF_STATE_BUCKET}/${TF_STATE_KEY}" || true
+
+      - name: Delete PR relay AMIs
+        run: |
+          set -e
+          AMIS="$(aws ec2 describe-images \
+            --owners self \
+            --filters "Name=tag:CardGameRelayAmiScope,Values=pr" "Name=tag:CardGamePullRequest,Values=${PR_NUMBER}" \
+            --query 'Images[].ImageId' \
+            --output text || true)"
+          for AMI in $AMIS; do
+            SNAPSHOTS="$(aws ec2 describe-images --image-ids "$AMI" --query 'Images[].BlockDeviceMappings[].Ebs.SnapshotId' --output text || true)"
+            aws ec2 deregister-image --image-id "$AMI" || true
+            for SNAPSHOT in $SNAPSHOTS; do
+              aws ec2 delete-snapshot --snapshot-id "$SNAPSHOT" || true
+            done
+          done
 
       - name: Comment teardown
         uses: actions/github-script@v7

--- a/.github/workflows/relay-perf.yml
+++ b/.github/workflows/relay-perf.yml
@@ -1,0 +1,197 @@
+name: Relay Perf
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to test and comment on
+        required: true
+        type: string
+      max_allocations:
+        description: Maximum TURN allocation step to attempt
+        required: false
+        default: "20"
+        type: string
+      duration_seconds:
+        description: Duration per allocation step
+        required: false
+        default: "60"
+        type: string
+      asg_max_size:
+        description: Relay ASG max size for this perf run
+        required: false
+        default: "2"
+        type: string
+      instance_type:
+        description: Relay instance type for this perf run
+        required: false
+        default: "t3.micro"
+        type: string
+      destroy_after:
+        description: Destroy the perf stack after the run
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: relay-perf-pr-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+env:
+  PR_NUMBER: ${{ inputs.pr_number }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  TF_STATE_BUCKET: ${{ secrets.TF_STATE_BUCKET }}
+  TF_STATE_LOCK_TABLE: ${{ secrets.TF_STATE_LOCK_TABLE }}
+  TF_STATE_KEY: card-game/perf/pr-${{ inputs.pr_number }}/terraform.tfstate
+  TF_VAR_room_jwt_secret: ${{ secrets.ROOM_JWT_SECRET }}
+  TF_VAR_environment: perf-pr-${{ inputs.pr_number }}
+  TF_VAR_aws_region: ${{ secrets.AWS_REGION }}
+  TF_VAR_custom_domain: perf-pr-${{ inputs.pr_number }}.cardgame.michaelj43.dev
+  TF_VAR_site_hostname: perf-pr-${{ inputs.pr_number }}.cardgame.michaelj43.dev
+  TF_VAR_http_api_hostname: api-perf-pr-${{ inputs.pr_number }}.cardgame.michaelj43.dev
+  TF_VAR_ws_api_hostname: ws-perf-pr-${{ inputs.pr_number }}.cardgame.michaelj43.dev
+  TF_VAR_turn_hostname: turn-perf-pr-${{ inputs.pr_number }}.cardgame.michaelj43.dev
+  TF_VAR_acm_certificate_arn: ${{ secrets.TF_ACM_CERTIFICATE_ARN }}
+  TF_VAR_route53_hosted_zone_id: ${{ secrets.TF_ROUTE53_HOSTED_ZONE_ID }}
+  TF_VAR_turn_ec2_enabled: "true"
+  TF_VAR_turn_coturn_static_password: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
+  TF_VAR_turn_asg_max_size: ${{ inputs.asg_max_size }}
+  TF_VAR_turn_instance_type: ${{ inputs.instance_type }}
+  TF_VAR_turn_ami_id: ${{ vars.TF_TURN_AMI_ID }}
+
+jobs:
+  perf:
+    if: vars.TF_RELAY_PERF_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+
+      - name: Install site deps
+        run: npm ci
+
+      - name: Install Lambda deps
+        working-directory: lambda
+        run: npm ci
+
+      - name: Build Lambdas
+        working-directory: lambda
+        run: npm run build
+
+      - name: Bundle Lambda zips
+        working-directory: lambda
+        run: npm run bundle
+
+      - name: Install TURN load tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y coturn
+
+      - name: Terraform init
+        working-directory: deploy/terraform/aws
+        run: |
+          terraform init \
+            -backend-config="bucket=${TF_STATE_BUCKET}" \
+            -backend-config="key=${TF_STATE_KEY}" \
+            -backend-config="region=${AWS_REGION}" \
+            -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
+            -backend-config="encrypt=true"
+
+      - name: Terraform apply
+        working-directory: deploy/terraform/aws
+        run: terraform apply -auto-approve -var-file=../../../terraform/relay-perf.tfvars
+
+      - name: Capture Terraform outputs
+        id: tf
+        working-directory: deploy/terraform/aws
+        run: |
+          echo "http_api_url=$(terraform output -raw http_api_url)" >> "$GITHUB_OUTPUT"
+          TURN_HOST="$(terraform output -raw turn_hostname 2>/dev/null || true)"
+          if [ "$TURN_HOST" = "null" ]; then TURN_HOST=""; fi
+          echo "turn_hostname=${TURN_HOST}" >> "$GITHUB_OUTPUT"
+
+      - name: Run relay performance test
+        env:
+          RELAY_PERF_HTTP_URL: ${{ steps.tf.outputs.http_api_url }}
+          RELAY_PERF_TURN_HOST: ${{ steps.tf.outputs.turn_hostname }}
+          RELAY_PERF_TURN_USER: cardgame
+          RELAY_PERF_TURN_CREDENTIAL: ${{ secrets.TURN_COTURN_STATIC_PASSWORD }}
+          RELAY_PERF_MAX_ALLOCATIONS: ${{ inputs.max_allocations }}
+          RELAY_PERF_DURATION_SECONDS: ${{ inputs.duration_seconds }}
+          RELAY_PERF_ASG_NAME: card-game-perf-pr-${{ inputs.pr_number }}-coturn
+          RELAY_PERF_OUT_DIR: relay-perf-results
+        run: node scripts/relay-perf/run.mjs
+
+      - name: Upload relay perf artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: relay-perf-pr-${{ inputs.pr_number }}
+          path: relay-perf-results/
+
+      - name: Comment relay perf results
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- card-game-relay-perf -->';
+            const path = 'relay-perf-results/relay-perf.md';
+            const body = fs.existsSync(path)
+              ? fs.readFileSync(path, 'utf8')
+              : `${marker}\n### Relay performance test\n\nThe relay perf workflow did not produce a report. Check the workflow logs.`;
+            const { owner, repo } = context.repo;
+            const issue_number = Number('${{ inputs.pr_number }}');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Terraform destroy
+        if: always() && inputs.destroy_after
+        working-directory: deploy/terraform/aws
+        run: terraform destroy -auto-approve -var-file=../../../terraform/relay-perf.tfvars
+
+      - name: Delete relay perf Terraform state
+        if: always() && inputs.destroy_after
+        run: aws s3 rm "s3://${TF_STATE_BUCKET}/${TF_STATE_KEY}" || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,11 +212,13 @@ npm run bundle  # zip dist/ into http.zip + websocket.zip for Terraform
 npm run test    # vitest run
 ```
 
-Infra lives in `deploy/terraform/aws/` (see its `README.md`). The GitHub Actions
-workflow `.github/workflows/deploy.yml` runs build + bundle + terraform apply +
-S3 sync + CloudFront invalidation on pushes to `main`. One-time AWS/GitHub
-bootstrap steps are tracked in the gitignored `AWS_SETUP.md` (kept out of the
-repo on purpose).
+Infra lives in `deploy/terraform/aws/` (see its `README.md`). Root-level
+`terraform/*.tfvars` files hold non-secret environment defaults for prod,
+preview, and relay perf runs. The GitHub Actions workflow
+`.github/workflows/deploy.yml` runs build + bundle + terraform apply + S3 sync
++ CloudFront invalidation on pushes to `main`. One-time AWS/GitHub bootstrap
+steps are tracked in the gitignored `AWS_SETUP.md` (kept out of the repo on
+purpose).
 
 ---
 
@@ -284,14 +286,25 @@ sweeper process.
 ### GitHub Actions
 
 - `.github/workflows/ci.yml` — lint, test (site + lambda), build on every PR/push.
-- `.github/workflows/deploy.yml` — OIDC-assumed role; applies Terraform, builds
-  the site with endpoint URLs baked in, syncs to S3 and invalidates CloudFront.
-  The deploy job targets GitHub **Environment** `production` (deployment history + URL in the repo UI).
+- `.github/workflows/deploy.yml` — OIDC-assumed role; optionally builds a fresh
+  relay AMI when `packer/relay-coturn.pkr.hcl` changed, applies Terraform,
+  builds the site with endpoint URLs baked in, syncs to S3 and invalidates
+  CloudFront. The deploy job targets GitHub **Environment** `production`
+  (deployment history + URL in the repo UI).
 - `.github/workflows/preview.yml` — same-repository PR previews; creates a
   per-PR Terraform stack/state key on open/update and destroys it on PR close.
   Preview hostnames are `pr-<n>.cardgame.michaelj43.dev`,
   `api-pr-<n>.cardgame.michaelj43.dev`, `ws-pr-<n>.cardgame.michaelj43.dev`,
-  and optional `turn-pr-<n>.cardgame.michaelj43.dev`.
+  and optional `turn-pr-<n>.cardgame.michaelj43.dev`. If a PR changes the relay
+  Packer file, preview builds a PR-scoped AMI and passes it only to that PR
+  stack; it never updates the main `TF_TURN_AMI_ID` variable.
+- `.github/workflows/build-relay-ami.yml` — reusable/manual Packer workflow for
+  `packer/relay-coturn.pkr.hcl`. `main` builds promote the AMI id to repository
+  Variable `TF_TURN_AMI_ID`; PR builds are isolated and cleaned up with preview
+  teardown.
+- `.github/workflows/relay-perf.yml` — manual, gated relay perf workflow. It
+  creates a separate `perf-pr-<n>` stack, runs TURN allocation/throughput checks,
+  uploads raw artifacts, and updates a PR comment.
 
 Required repository **Secrets** for deploy:
 
@@ -312,10 +325,22 @@ Custom site hostname (e.g. `cardgame.michaelj43.dev`): set repository **Variable
 
 Optional **coturn on EC2** (Terraform `turn_ec2_enabled`: EC2, `turn.<domain>` A record, `turn-scheduled` Lambda): set repository **Variable** `TF_TURN_EC2_ENABLED` to **`true`** so deploy exports `TF_VAR_turn_ec2_enabled`. No effect unless **`TF_ROUTE53_HOSTED_ZONE_ID`** is also set (TURN requires managed apex/api/ws DNS). Defaults stay **off** so merges do not surprise-bill EC2.
 
+Relay compute can run in either the legacy single-instance mode or ASG mode via
+`turn_compute_mode` in `terraform/prod.tfvars` / `terraform/preview.tfvars` /
+`terraform/relay-perf.tfvars`. The current planned default is ASG-backed coturn:
+`/turn/start` sets desired capacity to at least one, `/turn/status` reconciles
+Route 53 with healthy relay IPs, and `turn-scheduled` scales back down after
+uptime/idle rules. `TF_TURN_AMI_ID` is a generated repository Variable managed
+by the Packer workflow; do not hard-code AMI ids in docs or workflows unless
+debugging a one-off run.
+
 PR previews reuse the deploy secrets and require the ACM certificate to cover
 `*.cardgame.michaelj43.dev`. Repository **Variable**
-`TF_PREVIEW_TURN_EC2_ENABLED` controls whether previews create a per-PR coturn
-EC2 instance; keep it **`false`** unless testing TURN specifically.
+`TF_PREVIEW_TURN_EC2_ENABLED` controls whether previews create per-PR coturn
+relay compute; keep it **`false`** unless testing TURN specifically.
+
+Repository **Variable** `TF_RELAY_PERF_ENABLED` gates the manual relay perf
+workflow. Keep it **`false`** unless intentionally running capacity tests.
 
 ### Future backlog (not in this PR)
 

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -39,7 +39,7 @@ Notable optional inputs:
 - **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, **`site_bucket_force_destroy`** (preview teardown only), room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
 - **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires configured custom hostnames, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **GitHub Deploy** exports `TF_VAR_turn_ec2_enabled` when repository **Variable** **`TF_TURN_EC2_ENABLED`** is `true`; otherwise apply only updates the existing **http** / **ws** Lambdas and APIs (no relay compute or TURN record).
 - **`turn_compute_mode`** (`instance` or `asg`) — `instance` preserves the original single-EC2 start/stop model; `asg` creates a launch template, Auto Scaling Group, target-tracking CPU policy, and Lambda desired-capacity control.
-- **`turn_ami_id`** — optional pre-baked coturn AMI. CI updates repository Variable **`TF_TURN_AMI_ID`** after successful mainline Packer builds; deploy/preview/perf pass it as `TF_VAR_turn_ami_id`. Empty falls back to latest AL2023 and user-data installs coturn.
+- **`turn_ami_id`** — optional pre-baked coturn AMI. CI updates repository Variable **`TF_TURN_AMI_ID`** after successful mainline Packer builds; deploy/preview/perf pass it as `TF_VAR_turn_ami_id`. Empty falls back to latest Ubuntu 24.04 LTS and user-data installs coturn.
 - **`turn_instance_type`**, **`turn_asg_min_size`**, **`turn_asg_desired_capacity`**, **`turn_asg_max_size`**, **`turn_asg_cpu_target_percent`**, **`turn_relay_min_port`**, **`turn_relay_max_port`** — relay sizing/scaling inputs. Defaults for prod/preview/perf live in root-level `terraform/*.tfvars`.
 - **`turn_coturn_static_password`** (default `""`, sensitive) — **required** when the TURN stack applies: long-term coturn password for user **`cardgame`**. You choose it once (e.g. password generator); pass the same value as GitHub Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`** so Terraform user-data and the Vite build both use it. Min **8** characters (after trim).
 
@@ -110,7 +110,7 @@ Then redeploy the site. The HTTP Lambda requests relay capacity on `/turn/start`
 
 ### Packer-built relay AMIs
 
-`packer/relay-coturn.pkr.hcl` builds an Amazon Linux 2023 coturn AMI with packages installed and the service enabled. It does **not** bake TURN credentials into the image; Terraform user-data still writes `/etc/turnserver.conf` with the environment-specific realm, user, password, and relay port range.
+`packer/relay-coturn.pkr.hcl` builds an Ubuntu 24.04 LTS coturn AMI with packages installed and the service enabled. It does **not** bake TURN credentials into the image; Terraform user-data still writes `/etc/turnserver.conf` with the environment-specific realm, user, password, and relay port range.
 
 `.github/workflows/build-relay-ami.yml` is used by deploy/preview workflows before Terraform:
 

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -16,7 +16,7 @@ Human-facing setup and CI are documented in the repository **README**, **`AGENTS
 | DNS | When custom hostnames + `acm_certificate_arn` + `route53_hosted_zone_id` are set: site **A/AAAA** → CloudFront; HTTP / WebSocket **A** aliases → API Gateway regional domain targets |
 | Data | `aws_dynamodb_table.rooms` (TTL) |
 | Compute | `aws_lambda_function` **http** / **ws** (+ optional **turn-scheduled**), log groups, IAM role + inline policy (+ optional **turn** inline policy) |
-| Optional TURN | When **`turn_ec2_enabled`** and Route 53 are on: coturn **EC2** (default VPC), the configured TURN A record (placeholder `127.0.0.1`; **HTTP Lambda** overwrites with public IP after `/turn/start`), EventBridge **15m** → idle-stop Lambda. **No EIP** (avoids EIP hourly charge while instance is stopped). |
+| Optional TURN | When **`turn_ec2_enabled`** and Route 53 are on: coturn on either a single **EC2** instance or an **Auto Scaling Group** (`turn_compute_mode`), the configured TURN A record (placeholder `127.0.0.1`; Lambdas overwrite it with live public IPs), EventBridge **15m** → idle scale-down Lambda. **No EIP** (avoids EIP hourly charge while stopped / scaled to zero). |
 
 **Certificate / region:** CloudFront requires an ACM cert in **`us-east-1`**. API Gateway regional custom domains use the same **`acm_certificate_arn`** in **`var.aws_region`** — use **`aws_region = "us-east-1"`** unless you split certs (not modeled as separate inputs). The cert must cover the configured site, HTTP API, WebSocket API, and optional TURN hostnames. PR previews use wildcard sibling names such as `pr-123.cardgame.michaelj43.dev`, `api-pr-123.cardgame.michaelj43.dev`, `ws-pr-123.cardgame.michaelj43.dev`, and `turn-pr-123.cardgame.michaelj43.dev`.
 
@@ -37,8 +37,19 @@ Notable optional inputs:
 - **`route53_hosted_zone_id`** — manage the DNS records above (only with custom domain + cert).
 - **`allowed_origin`** — override browser origin string for CORS / Lambda when non-empty.
 - **`aws_region`**, **`project`**, **`environment`**, **`tags`**, **`site_bucket_name`**, **`site_bucket_force_destroy`** (preview teardown only), room / connection TTLs, zip paths, **`site_assets_dir`** (used by automation that syncs `dist/`).
-- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires configured custom hostnames, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **`turn_instance_type`**, **`scheduled_lambda_zip`**. **GitHub Deploy** exports `TF_VAR_turn_ec2_enabled` when repository **Variable** **`TF_TURN_EC2_ENABLED`** is `true`; otherwise apply only updates the existing **http** / **ws** Lambdas and APIs (no EC2 or TURN record).
+- **`turn_ec2_enabled`** (default `false`) — optional coturn stack; requires configured custom hostnames, **`acm_certificate_arn`**, and **`route53_hosted_zone_id`**. **GitHub Deploy** exports `TF_VAR_turn_ec2_enabled` when repository **Variable** **`TF_TURN_EC2_ENABLED`** is `true`; otherwise apply only updates the existing **http** / **ws** Lambdas and APIs (no relay compute or TURN record).
+- **`turn_compute_mode`** (`instance` or `asg`) — `instance` preserves the original single-EC2 start/stop model; `asg` creates a launch template, Auto Scaling Group, target-tracking CPU policy, and Lambda desired-capacity control.
+- **`turn_ami_id`** — optional pre-baked coturn AMI. CI updates repository Variable **`TF_TURN_AMI_ID`** after successful mainline Packer builds; deploy/preview/perf pass it as `TF_VAR_turn_ami_id`. Empty falls back to latest AL2023 and user-data installs coturn.
+- **`turn_instance_type`**, **`turn_asg_min_size`**, **`turn_asg_desired_capacity`**, **`turn_asg_max_size`**, **`turn_asg_cpu_target_percent`**, **`turn_relay_min_port`**, **`turn_relay_max_port`** — relay sizing/scaling inputs. Defaults for prod/preview/perf live in root-level `terraform/*.tfvars`.
 - **`turn_coturn_static_password`** (default `""`, sensitive) — **required** when the TURN stack applies: long-term coturn password for user **`cardgame`**. You choose it once (e.g. password generator); pass the same value as GitHub Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`** so Terraform user-data and the Vite build both use it. Min **8** characters (after trim).
+
+Root-level config files keep non-secret sizing defaults out of GitHub Variables:
+
+| File | Role |
+|------|------|
+| `terraform/prod.tfvars` | Production relay mode and ASG sizing defaults. |
+| `terraform/preview.tfvars` | PR preview defaults, including force-destroy buckets and low-cost relay capacity. |
+| `terraform/relay-perf.tfvars` | Manual relay performance-test defaults. |
 
 ---
 
@@ -65,6 +76,8 @@ Notable optional inputs:
 | `http_regional_domain_name` | `d-…execute-api…` target for the **HTTP** custom domain (compare to Route 53 `api` alias) |
 | `ws_regional_domain_name` | `d-…execute-api…` target for the **WebSocket** custom domain (compare to Route 53 `ws` alias) |
 | `turn_hostname` | e.g. `turn.<custom_domain>` when TURN stack is enabled; else `null` |
+| `turn_compute_mode` | `instance` or `asg` when TURN is enabled; else `null` |
+| `turn_asg_name` | ASG name when `turn_compute_mode = "asg"`; else `null` |
 | `turn_coturn_static_password` | Sensitive echo of the configured coturn password when TURN is on (avoid printing in CI); user **`cardgame`** in user-data |
 
 **TURN / DNS:** There is **no** `VITE_MULTIPLAYER_TURN_URL` — WebRTC uses a `turn:` URL, which the app builds from the host. **One password, one secret:** create a strong password (min 8 characters), store it as GitHub Actions **Secret** **`TURN_COTURN_STATIC_PASSWORD`**. The **Deploy** workflow passes it to Terraform as **`TF_VAR_turn_coturn_static_password`** (coturn on EC2) and to Vite as **`VITE_MULTIPLAYER_TURN_CREDENTIAL`**, so you do not copy values out of `terraform output` after each apply.
@@ -74,6 +87,8 @@ Notable optional inputs:
 | **Secret** `TURN_COTURN_STATIC_PASSWORD` | Your chosen coturn password (same value for Terraform + browser bundle). |
 | **Variable** `VITE_MULTIPLAYER_TURN_HOST` | Hostname only, e.g. `turn.cardgame.michaelj43.dev` (same as `terraform output -raw turn_hostname`). **Do not** use `https://` or a path. |
 | **Variable** `VITE_MULTIPLAYER_TURN_USER` | `cardgame` (matches Terraform user-data). |
+| **Variable** `TF_TURN_AMI_ID` | Generated by mainline Packer builds; deploy/preview/perf use it as the promoted coturn AMI when no PR-scoped AMI was built. |
+| **Variable** `TF_RELAY_PERF_ENABLED` | Set to `true` only when intentionally allowing manual relay perf stacks. |
 
 If you previously used **`VITE_MULTIPLAYER_TURN_CREDENTIAL`** as a separate Actions secret, remove it and use **`TURN_COTURN_STATIC_PASSWORD`** only (both Terraform and Vite read that name in deploy).
 
@@ -91,7 +106,19 @@ If you previously used **`VITE_MULTIPLAYER_TURN_CREDENTIAL`** as a separate Acti
 | **`:` in password** | coturn’s `user=name:secret` line treats the **first** `:` as the split between username and password, so a password may contain **additional** colons. |
 | **`#` in password** | Should be OK in the middle of a `user=` line in `turnserver.conf` (comments are line-oriented); if you hit parse issues, avoid `#` at the start of the password. |
 
-Then redeploy the site. The HTTP Lambda waits for **EC2 status checks OK** before updating Route 53; the scheduled Lambda stops the instance only after **4h uptime** and **15m** without usage heartbeats (see app).
+Then redeploy the site. The HTTP Lambda requests relay capacity on `/turn/start` and returns quickly; `/turn/status` polls readiness and reconciles Route 53 when public relay IPs are healthy. The scheduled Lambda scales down only after **4h uptime** and **15m** without usage heartbeats (see app).
+
+### Packer-built relay AMIs
+
+`packer/relay-coturn.pkr.hcl` builds an Amazon Linux 2023 coturn AMI with packages installed and the service enabled. It does **not** bake TURN credentials into the image; Terraform user-data still writes `/etc/turnserver.conf` with the environment-specific realm, user, password, and relay port range.
+
+`.github/workflows/build-relay-ami.yml` is used by deploy/preview workflows before Terraform:
+
+- PRs that change the Packer file build a PR-scoped AMI and pass it only to that PR preview deploy.
+- `main` builds promote the AMI by updating repository Variable **`TF_TURN_AMI_ID`**, and the same deploy run uses the fresh AMI output directly.
+- Runs without Packer changes fall back to the current **`TF_TURN_AMI_ID`** value.
+
+PR AMIs are tagged with `CardGameRelayAmiScope=pr` and `CardGamePullRequest=<number>` so preview teardown can deregister them.
 
 The site build consumes **`http_api_url`** and **`ws_api_url`** as **`VITE_MULTIPLAYER_HTTP_URL`** / **`VITE_MULTIPLAYER_WS_URL`** when those env vars are not overridden in CI.
 
@@ -116,9 +143,19 @@ Preview hostnames are:
 | WebSocket API | `ws-pr-<number>.cardgame.michaelj43.dev` |
 | Optional TURN | `turn-pr-<number>.cardgame.michaelj43.dev` |
 
-The preview workflow reuses the production AWS secrets (`AWS_ROLE_ARN`, `AWS_REGION`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`, `ROOM_JWT_SECRET`, `TF_ACM_CERTIFICATE_ARN`, `TF_ROUTE53_HOSTED_ZONE_ID`). The ACM certificate must cover `*.cardgame.michaelj43.dev`. Per-PR TURN EC2 is controlled by repository Variable `TF_PREVIEW_TURN_EC2_ENABLED`; leave it `false` to avoid preview EC2 cost.
+The preview workflow reuses the production AWS secrets (`AWS_ROLE_ARN`, `AWS_REGION`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`, `ROOM_JWT_SECRET`, `TF_ACM_CERTIFICATE_ARN`, `TF_ROUTE53_HOSTED_ZONE_ID`). The ACM certificate must cover `*.cardgame.michaelj43.dev`. Per-PR TURN relay compute is controlled by repository Variable `TF_PREVIEW_TURN_EC2_ENABLED`; leave it `false` to avoid preview EC2/ASG cost. Multiple PRs can be active at once because state keys, environment names, DNS names, and optional relay resources are PR-number scoped.
 
 On PR close, the workflow runs `terraform destroy` with the same state key and variables, then removes the preview state object from S3. `site_bucket_force_destroy` is set for previews so the temporary S3 bucket can be deleted after assets have been uploaded.
+
+## Relay performance workflow
+
+`.github/workflows/relay-perf.yml` is a manual workflow for expensive relay checks. It deploys a separate `perf-pr-<number>` stack with state key:
+
+```bash
+card-game/perf/pr-<number>/terraform.tfstate
+```
+
+It calls `/turn/start`, waits for `/turn/status`, runs `turnutils_uclient` allocation/throughput steps against the TURN host, collects EC2/CloudWatch datapoints where available, uploads raw JSON/Markdown artifacts, and updates one PR comment marked `<!-- card-game-relay-perf -->`. It only runs when repository Variable **`TF_RELAY_PERF_ENABLED`** is `true` and someone starts it with `workflow_dispatch`.
 
 ---
 
@@ -136,4 +173,4 @@ On PR close, the workflow runs `terraform destroy` with the same state key and v
 | `lambda.tf` | Lambdas, env, log groups |
 | `iam.tf` | Execution role + policies |
 | `dynamodb.tf` | Rooms table |
-| `turn.tf` | Optional coturn EC2, SG, Route 53 `turn` A, IAM for EC2/R53, scheduled Lambda + EventBridge |
+| `turn.tf` | Optional coturn single EC2 or ASG, SG, Route 53 `turn` A, IAM for EC2/ASG/R53, scheduled Lambda + EventBridge |

--- a/deploy/terraform/aws/lambda.tf
+++ b/deploy/terraform/aws/lambda.tf
@@ -12,7 +12,10 @@ resource "aws_cloudwatch_log_group" "ws" {
 
 locals {
   http_lambda_env_turn = local.turn_stack ? {
-    TURN_EC2_INSTANCE_ID     = aws_instance.turn[0].id
+    TURN_CONTROL_MODE        = var.turn_compute_mode
+    TURN_EC2_INSTANCE_ID     = local.turn_instance_stack ? aws_instance.turn[0].id : ""
+    TURN_ASG_NAME            = local.turn_asg_stack ? aws_autoscaling_group.turn[0].name : ""
+    TURN_ASG_MIN_SIZE        = tostring(var.turn_asg_min_size)
     TURN_ROUTE53_ZONE_ID     = local.route53_zone_id
     TURN_ROUTE53_RECORD_NAME = local.turn_hostname
     WS_MANAGEMENT_API_URL    = "https://${aws_apigatewayv2_api.ws.id}.execute-api.${var.aws_region}.amazonaws.com/${aws_apigatewayv2_stage.ws.name}"
@@ -31,7 +34,7 @@ resource "aws_lambda_function" "http" {
   source_code_hash = filebase64sha256(var.http_lambda_zip)
 
   memory_size = 256
-  timeout     = local.turn_stack ? 180 : 10
+  timeout     = 10
 
   environment {
     variables = merge(

--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -63,6 +63,16 @@ output "turn_hostname" {
   value       = local.turn_stack ? local.turn_hostname : null
 }
 
+output "turn_compute_mode" {
+  description = "TURN compute mode when TURN is enabled: instance or asg."
+  value       = local.turn_stack ? var.turn_compute_mode : null
+}
+
+output "turn_asg_name" {
+  description = "Auto Scaling Group name for ASG-backed TURN; null otherwise."
+  value       = local.turn_asg_stack ? aws_autoscaling_group.turn[0].name : null
+}
+
 output "turn_coturn_static_password" {
   description = "Echo of turn_coturn_static_password when TURN stack is on (sensitive). Prefer defining the password only in CI/GitHub secret TURN_COTURN_STATIC_PASSWORD; do not log this output in pipelines."
   value       = local.turn_stack && length(trimspace(var.turn_coturn_static_password)) > 0 ? trimspace(var.turn_coturn_static_password) : null

--- a/deploy/terraform/aws/turn-user-data.sh.tpl
+++ b/deploy/terraform/aws/turn-user-data.sh.tpl
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 if ! command -v turnserver >/dev/null 2>&1; then
-  dnf install -y coturn
+  if command -v apt-get >/dev/null 2>&1; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y coturn
+  elif command -v dnf >/dev/null 2>&1; then
+    dnf install -y coturn
+  else
+    echo "No supported package manager found for coturn install" >&2
+    exit 1
+  fi
 fi
 # Quoted heredoc so the coturn password is not re-expanded by bash (e.g. `$` in the secret).
 cat >/etc/turnserver.conf <<'TURNCONF'

--- a/deploy/terraform/aws/turn-user-data.sh.tpl
+++ b/deploy/terraform/aws/turn-user-data.sh.tpl
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-dnf install -y coturn
+if ! command -v turnserver >/dev/null 2>&1; then
+  dnf install -y coturn
+fi
 # Quoted heredoc so the coturn password is not re-expanded by bash (e.g. `$` in the secret).
 cat >/etc/turnserver.conf <<'TURNCONF'
 listening-port=3478
@@ -12,8 +14,8 @@ no-tlsv1
 no-tlsv1_1
 realm=${realm}
 user=${turn_user}:${turn_password}
-min-port=49152
-max-port=65535
+min-port=${min_port}
+max-port=${max_port}
 simple-log
 log-file=/var/log/turnserver.log
 TURNCONF

--- a/deploy/terraform/aws/turn.tf
+++ b/deploy/terraform/aws/turn.tf
@@ -24,6 +24,12 @@ data "aws_ami" "al2023_x86" {
   }
 }
 
+locals {
+  turn_instance_stack = local.turn_stack && var.turn_compute_mode == "instance"
+  turn_asg_stack      = local.turn_stack && var.turn_compute_mode == "asg"
+  turn_ami_id         = local.turn_stack ? (trimspace(var.turn_ami_id) != "" ? trimspace(var.turn_ami_id) : data.aws_ami.al2023_x86[0].id) : ""
+}
+
 resource "aws_security_group" "turn" {
   count       = local.turn_stack ? 1 : 0
   name        = "${local.name}-coturn"
@@ -46,8 +52,8 @@ resource "aws_security_group" "turn" {
   }
   ingress {
     description = "TURN relay UDP range"
-    from_port   = 49152
-    to_port     = 65535
+    from_port   = var.turn_relay_min_port
+    to_port     = var.turn_relay_max_port
     protocol    = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -63,8 +69,8 @@ resource "aws_security_group" "turn" {
 }
 
 resource "aws_instance" "turn" {
-  count                       = local.turn_stack ? 1 : 0
-  ami                         = data.aws_ami.al2023_x86[0].id
+  count                       = local.turn_instance_stack ? 1 : 0
+  ami                         = local.turn_ami_id
   instance_type               = var.turn_instance_type
   subnet_id                   = sort(tolist(data.aws_subnets.default[0].ids))[0]
   vpc_security_group_ids      = [aws_security_group.turn[0].id]
@@ -74,6 +80,8 @@ resource "aws_instance" "turn" {
     realm         = local.turn_hostname
     turn_user     = "cardgame"
     turn_password = trimspace(var.turn_coturn_static_password)
+    min_port      = var.turn_relay_min_port
+    max_port      = var.turn_relay_max_port
   }))
 
   lifecycle {
@@ -91,6 +99,109 @@ resource "aws_instance" "turn" {
     Name               = "${local.name}-coturn"
     CARDGAME_TURN_LINK = "coturn"
   })
+}
+
+resource "aws_launch_template" "turn" {
+  count = local.turn_asg_stack ? 1 : 0
+
+  name_prefix   = "${local.name}-coturn-"
+  image_id      = local.turn_ami_id
+  instance_type = var.turn_instance_type
+
+  user_data = base64encode(templatefile("${path.module}/turn-user-data.sh.tpl", {
+    realm         = local.turn_hostname
+    turn_user     = "cardgame"
+    turn_password = trimspace(var.turn_coturn_static_password)
+    min_port      = var.turn_relay_min_port
+    max_port      = var.turn_relay_max_port
+  }))
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.turn[0].id]
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, {
+      Name               = "${local.name}-coturn"
+      CARDGAME_TURN_LINK = "coturn"
+    })
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags          = local.common_tags
+  }
+
+  tags = merge(local.common_tags, { CARDGAME_TURN_LINK = "coturn" })
+}
+
+resource "aws_autoscaling_group" "turn" {
+  count = local.turn_asg_stack ? 1 : 0
+
+  name                = "${local.name}-coturn"
+  min_size            = var.turn_asg_min_size
+  desired_capacity    = var.turn_asg_desired_capacity
+  max_size            = var.turn_asg_max_size
+  vpc_zone_identifier = sort(tolist(data.aws_subnets.default[0].ids))
+
+  launch_template {
+    id      = aws_launch_template.turn[0].id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${local.name}-coturn"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "CARDGAME_TURN_LINK"
+    value               = "coturn"
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = local.common_tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !local.turn_stack || length(trimspace(var.turn_coturn_static_password)) >= 8
+      error_message = "When the TURN EC2 stack is enabled, set turn_coturn_static_password (e.g. TF_VAR_turn_coturn_static_password from GitHub secret TURN_COTURN_STATIC_PASSWORD) to a shared password (min 8 characters) used by both Terraform user-data and VITE_MULTIPLAYER_TURN_CREDENTIAL."
+    }
+    precondition {
+      condition     = var.turn_asg_min_size <= var.turn_asg_desired_capacity && var.turn_asg_desired_capacity <= var.turn_asg_max_size
+      error_message = "TURN ASG capacity must satisfy min <= desired <= max."
+    }
+  }
+}
+
+resource "aws_autoscaling_policy" "turn_cpu_target" {
+  count = local.turn_asg_stack && var.turn_asg_cpu_target_percent > 0 ? 1 : 0
+
+  name                   = "${local.name}-coturn-cpu-target"
+  autoscaling_group_name = aws_autoscaling_group.turn[0].name
+  policy_type            = "TargetTrackingScaling"
+
+  target_tracking_configuration {
+    target_value = var.turn_asg_cpu_target_percent
+
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+  }
 }
 
 # Placeholder A; Lambda overwrites with live public IP on /turn/start (ignore drift).
@@ -117,14 +228,31 @@ data "aws_iam_policy_document" "lambda_turn" {
     ]
     resources = ["*"]
   }
-  statement {
-    sid = "TurnEc2StartStop"
-    actions = [
-      "ec2:StartInstances",
-      "ec2:StopInstances",
-    ]
-    resources = [aws_instance.turn[0].arn]
+
+  dynamic "statement" {
+    for_each = local.turn_instance_stack ? [1] : []
+    content {
+      sid = "TurnEc2StartStop"
+      actions = [
+        "ec2:StartInstances",
+        "ec2:StopInstances",
+      ]
+      resources = [aws_instance.turn[0].arn]
+    }
   }
+
+  dynamic "statement" {
+    for_each = local.turn_asg_stack ? [1] : []
+    content {
+      sid = "TurnAsgScale"
+      actions = [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:SetDesiredCapacity",
+      ]
+      resources = ["*"]
+    }
+  }
+
   statement {
     sid       = "TurnRoute53"
     actions   = ["route53:ChangeResourceRecordSets"]
@@ -163,7 +291,10 @@ resource "aws_lambda_function" "turn_scheduled" {
   environment {
     variables = {
       ROOMS_TABLE              = aws_dynamodb_table.rooms.name
-      TURN_EC2_INSTANCE_ID     = aws_instance.turn[0].id
+      TURN_CONTROL_MODE        = var.turn_compute_mode
+      TURN_EC2_INSTANCE_ID     = local.turn_instance_stack ? aws_instance.turn[0].id : ""
+      TURN_ASG_NAME            = local.turn_asg_stack ? aws_autoscaling_group.turn[0].name : ""
+      TURN_ASG_MIN_SIZE        = tostring(var.turn_asg_min_size)
       TURN_MAX_UPTIME_SECONDS  = "14400"
       TURN_USAGE_GRACE_SECONDS = "900"
     }

--- a/deploy/terraform/aws/turn.tf
+++ b/deploy/terraform/aws/turn.tf
@@ -14,20 +14,28 @@ data "aws_subnets" "default" {
   }
 }
 
-data "aws_ami" "al2023_x86" {
+data "aws_ami" "ubuntu_noble_x86" {
   count       = local.turn_stack ? 1 : 0
   most_recent = true
-  owners      = ["amazon"]
+  owners      = ["099720109477"]
   filter {
     name   = "name"
-    values = ["al2023-ami-202*-kernel-6.1-x86_64"]
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
 locals {
   turn_instance_stack = local.turn_stack && var.turn_compute_mode == "instance"
   turn_asg_stack      = local.turn_stack && var.turn_compute_mode == "asg"
-  turn_ami_id         = local.turn_stack ? (trimspace(var.turn_ami_id) != "" ? trimspace(var.turn_ami_id) : data.aws_ami.al2023_x86[0].id) : ""
+  turn_ami_id         = local.turn_stack ? (trimspace(var.turn_ami_id) != "" ? trimspace(var.turn_ami_id) : data.aws_ami.ubuntu_noble_x86[0].id) : ""
 }
 
 resource "aws_security_group" "turn" {

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -138,7 +138,7 @@ variable "turn_instance_type" {
 }
 
 variable "turn_ami_id" {
-  description = "Optional pre-baked coturn AMI id. When empty, Terraform uses the latest AL2023 AMI and user-data installs coturn at boot."
+  description = "Optional pre-baked coturn AMI id. When empty, Terraform uses the latest Ubuntu 24.04 LTS AMI and user-data installs coturn at boot."
   type        = string
   default     = ""
 }

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -137,6 +137,59 @@ variable "turn_instance_type" {
   default     = "t3.micro"
 }
 
+variable "turn_ami_id" {
+  description = "Optional pre-baked coturn AMI id. When empty, Terraform uses the latest AL2023 AMI and user-data installs coturn at boot."
+  type        = string
+  default     = ""
+}
+
+variable "turn_compute_mode" {
+  description = "Compute mode for the optional coturn relay: instance keeps the original single EC2 start/stop model; asg uses a launch template and Auto Scaling Group."
+  type        = string
+  default     = "instance"
+
+  validation {
+    condition     = contains(["instance", "asg"], var.turn_compute_mode)
+    error_message = "turn_compute_mode must be either \"instance\" or \"asg\"."
+  }
+}
+
+variable "turn_asg_min_size" {
+  description = "Minimum capacity for ASG-backed TURN. Use 0 for on-demand/ephemeral stacks, 1+ for always-warm production relay."
+  type        = number
+  default     = 0
+}
+
+variable "turn_asg_desired_capacity" {
+  description = "Initial desired capacity for ASG-backed TURN."
+  type        = number
+  default     = 0
+}
+
+variable "turn_asg_max_size" {
+  description = "Maximum capacity for ASG-backed TURN."
+  type        = number
+  default     = 1
+}
+
+variable "turn_asg_cpu_target_percent" {
+  description = "Target average CPU utilization for ASG-backed TURN target tracking. Set to 0 to disable the default target-tracking policy."
+  type        = number
+  default     = 60
+}
+
+variable "turn_relay_min_port" {
+  description = "Minimum UDP relay port exposed by coturn."
+  type        = number
+  default     = 49152
+}
+
+variable "turn_relay_max_port" {
+  description = "Maximum UDP relay port exposed by coturn."
+  type        = number
+  default     = 65535
+}
+
 variable "scheduled_lambda_zip" {
   description = "Path to turnScheduled.zip from lambda/scripts/bundle.mjs."
   type        = string

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,8 +32,8 @@ flowchart TB
     LWs["Lambda: card-game-*-ws"]
     DDB["DynamoDB — rooms + connections + TURN scheduler rows"]
     subgraph OptionalTURN["Optional: TURN stack (Terraform flag)"]
-      EC2["EC2 — coturn"]
-      R53["Route 53 — turn.<apex> A record"]
+      EC2["EC2 or ASG — coturn"]
+      R53["Route 53 — turn.apex A record"]
       LSched["Lambda: turn-scheduled + EventBridge"]
     end
   end
@@ -45,7 +45,7 @@ flowchart TB
   WS --> LWs
   LHttp --> DDB
   LWs --> DDB
-  LHttp -->|Start / Describe / R53 update| EC2
+  LHttp -->|Start or scale / Describe / R53 update| EC2
   LHttp --> R53
   LSched --> EC2
   LSched --> DDB
@@ -144,21 +144,25 @@ sequenceDiagram
   participant U as User (host UI)
   participant Site as Static site bundle
   participant API as HTTP Lambda
-  participant EC2 as coturn EC2
-  participant DNS as Route 53 turn.*
+  participant Relay as coturn EC2 or ASG
+  participant DNS as Route53 turn
 
   U->>Site: Start relay
   Site->>API: POST /turn/start
-  API->>EC2: StartInstances + wait healthy
-  API->>DNS: UPSERT turn A → public IPv4
-  API-->>Site: { ready, publicIp, … }
+  API->>Relay: StartInstances or SetDesiredCapacity
+  API-->>Site: { ready: false, state: pending, … }
+  Site->>API: GET /turn/status
+  API->>Relay: Describe capacity and status checks
+  API->>DNS: UPSERT turn A → live public IPv4s
+  API-->>Site: { ready, publicIps, … }
   Note over Site: WebRTC may now use TURN candidate in ICE
 ```
 
 - **`GET /turn/status`** — cheap poll for “is instance running / DNS aligned / checks OK”.
 - **`POST /turn/heartbeat`** — usage signal for scheduled idle-stop (Dynamo scheduler).
-- **`turn-scheduled` Lambda** — periodic **DescribeInstances** / optional **StopInstances** (see `lambda/src/turnScheduled.ts`, `turn.tf`).
-- Terraform leaves **`turn.<domain>`** at **`127.0.0.1`** until the HTTP path updates it — see deploy README.
+- **`turn-scheduled` Lambda** — periodic **DescribeInstances** / ASG checks / optional **StopInstances** or ASG scale-down (see `lambda/src/turnScheduled.ts`, `turn.tf`).
+- Terraform leaves **`turn.<domain>`** at **`127.0.0.1`** until the HTTP/status path updates it. In ASG mode the record can contain multiple live relay public IPv4s — see deploy README.
+- **Packer AMI flow** — `packer/relay-coturn.pkr.hcl` pre-installs coturn. PR builds use PR-scoped AMIs only; `main` builds promote the AMI id to `TF_TURN_AMI_ID`.
 
 ---
 
@@ -186,7 +190,8 @@ DynamoDB is a **single table** for room meta, WebSocket connection rows, reverse
 
 - **CI** — lint, tests, site build, lambda bundle (see `.github/workflows/ci.yml`).
 - **Deploy** — Terraform apply → build site with baked `VITE_*` → S3 sync → CloudFront invalidation (see `.github/workflows/deploy.yml`).
-- **PR previews** — same AWS stack shape with per-PR Terraform state, preview DNS (`pr-<n>`, `api-pr-<n>`, `ws-pr-<n>`, optional `turn-pr-<n>`), and automatic `terraform destroy` on PR close (see `.github/workflows/preview.yml`).
+- **PR previews** — same AWS stack shape with per-PR Terraform state, preview DNS (`pr-<n>`, `api-pr-<n>`, `ws-pr-<n>`, optional `turn-pr-<n>`), isolated PR AMIs when Packer changes, and automatic `terraform destroy` on PR close (see `.github/workflows/preview.yml`).
+- **Relay perf** — manually deploys a separate `perf-pr-<n>` stack, runs TURN allocation/throughput checks, and comments results back on the PR (see `.github/workflows/relay-perf.yml`).
 
 For **variables, secrets, custom domains, TURN secrets, and outputs**, use:
 

--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.651.0",
+        "@aws-sdk/client-auto-scaling": "^3.1037.0",
         "@aws-sdk/client-dynamodb": "^3.651.0",
         "@aws-sdk/client-ec2": "^3.651.0",
         "@aws-sdk/client-route-53": "^3.651.0",
@@ -199,6 +200,57 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-auto-scaling": {
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-auto-scaling/-/client-auto-scaling-3.1037.0.tgz",
+      "integrity": "sha512-kYj0lnqXH45hVa+clp7x5SKMsnHsqH1JRW1wJuIdIUHOx4RKDorKaixz6LuYhTKKekhaRMFouB1Zr2i12qOiMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-node": "^3.972.36",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1032.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1032.0.tgz",
@@ -357,22 +409,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.2.tgz",
-      "integrity": "sha512-oav5AOAz+1XkwUfp6SrEm42UPDpUP5D4jNYXkDwFR1VfWqYX62+jpytdfzURmJ9McSoJIQwi0OJlC4oCi6t0VQ==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.18",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/xml-builder": "^3.972.19",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -381,12 +434,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.28.tgz",
-      "integrity": "sha512-87GdRJ2OR0qR4VkMjXN/SZi66DZsunW2qQCbtw9rKw3Y7JurFi6tQWYKOSLY/gOADrU6OxGqFmdw3hKzZqDZOQ==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.5",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -397,20 +450,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.30.tgz",
-      "integrity": "sha512-6quozmW2PKwBJTUQLb+lk1q8w5Pm45qaqhx4Tld9EIqYYQOVGj+MT0a8NRVS7QgWJj7rzGlB7rQu3KYBFHemJw==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.5",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -418,19 +471,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.32.tgz",
-      "integrity": "sha512-Nkr+UKtczZlocUjc6g96WzQadZSIZO/HVXPki4qbfaVOZYSbfLQKWKfADtJ0kGYsCvSYOZrO66tSc9dkboUt/w==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/credential-provider-env": "^3.972.28",
-        "@aws-sdk/credential-provider-http": "^3.972.30",
-        "@aws-sdk/credential-provider-login": "^3.972.32",
-        "@aws-sdk/credential-provider-process": "^3.972.28",
-        "@aws-sdk/credential-provider-sso": "^3.972.32",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-login": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/nested-clients": "^3.997.3",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -443,13 +496,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.32.tgz",
-      "integrity": "sha512-UxgwT1HmZz1QPXuBy5ZUPJNFXOSlhwdQL61eGhWRthF0xRrT02BCOVJ1p5Ejg5AXfnESTWoKPJ7v/sCkNUtB9g==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -462,17 +515,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.33.tgz",
-      "integrity": "sha512-6pGQnEdSeRvBViTQh/FwaRKB38a3Th+W2mVxuvqAd2Z1Ayo3e6eJ5QqJoZwEMwR6xoxkl3wz3qAfiB1xRhMC+w==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.28",
-        "@aws-sdk/credential-provider-http": "^3.972.30",
-        "@aws-sdk/credential-provider-ini": "^3.972.32",
-        "@aws-sdk/credential-provider-process": "^3.972.28",
-        "@aws-sdk/credential-provider-sso": "^3.972.32",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-ini": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -485,12 +538,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.28.tgz",
-      "integrity": "sha512-CRAlD8u6oNBhjnX/3ekVGocarD+lFmEn/qeDzytgIdmwrmwMJGFPqS9lGwEfhOTihZKrQ0xSp3z6paX+iXJJhA==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.5",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -502,14 +555,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.32.tgz",
-      "integrity": "sha512-whhmQghRYOt9mJxFyVMhX7eB8n0oA25OCvqoR7dzFAZjmioCkf7WVB22Bc6llM5cFpBXFX7s4Jv+xVq32VPGWg==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
-        "@aws-sdk/token-providers": "3.1033.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/token-providers": "3.1036.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -521,13 +574,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.32.tgz",
-      "integrity": "sha512-Z0Y0LDaqyQDznlmr9gv6n4+eWKKWNgmi9j5L6RENr6wyOCguhO8FRPmqDbVLSw0DPdMqICKnA3PurJiS8bD6Cw==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -683,23 +736,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.31.tgz",
-      "integrity": "sha512-5hS08Fp0Rm+59uGCmkWhZmveXiA7OUV7Wa+IARejdzf9JTZ1qAVeIOE9JoBpsLPvUgEjmsGNHBuFbtGmYyqiqQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.5",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.15",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -708,18 +761,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.32.tgz",
-      "integrity": "sha512-HQ0x9DDKqLZOGhDiL2eicYXXkYT5dogE4mw0lAfHCpJ6t7MM0PNIsJl2TZzWKU9SpBzOMXHRa7K6ZLKUJu1y0w==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.5",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -727,48 +780,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.0.tgz",
-      "integrity": "sha512-4bI5GHjUiY5R8N6PtchpG6tW2Dl8I2IcZNg3JwqwxHRXjfvQlPoo4VMknG4qkd5W0t3Y20rQ6C7pSR561YG5JQ==",
+      "version": "3.997.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/core": "^3.974.5",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.32",
-        "@aws-sdk/region-config-resolver": "^3.972.12",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.19",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.18",
-        "@smithy/config-resolver": "^4.4.16",
-        "@smithy/core": "^3.23.15",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/hash-node": "^4.2.14",
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.30",
-        "@smithy/middleware-retry": "^4.5.3",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.47",
-        "@smithy/util-defaults-mode-node": "^4.2.52",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.4",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -777,13 +830,13 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
-      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/config-resolver": "^4.4.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -793,12 +846,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.19.tgz",
-      "integrity": "sha512-7Sy8+GhfwUi06NQNLplxuJuXMKJURDsNQfK8yTW6E9wN2J1B+8S5dWZG7vg3InvPPhaXqkcYTr8pzeE+dLjMbQ==",
+      "version": "3.996.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.31",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -810,13 +863,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1033.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1033.0.tgz",
-      "integrity": "sha512-/TsXhqjyRAFb0xVgmbFAha3cJfZdWjnyn6ohJ3AB4E3peLgxNcmKfYr45hruHymyJAydiHoXC3N1a8qgl41cog==",
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.2",
-        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -868,15 +921,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
-      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -923,12 +976,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.18.tgz",
-      "integrity": "sha512-Nh4YvAL0Mzv5jBvzXLFL0tLf7WPrRMnYZQ5jlFuyS0xiVJQsObMUKAkbYjmt/e04wpQqUaa+Is7k+mBr89A9yA==",
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.32",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -948,13 +1001,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1386,6 +1439,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1489,9 +1554,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1506,9 +1568,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1523,9 +1582,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1540,9 +1596,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1557,9 +1610,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1574,9 +1624,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1591,9 +1638,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1608,9 +1652,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1625,9 +1666,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1642,9 +1680,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1659,9 +1694,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1676,9 +1708,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1693,9 +1722,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1804,9 +1830,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.16",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -1815,7 +1841,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -1911,13 +1937,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.31",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
-      "integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@smithy/types": "^4.14.1",
@@ -1930,19 +1956,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
-      "integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
+      "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
+        "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-retry": "^4.3.4",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -1951,12 +1977,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
-      "integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
+        "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -1994,9 +2020,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
-      "integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -2106,17 +2132,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
-      "integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.16",
-        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2213,13 +2239,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.48",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
-      "integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -2228,16 +2254,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.53",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
-      "integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -2285,9 +2311,9 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
-      "integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
+      "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.3.0",
@@ -2299,13 +2325,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
-      "integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
@@ -3106,9 +3132,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -3117,9 +3143,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -13,9 +13,10 @@
   },
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.651.0",
+    "@aws-sdk/client-auto-scaling": "^3.1037.0",
+    "@aws-sdk/client-dynamodb": "^3.651.0",
     "@aws-sdk/client-ec2": "^3.651.0",
     "@aws-sdk/client-route-53": "^3.651.0",
-    "@aws-sdk/client-dynamodb": "^3.651.0",
     "@aws-sdk/lib-dynamodb": "^3.651.0",
     "jsonwebtoken": "^9.0.2"
   },

--- a/lambda/src/turnEc2Ops.ts
+++ b/lambda/src/turnEc2Ops.ts
@@ -5,14 +5,59 @@ import {
   StartInstancesCommand,
   StopInstancesCommand,
 } from '@aws-sdk/client-ec2'
+import {
+  AutoScalingClient,
+  DescribeAutoScalingGroupsCommand,
+  SetDesiredCapacityCommand,
+} from '@aws-sdk/client-auto-scaling'
 import { ChangeResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53'
 
+const PLACEHOLDER_IPV4 = '127.0.0.1'
+
 const ec2 = () => new EC2Client({})
+const autoscaling = () => new AutoScalingClient({})
 const r53 = () => new Route53Client({})
+
+export type TurnControlMode = 'instance' | 'asg'
+
+export interface TurnInstanceState {
+  instanceId: string
+  state: string | undefined
+  publicIp: string | undefined
+  launchTime: Date | undefined
+  checksOk: boolean
+}
+
+export interface TurnCapacityState {
+  mode: TurnControlMode
+  configured: boolean
+  state: string
+  ready: boolean
+  publicIps: string[]
+  instances: TurnInstanceState[]
+  desiredCapacity?: number
+  minSize?: number
+  maxSize?: number
+}
+
+export function turnControlMode(): TurnControlMode {
+  return process.env.TURN_CONTROL_MODE === 'asg' || turnAsgName() ? 'asg' : 'instance'
+}
 
 export function turnInstanceId(): string | undefined {
   const id = process.env.TURN_EC2_INSTANCE_ID?.trim()
   return id && id.length > 0 ? id : undefined
+}
+
+export function turnAsgName(): string | undefined {
+  const name = process.env.TURN_ASG_NAME?.trim()
+  return name && name.length > 0 ? name : undefined
+}
+
+export function turnAsgMinSize(): number {
+  const raw = process.env.TURN_ASG_MIN_SIZE
+  const n = raw ? Number(raw) : 0
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0
 }
 
 export function turnRoute53Config(): { hostedZoneId: string; recordName: string } | undefined {
@@ -20,6 +65,28 @@ export function turnRoute53Config(): { hostedZoneId: string; recordName: string 
   const n = process.env.TURN_ROUTE53_RECORD_NAME?.trim()
   if (!z || !n) return undefined
   return { hostedZoneId: z, recordName: n.endsWith('.') ? n.slice(0, -1) : n }
+}
+
+async function describeInstances(instanceIds: string[]): Promise<TurnInstanceState[]> {
+  if (instanceIds.length === 0) return []
+  const res = await ec2().send(new DescribeInstancesCommand({ InstanceIds: instanceIds }))
+  const instances = (res.Reservations ?? []).flatMap((r) => r.Instances ?? [])
+  const status = await ec2().send(
+    new DescribeInstanceStatusCommand({ InstanceIds: instanceIds, IncludeAllInstances: true }),
+  )
+  const checks = new Map(
+    (status.InstanceStatuses ?? []).map((s) => [
+      s.InstanceId,
+      s.SystemStatus?.Status === 'ok' && s.InstanceStatus?.Status === 'ok',
+    ]),
+  )
+  return instances.map((inst) => ({
+    instanceId: inst.InstanceId ?? '',
+    state: inst.State?.Name,
+    publicIp: inst.PublicIpAddress,
+    launchTime: inst.LaunchTime,
+    checksOk: checks.get(inst.InstanceId) ?? false,
+  }))
 }
 
 export async function describeInstanceState(
@@ -51,6 +118,107 @@ export async function stopTurnInstance(instanceId: string): Promise<void> {
   await ec2().send(new StopInstancesCommand({ InstanceIds: [instanceId] }))
 }
 
+export async function setTurnAsgDesiredCapacity(asgName: string, desiredCapacity: number): Promise<void> {
+  await autoscaling().send(
+    new SetDesiredCapacityCommand({
+      AutoScalingGroupName: asgName,
+      DesiredCapacity: desiredCapacity,
+      HonorCooldown: false,
+    }),
+  )
+}
+
+async function describeTurnAsg(asgName: string): Promise<TurnCapacityState> {
+  const res = await autoscaling().send(new DescribeAutoScalingGroupsCommand({ AutoScalingGroupNames: [asgName] }))
+  const group = res.AutoScalingGroups?.[0]
+  if (!group) {
+    return {
+      mode: 'asg',
+      configured: true,
+      state: 'not_found',
+      ready: false,
+      publicIps: [],
+      instances: [],
+    }
+  }
+  const active = (group.Instances ?? []).filter(
+    (i) => i.InstanceId && i.LifecycleState !== 'Terminating' && i.LifecycleState !== 'Terminating:Wait',
+  )
+  const instances = await describeInstances(active.map((i) => i.InstanceId!).filter(Boolean))
+  const publicIps = instances
+    .filter((i) => i.state === 'running' && i.publicIp && i.checksOk)
+    .map((i) => i.publicIp!)
+  const desired = group.DesiredCapacity ?? 0
+  const anyPending = instances.some((i) => i.state === 'pending')
+  const anyRunning = instances.some((i) => i.state === 'running')
+  const state = desired === 0 ? 'stopped' : publicIps.length > 0 ? 'running' : anyPending ? 'pending' : anyRunning ? 'running' : 'pending'
+  return {
+    mode: 'asg',
+    configured: true,
+    state,
+    ready: publicIps.length > 0,
+    publicIps,
+    instances,
+    desiredCapacity: desired,
+    minSize: group.MinSize,
+    maxSize: group.MaxSize,
+  }
+}
+
+export async function describeTurnCapacity(): Promise<TurnCapacityState> {
+  if (turnControlMode() === 'asg') {
+    const asgName = turnAsgName()
+    if (!asgName) {
+      return { mode: 'asg', configured: false, state: 'not_configured', ready: false, publicIps: [], instances: [] }
+    }
+    return describeTurnAsg(asgName)
+  }
+
+  const instanceId = turnInstanceId()
+  if (!instanceId) {
+    return { mode: 'instance', configured: false, state: 'not_configured', ready: false, publicIps: [], instances: [] }
+  }
+  const [inst] = await describeInstances([instanceId])
+  const publicIps = inst?.state === 'running' && inst.publicIp && inst.checksOk ? [inst.publicIp] : []
+  return {
+    mode: 'instance',
+    configured: true,
+    state: inst?.state ?? 'unknown',
+    ready: publicIps.length > 0,
+    publicIps,
+    instances: inst ? [inst] : [],
+  }
+}
+
+export async function startTurnCapacity(): Promise<boolean> {
+  if (turnControlMode() === 'asg') {
+    const asgName = turnAsgName()
+    if (!asgName) return false
+    const cap = await describeTurnAsg(asgName)
+    await setTurnAsgDesiredCapacity(asgName, Math.max(1, cap.desiredCapacity ?? 0, cap.minSize ?? 0))
+    return true
+  }
+
+  const instanceId = turnInstanceId()
+  if (!instanceId) return false
+  await startTurnInstance(instanceId)
+  return true
+}
+
+export async function stopTurnCapacity(): Promise<boolean> {
+  if (turnControlMode() === 'asg') {
+    const asgName = turnAsgName()
+    if (!asgName) return false
+    await setTurnAsgDesiredCapacity(asgName, turnAsgMinSize())
+    return true
+  }
+
+  const instanceId = turnInstanceId()
+  if (!instanceId) return false
+  await stopTurnInstance(instanceId)
+  return true
+}
+
 /** Poll until running, has public IP, and status checks ok (or timeout). */
 export async function waitForRunningReady(
   instanceId: string,
@@ -69,7 +237,12 @@ export async function waitForRunningReady(
 }
 
 export async function upsertTurnARecord(hostedZoneId: string, recordName: string, ipv4: string): Promise<void> {
+  await upsertTurnARecords(hostedZoneId, recordName, [ipv4])
+}
+
+export async function upsertTurnARecords(hostedZoneId: string, recordName: string, ipv4s: string[]): Promise<void> {
   const name = recordName.endsWith('.') ? recordName : `${recordName}.`
+  const records = (ipv4s.length > 0 ? ipv4s : [PLACEHOLDER_IPV4]).map((Value) => ({ Value }))
   await r53().send(
     new ChangeResourceRecordSetsCommand({
       HostedZoneId: hostedZoneId,
@@ -82,7 +255,7 @@ export async function upsertTurnARecord(hostedZoneId: string, recordName: string
               Name: name,
               Type: 'A',
               TTL: 60,
-              ResourceRecords: [{ Value: ipv4 }],
+              ResourceRecords: records,
             },
           },
         ],

--- a/lambda/src/turnHttpHandlers.ts
+++ b/lambda/src/turnHttpHandlers.ts
@@ -1,13 +1,11 @@
 import { verifyRoomToken } from './auth'
 import { deleteRoomCascade, getRoom, listConnections } from './storage'
 import {
-  describeInstanceState,
-  instanceStatusChecksOk,
-  startTurnInstance,
-  turnInstanceId,
+  describeTurnCapacity,
+  startTurnCapacity,
   turnRoute53Config,
-  upsertTurnARecord,
-  waitForRunningReady,
+  upsertTurnARecords,
+  type TurnCapacityState,
 } from './turnEc2Ops'
 import {
   ensureLiveRow,
@@ -63,33 +61,49 @@ function jwtSecret(): string {
   return s
 }
 
+async function publishTurnDns(capacity: TurnCapacityState): Promise<string | undefined> {
+  if (!capacity.ready || capacity.publicIps.length === 0) return undefined
+  const r53 = turnRoute53Config()
+  if (!r53) return capacity.publicIps.join(',')
+  await upsertTurnARecords(r53.hostedZoneId, r53.recordName, capacity.publicIps)
+  return capacity.publicIps.join(',')
+}
+
 export async function handleGetTurnStatus(origin?: string) {
-  const instanceId = turnInstanceId()
-  if (!instanceId) return ok({ enabled: false, reason: 'not_configured' }, origin)
   try {
     await ensureSchedulerRowExists()
     const sched = await getSchedulerState()
-    const { state, publicIp } = await describeInstanceState(instanceId)
-    if (state !== 'running') {
-      return ok(
-        {
-          enabled: true,
-          state: state ?? 'unknown',
-          ready: false,
-          publicIp: publicIp ?? null,
-        },
-        origin,
-      )
+    const capacity = await describeTurnCapacity()
+    if (!capacity.configured) return ok({ enabled: false, reason: 'not_configured' }, origin)
+
+    let dnsTarget = sched?.lastDnsIpv4
+    if (capacity.ready) {
+      const published = await publishTurnDns(capacity)
+      if (published && published !== sched?.lastDnsIpv4) {
+        const next: TurnSchedulerState = {
+          pk: TURN_SCHEDULER_PK,
+          sk: TURN_SCHEDULER_SK,
+          nextPollAt: Date.now(),
+          backoffStage: 0,
+          lastInstanceState: capacity.state,
+          lastDnsIpv4: published,
+        }
+        if (sched?.lastStopAt) next.lastStopAt = sched.lastStopAt
+        await putSchedulerState(next)
+        dnsTarget = published
+      }
     }
-    const checksOk = await instanceStatusChecksOk(instanceId)
-    const dnsTarget = sched?.lastDnsIpv4
-    const dnsAligned = !dnsTarget || !publicIp || dnsTarget === publicIp
+    const currentTarget = capacity.publicIps.join(',')
+    const dnsAligned = !dnsTarget || !currentTarget || dnsTarget === currentTarget
     return ok(
       {
         enabled: true,
-        state: 'running',
-        ready: checksOk && !!publicIp && dnsAligned,
-        publicIp: publicIp ?? null,
+        mode: capacity.mode,
+        state: capacity.state,
+        ready: capacity.ready && dnsAligned,
+        publicIp: capacity.publicIps[0] ?? null,
+        publicIps: capacity.publicIps,
+        desiredCapacity: capacity.desiredCapacity,
       },
       origin,
     )
@@ -100,28 +114,23 @@ export async function handleGetTurnStatus(origin?: string) {
 }
 
 export async function handlePostTurnStart(origin?: string) {
-  const instanceId = turnInstanceId()
-  if (!instanceId) return bad(400, 'TURN EC2 not configured', origin)
   await ensureSchedulerRowExists()
   await resetSchedulerBackoff()
   try {
-    await startTurnInstance(instanceId)
+    const started = await startTurnCapacity()
+    if (!started) return bad(400, 'TURN relay not configured', origin)
   } catch (e) {
-    console.error('start instance', e)
-    return bad(500, 'Failed to start instance', origin)
+    console.error('start relay capacity', e)
+    return bad(500, 'Failed to start relay capacity', origin)
   }
-  const ready = await waitForRunningReady(instanceId, { maxWaitMs: 180_000, pollMs: 3000 })
-  if ('error' in ready) {
-    return ok({ enabled: true, state: 'pending', ready: false, message: ready.error }, origin)
-  }
-  const r53 = turnRoute53Config()
-  if (r53) {
-    try {
-      await upsertTurnARecord(r53.hostedZoneId, r53.recordName, ready.publicIp)
-    } catch (e) {
-      console.error('route53', e)
-      return bad(500, 'Instance is up but DNS update failed', origin)
-    }
+
+  const capacity = await describeTurnCapacity()
+  let published: string | undefined
+  try {
+    published = await publishTurnDns(capacity)
+  } catch (e) {
+    console.error('route53', e)
+    return bad(500, 'Relay is starting but DNS update failed', origin)
   }
   const prev = await getSchedulerState()
   const next: TurnSchedulerState = {
@@ -129,12 +138,21 @@ export async function handlePostTurnStart(origin?: string) {
     sk: TURN_SCHEDULER_SK,
     nextPollAt: Date.now(),
     backoffStage: 0,
-    lastInstanceState: 'running',
-    lastDnsIpv4: ready.publicIp,
+    lastInstanceState: capacity.state,
   }
+  if (published) next.lastDnsIpv4 = published
   if (prev?.lastStopAt) next.lastStopAt = prev.lastStopAt
   await putSchedulerState(next)
-  return ok({ enabled: true, state: 'running', ready: true, publicIp: ready.publicIp, estimatedSeconds: 120 }, origin)
+  return ok({
+    enabled: true,
+    mode: capacity.mode,
+    state: capacity.state,
+    ready: capacity.ready && Boolean(published),
+    publicIp: capacity.publicIps[0] ?? null,
+    publicIps: capacity.publicIps,
+    estimatedSeconds: capacity.ready ? 0 : 120,
+    message: capacity.ready ? undefined : 'Relay capacity requested; polling will report ready after EC2 and DNS are ready.',
+  }, origin)
 }
 
 interface HeartbeatBody {

--- a/lambda/src/turnScheduled.ts
+++ b/lambda/src/turnScheduled.ts
@@ -6,10 +6,10 @@ import {
   updateSchedulerAfterStopPoll,
 } from './turnState'
 import {
-  describeInstanceState,
-  instanceStatusChecksOk,
-  stopTurnInstance,
-  turnInstanceId,
+  describeTurnCapacity,
+  stopTurnCapacity,
+  turnRoute53Config,
+  upsertTurnARecords,
 } from './turnEc2Ops'
 
 function maxUptimeMs(): number {
@@ -29,9 +29,6 @@ function usageGraceMs(): number {
  * may stop the TURN EC2 when uptime and idle conditions match (prefer staying on).
  */
 export const handler = async (): Promise<void> => {
-  const instanceId = turnInstanceId()
-  if (!instanceId) return
-
   await ensureSchedulerRowExists()
   const sched = await getSchedulerState()
   const nextAt = sched?.nextPollAt ?? 0
@@ -46,17 +43,19 @@ export const handler = async (): Promise<void> => {
     return
   }
 
-  let state: string | undefined
-  let launchTime: Date | undefined
+  const capacity = await describeTurnCapacity()
+  if (!capacity.configured) return
+
   try {
-    const d = await describeInstanceState(instanceId)
-    state = d.state
-    launchTime = d.launchTime
+    const r53 = turnRoute53Config()
+    if (r53 && capacity.publicIps.length > 0) {
+      await upsertTurnARecords(r53.hostedZoneId, r53.recordName, capacity.publicIps)
+    }
   } catch (e) {
-    console.warn('turn scheduled: describe failed', e)
-    return
+    console.warn('turn scheduled: DNS reconcile failed', e)
   }
 
+  const state = capacity.state
   if (state === 'stopping') return
 
   if (state === 'stopped') {
@@ -66,21 +65,23 @@ export const handler = async (): Promise<void> => {
 
   if (state !== 'running') return
 
-  const checksOk = await instanceStatusChecksOk(instanceId)
-  if (!checksOk) return
-
-  const launchMs = launchTime?.getTime()
-  if (launchMs == null || !Number.isFinite(launchMs)) return
+  const launchTimes = capacity.instances
+    .filter((i) => i.state === 'running' && i.checksOk)
+    .map((i) => i.launchTime?.getTime())
+    .filter((t): t is number => typeof t === 'number' && Number.isFinite(t))
+  if (launchTimes.length === 0) return
 
   const now = Date.now()
-  if (now - launchMs < maxUptimeMs()) return
+  if (now - Math.min(...launchTimes) < maxUptimeMs()) return
 
   if (liveLast > 0 && now - liveLast < usageGraceMs()) return
 
   try {
-    await stopTurnInstance(instanceId)
+    await stopTurnCapacity()
+    const r53 = turnRoute53Config()
+    if (r53) await upsertTurnARecords(r53.hostedZoneId, r53.recordName, [])
     await updateSchedulerAfterStopPoll()
   } catch (e) {
-    console.error('turn scheduled: stop failed', e)
+    console.error('turn scheduled: scale down failed', e)
   }
 }

--- a/packer/relay-coturn.pkr.hcl
+++ b/packer/relay-coturn.pkr.hcl
@@ -30,28 +30,28 @@ locals {
 source "amazon-ebs" "coturn" {
   region        = var.aws_region
   instance_type = "t3.micro"
-  ssh_username  = "ec2-user"
+  ssh_username  = "ubuntu"
   ami_name      = local.ami_name
 
   source_ami_filter {
     filters = {
       architecture        = "x86_64"
-      name                = "al2023-ami-202*-kernel-6.1-x86_64"
+      name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }
-    owners      = ["amazon"]
+    owners      = ["099720109477"]
     most_recent = true
   }
 
   tags = {
-    Name                    = local.ami_name
-    Project                 = "card-game"
-    Component               = "coturn"
-    ManagedBy               = "packer"
-    CardGameRelayAmiScope   = local.ami_scope
-    CardGameSourceSha       = var.source_sha
-    CardGamePullRequest     = var.pr_number
+    Name                  = local.ami_name
+    Project               = "card-game"
+    Component             = "coturn"
+    ManagedBy             = "packer"
+    CardGameRelayAmiScope = local.ami_scope
+    CardGameSourceSha     = var.source_sha
+    CardGamePullRequest   = var.pr_number
   }
 }
 
@@ -60,8 +60,9 @@ build {
 
   provisioner "shell" {
     inline = [
-      "sudo dnf update -y",
-      "sudo dnf install -y coturn amazon-cloudwatch-agent",
+      "sudo apt-get update",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y coturn",
       "sudo systemctl enable coturn",
       "sudo truncate -s 0 /var/log/turnserver.log || true",
       "sudo rm -f /etc/turnserver.conf",

--- a/packer/relay-coturn.pkr.hcl
+++ b/packer/relay-coturn.pkr.hcl
@@ -1,0 +1,70 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = ">= 1.3.0"
+    }
+  }
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "source_sha" {
+  type    = string
+  default = "local"
+}
+
+variable "pr_number" {
+  type    = string
+  default = ""
+}
+
+locals {
+  ami_scope = var.pr_number != "" ? "pr" : "main"
+  ami_name  = "card-game-coturn-${local.ami_scope}-${var.source_sha}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+source "amazon-ebs" "coturn" {
+  region        = var.aws_region
+  instance_type = "t3.micro"
+  ssh_username  = "ec2-user"
+  ami_name      = local.ami_name
+
+  source_ami_filter {
+    filters = {
+      architecture        = "x86_64"
+      name                = "al2023-ami-202*-kernel-6.1-x86_64"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    owners      = ["amazon"]
+    most_recent = true
+  }
+
+  tags = {
+    Name                    = local.ami_name
+    Project                 = "card-game"
+    Component               = "coturn"
+    ManagedBy               = "packer"
+    CardGameRelayAmiScope   = local.ami_scope
+    CardGameSourceSha       = var.source_sha
+    CardGamePullRequest     = var.pr_number
+  }
+}
+
+build {
+  sources = ["source.amazon-ebs.coturn"]
+
+  provisioner "shell" {
+    inline = [
+      "sudo dnf update -y",
+      "sudo dnf install -y coturn amazon-cloudwatch-agent",
+      "sudo systemctl enable coturn",
+      "sudo truncate -s 0 /var/log/turnserver.log || true",
+      "sudo rm -f /etc/turnserver.conf",
+    ]
+  }
+}

--- a/scripts/relay-perf/run.mjs
+++ b/scripts/relay-perf/run.mjs
@@ -1,0 +1,232 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const outDir = resolve(process.env.RELAY_PERF_OUT_DIR ?? 'relay-perf-results')
+mkdirSync(outDir, { recursive: true })
+
+function required(name) {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+function optionalNumber(name, fallback) {
+  const raw = process.env[name]?.trim()
+  const n = raw ? Number(raw) : fallback
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback
+}
+
+async function postJson(url, body) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  })
+  const text = await res.text()
+  let data = {}
+  try {
+    data = text ? JSON.parse(text) : {}
+  } catch {
+    data = { raw: text }
+  }
+  if (!res.ok) throw new Error(`${url} failed with HTTP ${res.status}: ${text}`)
+  return data
+}
+
+async function getJson(url) {
+  const res = await fetch(url)
+  const text = await res.text()
+  let data = {}
+  try {
+    data = text ? JSON.parse(text) : {}
+  } catch {
+    data = { raw: text }
+  }
+  if (!res.ok) throw new Error(`${url} failed with HTTP ${res.status}: ${text}`)
+  return data
+}
+
+function commandExists(name) {
+  const result = spawnSync('bash', ['-lc', `command -v ${name}`], { encoding: 'utf8' })
+  return result.status === 0
+}
+
+function runTurnClient({ host, user, password, allocations, durationSeconds }) {
+  if (!commandExists('turnutils_uclient')) {
+    return {
+      skipped: true,
+      reason: 'turnutils_uclient is not installed on the runner',
+    }
+  }
+
+  const startedAt = Date.now()
+  const args = [
+    '-y',
+    '-u',
+    user,
+    '-w',
+    password,
+    '-n',
+    String(Math.max(1, Math.floor(durationSeconds / 5))),
+    '-m',
+    String(allocations),
+    '-l',
+    '256',
+    host,
+  ]
+  const result = spawnSync('turnutils_uclient', args, {
+    encoding: 'utf8',
+    timeout: (durationSeconds + 30) * 1000,
+  })
+  return {
+    skipped: false,
+    command: `turnutils_uclient ${args.map((a) => (a === password ? '<redacted>' : a)).join(' ')}`,
+    exitCode: result.status,
+    signal: result.signal,
+    durationMs: Date.now() - startedAt,
+    stdout: result.stdout.slice(-12000),
+    stderr: result.stderr.slice(-12000),
+  }
+}
+
+function collectAwsMetrics({ region, asgName, startIso, endIso }) {
+  if (!asgName || !commandExists('aws')) return { skipped: true }
+  try {
+    const groupRaw = execFileSync(
+      'aws',
+      ['autoscaling', 'describe-auto-scaling-groups', '--auto-scaling-group-names', asgName, '--region', region, '--output', 'json'],
+      { encoding: 'utf8' },
+    )
+    const group = JSON.parse(groupRaw)
+    const instanceIds = group.AutoScalingGroups?.[0]?.Instances?.map((i) => i.InstanceId).filter(Boolean) ?? []
+    const metrics = []
+    for (const instanceId of instanceIds) {
+      for (const metricName of ['CPUUtilization', 'NetworkIn', 'NetworkOut', 'NetworkPacketsIn', 'NetworkPacketsOut', 'CPUCreditBalance']) {
+        const namespace = metricName === 'CPUCreditBalance' ? 'AWS/EC2' : 'AWS/EC2'
+        const raw = execFileSync(
+          'aws',
+          [
+            'cloudwatch',
+            'get-metric-statistics',
+            '--namespace',
+            namespace,
+            '--metric-name',
+            metricName,
+            '--dimensions',
+            `Name=InstanceId,Value=${instanceId}`,
+            '--start-time',
+            startIso,
+            '--end-time',
+            endIso,
+            '--period',
+            '60',
+            '--statistics',
+            'Average',
+            'Maximum',
+            '--region',
+            region,
+            '--output',
+            'json',
+          ],
+          { encoding: 'utf8' },
+        )
+        metrics.push({ instanceId, metricName, datapoints: JSON.parse(raw).Datapoints ?? [] })
+      }
+    }
+    return { skipped: false, asgName, instanceIds, metrics }
+  } catch (error) {
+    return { skipped: true, error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+const httpUrl = required('RELAY_PERF_HTTP_URL').replace(/\/$/, '')
+const turnHost = required('RELAY_PERF_TURN_HOST')
+const turnUser = process.env.RELAY_PERF_TURN_USER?.trim() || 'cardgame'
+const turnPassword = required('RELAY_PERF_TURN_CREDENTIAL')
+const region = required('AWS_REGION')
+const asgName = process.env.RELAY_PERF_ASG_NAME?.trim()
+const maxAllocations = optionalNumber('RELAY_PERF_MAX_ALLOCATIONS', 20)
+const durationSeconds = optionalNumber('RELAY_PERF_DURATION_SECONDS', 60)
+const pollSeconds = optionalNumber('RELAY_PERF_READY_TIMEOUT_SECONDS', 240)
+
+const startedAt = new Date()
+const startResponse = await postJson(`${httpUrl}/turn/start`, {})
+let status = await getJson(`${httpUrl}/turn/status`)
+const statusSamples = [{ at: new Date().toISOString(), status }]
+const deadline = Date.now() + pollSeconds * 1000
+while (!status.ready && Date.now() < deadline) {
+  await new Promise((resolveSleep) => setTimeout(resolveSleep, 5000))
+  status = await getJson(`${httpUrl}/turn/status`)
+  statusSamples.push({ at: new Date().toISOString(), status })
+}
+
+const readyAt = status.ready ? new Date() : null
+const allocations = []
+for (const count of [1, Math.ceil(maxAllocations / 4), Math.ceil(maxAllocations / 2), maxAllocations]) {
+  const uniqueCount = Math.max(1, Math.min(maxAllocations, count))
+  if (allocations.some((row) => row.requestedAllocations === uniqueCount)) continue
+  allocations.push({
+    requestedAllocations: uniqueCount,
+    result: runTurnClient({
+      host: turnHost,
+      user: turnUser,
+      password: turnPassword,
+      allocations: uniqueCount,
+      durationSeconds,
+    }),
+  })
+}
+
+const endedAt = new Date()
+const awsMetrics = collectAwsMetrics({
+  region,
+  asgName,
+  startIso: startedAt.toISOString(),
+  endIso: endedAt.toISOString(),
+})
+
+const successfulAllocations = allocations
+  .filter((row) => row.result.skipped || row.result.exitCode === 0)
+  .map((row) => row.requestedAllocations)
+const peakSuccessfulAllocations = successfulAllocations.length ? Math.max(...successfulAllocations) : 0
+
+const result = {
+  startedAt: startedAt.toISOString(),
+  endedAt: endedAt.toISOString(),
+  relayHost: turnHost,
+  httpUrl,
+  startResponse,
+  statusSamples,
+  finalStatus: status,
+  readySeconds: readyAt ? Math.round((readyAt.getTime() - startedAt.getTime()) / 1000) : null,
+  maxAllocations,
+  durationSeconds,
+  peakSuccessfulAllocations,
+  allocations,
+  awsMetrics,
+}
+
+writeFileSync(resolve(outDir, 'relay-perf.json'), `${JSON.stringify(result, null, 2)}\n`)
+
+const markdown = [
+  '<!-- card-game-relay-perf -->',
+  '### Relay performance test',
+  '',
+  `- Relay host: \`${turnHost}\``,
+  `- Ready: ${status.ready ? 'yes' : 'no'}`,
+  `- Startup time: ${result.readySeconds == null ? 'not ready before timeout' : `${result.readySeconds}s`}`,
+  `- Peak attempted allocation step without tool failure: ${peakSuccessfulAllocations}`,
+  `- Requested max allocations: ${maxAllocations}`,
+  `- Test duration per step: ${durationSeconds}s`,
+  `- ASG: ${asgName ? `\`${asgName}\`` : 'not provided'}`,
+  '',
+  'Raw JSON metrics are attached to the workflow run artifacts.',
+]
+
+if (allocations.some((row) => row.result.skipped)) {
+  markdown.push('', 'Note: `turnutils_uclient` was unavailable, so allocation steps were recorded as skipped.')
+}
+
+writeFileSync(resolve(outDir, 'relay-perf.md'), `${markdown.join('\n')}\n`)
+console.log(markdown.join('\n'))

--- a/src/net/api.ts
+++ b/src/net/api.ts
@@ -17,10 +17,13 @@ export interface JoinRoomResponse {
 
 export interface TurnStatusResponse {
   enabled: boolean
+  mode?: 'instance' | 'asg'
   reason?: string
   state?: string
   ready?: boolean
   publicIp?: string | null
+  publicIps?: string[]
+  desiredCapacity?: number
   message?: string
 }
 

--- a/terraform/preview.tfvars
+++ b/terraform/preview.tfvars
@@ -1,0 +1,8 @@
+site_bucket_force_destroy = true
+
+turn_compute_mode           = "asg"
+turn_instance_type          = "t3.micro"
+turn_asg_min_size           = 0
+turn_asg_desired_capacity   = 0
+turn_asg_max_size           = 1
+turn_asg_cpu_target_percent = 60

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,0 +1,6 @@
+turn_compute_mode           = "asg"
+turn_instance_type          = "t3.micro"
+turn_asg_min_size           = 1
+turn_asg_desired_capacity   = 1
+turn_asg_max_size           = 3
+turn_asg_cpu_target_percent = 60

--- a/terraform/relay-perf.tfvars
+++ b/terraform/relay-perf.tfvars
@@ -1,0 +1,8 @@
+site_bucket_force_destroy = true
+
+turn_compute_mode           = "asg"
+turn_instance_type          = "t3.micro"
+turn_asg_min_size           = 0
+turn_asg_desired_capacity   = 0
+turn_asg_max_size           = 2
+turn_asg_cpu_target_percent = 60


### PR DESCRIPTION
## Summary
- Add ASG-backed coturn relay mode with launch templates, AMI override support, target tracking, multi-IP Route 53 reconciliation, and async relay start/status handling.
- Add Packer relay AMI automation with PR-scoped AMIs and mainline promotion to `TF_TURN_AMI_ID`.
- Add root `terraform/*.tfvars` environment defaults, manual relay perf workflow/reporting, and updated deploy/preview/docs/AGENTS guidance.

## Test plan
- `terraform init -backend=false && terraform validate` in `deploy/terraform/aws`
- `terraform fmt -recursive deploy/terraform/aws terraform`
- `npm run build`
- `npm run lint`
- `npm run test -- --run`
- `npm run build` in `lambda`
- `npm run bundle` in `lambda`
- `npm run test` in `lambda`

Note: local Packer validation was not run because `packer` is not installed in this environment; the new workflow runs `packer init`, `packer validate`, and `packer build` when applicable.

Made with [Cursor](https://cursor.com)