### PR TITLE
Fix relay AMI promotion token

### DIFF
--- a/.github/workflows/build-relay-ami.yml
+++ b/.github/workflows/build-relay-ami.yml
@@ -121,6 +121,16 @@ jobs:
       - name: Promote AMI variable
         if: inputs.promote && steps.capture.outputs.ami_id != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_VARIABLES_TOKEN }}
           AMI_ID: ${{ steps.capture.outputs.ami_id }}
-        run: gh variable set TF_TURN_AMI_ID --body "$AMI_ID" --repo "$GITHUB_REPOSITORY"
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::GH_VARIABLES_TOKEN is not set; skipping TF_TURN_AMI_ID promotion. This deploy will still use AMI ${AMI_ID} from the current job output."
+            exit 0
+          fi
+          if gh variable set TF_TURN_AMI_ID --body "$AMI_ID" --repo "$GITHUB_REPOSITORY"; then
+            echo "Promoted TF_TURN_AMI_ID=${AMI_ID}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Could not update TF_TURN_AMI_ID. This deploy will still use AMI ${AMI_ID} from the current job output."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,7 @@ sweeper process.
 Required repository **Secrets** for deploy:
 
 - `AWS_ROLE_ARN`, `ROOM_JWT_SECRET`, `AWS_REGION`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`.
+- Packer AMI promotion: **`GH_VARIABLES_TOKEN`** — fine-grained token with repository **Variables: read/write** permission. Mainline Packer builds use it to update `TF_TURN_AMI_ID`; promotion failure is non-blocking because deploy still consumes the current job's AMI output.
 - Optional coturn: **`TURN_COTURN_STATIC_PASSWORD`** — required when **`TF_TURN_EC2_ENABLED`** is `true` (same value for Terraform `turn_coturn_static_password` and `VITE_MULTIPLAYER_TURN_CREDENTIAL` in the site build).
 
 Optional repository **Variables** (plaintext) for Vite — set these so every

--- a/deploy/terraform/aws/README.md
+++ b/deploy/terraform/aws/README.md
@@ -84,6 +84,7 @@ Root-level config files keep non-secret sizing defaults out of GitHub Variables:
 
 | GitHub Actions | Value |
 |----------------|--------|
+| **Secret** `GH_VARIABLES_TOKEN` | Fine-grained token with repository **Variables: read/write** permission. Used only by mainline Packer builds to promote `TF_TURN_AMI_ID`; promotion failure is non-blocking. |
 | **Secret** `TURN_COTURN_STATIC_PASSWORD` | Your chosen coturn password (same value for Terraform + browser bundle). |
 | **Variable** `VITE_MULTIPLAYER_TURN_HOST` | Hostname only, e.g. `turn.cardgame.michaelj43.dev` (same as `terraform output -raw turn_hostname`). **Do not** use `https://` or a path. |
 | **Variable** `VITE_MULTIPLAYER_TURN_USER` | `cardgame` (matches Terraform user-data). |
@@ -115,7 +116,7 @@ Then redeploy the site. The HTTP Lambda requests relay capacity on `/turn/start`
 `.github/workflows/build-relay-ami.yml` is used by deploy/preview workflows before Terraform:
 
 - PRs that change the Packer file build a PR-scoped AMI and pass it only to that PR preview deploy.
-- `main` builds promote the AMI by updating repository Variable **`TF_TURN_AMI_ID`**, and the same deploy run uses the fresh AMI output directly.
+- `main` builds promote the AMI by updating repository Variable **`TF_TURN_AMI_ID`** with **`GH_VARIABLES_TOKEN`**, and the same deploy run uses the fresh AMI output directly. If promotion fails, deploy still continues with that run's AMI output.
 - Runs without Packer changes fall back to the current **`TF_TURN_AMI_ID`** value.
 
 PR AMIs are tagged with `CardGameRelayAmiScope=pr` and `CardGamePullRequest=<number>` so preview teardown can deregister them.


### PR DESCRIPTION
## Summary
- Use the `GH_VARIABLES_TOKEN` secret for `TF_TURN_AMI_ID` promotion instead of `GITHUB_TOKEN`.
- Make AMI promotion non-blocking so deploy can still consume the freshly built AMI job output if variable promotion fails.
- Document the new secret in the Terraform README and `AGENTS.md`.

## Test plan
- `npm run lint`


Made with [Cursor](https://cursor.com)