### PR TITLE
Add preview deployment environments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,6 +48,9 @@ jobs:
     needs: build-relay-ami
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    environment:
+      name: preview-pr-${{ github.event.pull_request.number }}
+      url: https://pr-${{ github.event.pull_request.number }}.cardgame.michaelj43.dev
     env:
       PACKER_RELAY_AMI_ID: ${{ needs.build-relay-ami.outputs.ami_id }}
       PROMOTED_RELAY_AMI_ID: ${{ vars.TF_TURN_AMI_ID }}

--- a/.github/workflows/relay-perf.yml
+++ b/.github/workflows/relay-perf.yml
@@ -69,6 +69,9 @@ jobs:
   perf:
     if: vars.TF_RELAY_PERF_ENABLED == 'true'
     runs-on: ubuntu-latest
+    environment:
+      name: relay-perf-pr-${{ inputs.pr_number }}
+      url: https://perf-pr-${{ inputs.pr_number }}.cardgame.michaelj43.dev
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add per-PR GitHub deployment environments for preview deployments.
- Add matching GitHub environment metadata for manual relay perf runs.

## Test plan
- `npm run lint`


Made with [Cursor](https://cursor.com)