### PR TITLE
Mark ephemeral deployments inactive after teardown

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,7 @@ permissions:
   issues: write
   pull-requests: write
   actions: write
+  deployments: write
 
 concurrency:
   group: preview-pr-${{ github.event.pull_request.number }}
@@ -280,6 +281,21 @@ jobs:
               aws ec2 delete-snapshot --snapshot-id "$SNAPSHOT" || true
             done
           done
+
+      - name: Mark preview deployment inactive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ENV_NAME: preview-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          DEPLOYMENT_ID="$(gh api "repos/${GITHUB_REPOSITORY}/deployments" \
+            -f environment="${ENV_NAME}" \
+            --jq '.[0].id' || true)"
+          if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+              -f state=inactive \
+              -f description="Preview environment destroyed"
+          fi
 
       - name: Comment teardown
         uses: actions/github-script@v7

--- a/.github/workflows/relay-perf.yml
+++ b/.github/workflows/relay-perf.yml
@@ -38,6 +38,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  deployments: write
 
 concurrency:
   group: relay-perf-pr-${{ inputs.pr_number }}
@@ -198,3 +199,19 @@ jobs:
       - name: Delete relay perf Terraform state
         if: always() && inputs.destroy_after
         run: aws s3 rm "s3://${TF_STATE_BUCKET}/${TF_STATE_KEY}" || true
+
+      - name: Mark relay perf deployment inactive
+        if: always() && inputs.destroy_after
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ENV_NAME: relay-perf-pr-${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          DEPLOYMENT_ID="$(gh api "repos/${GITHUB_REPOSITORY}/deployments" \
+            -f environment="${ENV_NAME}" \
+            --jq '.[0].id' || true)"
+          if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+              -f state=inactive \
+              -f description="Relay perf environment destroyed"
+          fi


### PR DESCRIPTION
## Summary
- Mark PR preview deployments inactive after preview teardown completes.
- Mark relay perf deployments inactive after the perf stack is destroyed.
- Add `deployments: write` permission so workflow teardown steps can update deployment status.

## Test plan
- Not run locally; workflow-only change.
- Verify on a closed preview PR or a relay perf run with `destroy_after=true` that the deployment shows as inactive after teardown.


Made with [Cursor](https://cursor.com)