### PR TITLE
Fix inactive deployment status update

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -288,13 +288,17 @@ jobs:
           ENV_NAME: preview-pr-${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          DEPLOYMENT_ID="$(gh api "repos/${GITHUB_REPOSITORY}/deployments" \
+          DEPLOYMENT_ID="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments" \
             -f environment="${ENV_NAME}" \
-            --jq '.[0].id' || true)"
-          if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
-            gh api "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
-              -f state=inactive \
-              -f description="Preview environment destroyed"
+            --jq '.[0].id // empty' || true)"
+          if [ -z "$DEPLOYMENT_ID" ]; then
+            echo "::warning::No deployment found for ${ENV_NAME}; skipping inactive status update."
+            exit 0
+          fi
+          if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+            -f state=inactive \
+            -f description="Preview environment destroyed"; then
+            echo "::warning::Could not mark ${ENV_NAME} deployment inactive."
           fi
 
       - name: Comment teardown

--- a/.github/workflows/relay-perf.yml
+++ b/.github/workflows/relay-perf.yml
@@ -207,11 +207,15 @@ jobs:
           ENV_NAME: relay-perf-pr-${{ inputs.pr_number }}
         run: |
           set -euo pipefail
-          DEPLOYMENT_ID="$(gh api "repos/${GITHUB_REPOSITORY}/deployments" \
+          DEPLOYMENT_ID="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/deployments" \
             -f environment="${ENV_NAME}" \
-            --jq '.[0].id' || true)"
-          if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
-            gh api "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
-              -f state=inactive \
-              -f description="Relay perf environment destroyed"
+            --jq '.[0].id // empty' || true)"
+          if [ -z "$DEPLOYMENT_ID" ]; then
+            echo "::warning::No deployment found for ${ENV_NAME}; skipping inactive status update."
+            exit 0
+          fi
+          if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+            -f state=inactive \
+            -f description="Relay perf environment destroyed"; then
+            echo "::warning::Could not mark ${ENV_NAME} deployment inactive."
           fi


### PR DESCRIPTION
## Summary
- Force the deployment lookup call to use `GET` so `gh api` does not try to create a deployment.
- Treat missing deployments as a warning and skip the inactive update cleanly.
- Make the inactive status POST non-fatal so UI cleanup cannot fail teardown.

## Test plan
- Verified `gh api --method GET repos/MichaelJ43/card-game/deployments -f environment=preview-pr-48 --jq '.[0].id // empty'` returns the existing deployment ID.
- Not run in GitHub Actions yet; workflow-only fix.


Made with [Cursor](https://cursor.com)