### PR TITLE
Add preview environment cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-preview-environments.yml
+++ b/.github/workflows/cleanup-preview-environments.yml
@@ -1,0 +1,36 @@
+name: Cleanup Preview Environments
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview deletions without removing environments"
+        type: boolean
+        default: true
+      keep:
+        description: "Number of newest preview-pr-* environments to keep"
+        type: number
+        default: 10
+
+permissions:
+  contents: read
+  actions: write
+  deployments: read
+
+jobs:
+  cleanup:
+    name: Cleanup preview environments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Cleanup preview environments
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ENVIRONMENTS_TOKEN || github.token }}
+          KEEP_PREVIEW_ENVIRONMENTS: ${{ inputs.keep }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: node scripts/github/cleanup-preview-environments.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,11 +305,16 @@ sweeper process.
 - `.github/workflows/relay-perf.yml` — manual, gated relay perf workflow. It
   creates a separate `perf-pr-<n>` stack, runs TURN allocation/throughput checks,
   uploads raw artifacts, and updates a PR comment.
+- `.github/workflows/cleanup-preview-environments.yml` — manual cleanup for
+  stale GitHub **Environment** records named `preview-pr-*`. It keeps the newest
+  preview environments (default: 10) and only deletes older entries whose latest
+  deployment status is `inactive`; dry-run is the default.
 
 Required repository **Secrets** for deploy:
 
 - `AWS_ROLE_ARN`, `ROOM_JWT_SECRET`, `AWS_REGION`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`.
 - Packer AMI promotion: **`GH_VARIABLES_TOKEN`** — fine-grained token with repository **Variables: read/write** permission. Mainline Packer builds use it to update `TF_TURN_AMI_ID`; promotion failure is non-blocking because deploy still consumes the current job's AMI output.
+- Optional environment cleanup: **`GH_ENVIRONMENTS_TOKEN`** — repository token for deleting GitHub Environments if the default `GITHUB_TOKEN` cannot delete `preview-pr-*` environment records. A classic token with `repo` scope is sufficient for private repos per GitHub's environment API docs.
 - Optional coturn: **`TURN_COTURN_STATIC_PASSWORD`** — required when **`TF_TURN_EC2_ENABLED`** is `true` (same value for Terraform `turn_coturn_static_password` and `VITE_MULTIPLAYER_TURN_CREDENTIAL` in the site build).
 
 Optional repository **Variables** (plaintext) for Vite — set these so every

--- a/scripts/github/cleanup-preview-environments.mjs
+++ b/scripts/github/cleanup-preview-environments.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+const repository = process.env.GITHUB_REPOSITORY;
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const keepCount = Number.parseInt(process.env.KEEP_PREVIEW_ENVIRONMENTS || "10", 10);
+const dryRun = parseBoolean(process.env.DRY_RUN ?? "true");
+const environmentPattern = /^preview-pr-\d+$/;
+
+if (!repository || !repository.includes("/")) {
+  fail("GITHUB_REPOSITORY must be set to owner/repo.");
+}
+
+if (!token) {
+  fail("GITHUB_TOKEN or GH_TOKEN must be set.");
+}
+
+if (!Number.isInteger(keepCount) || keepCount < 0) {
+  fail("KEEP_PREVIEW_ENVIRONMENTS must be a non-negative integer.");
+}
+
+const [owner, repo] = repository.split("/");
+const apiBase = "https://api.github.com";
+
+const previewEnvironments = (await listEnvironments()).filter((environment) =>
+  environmentPattern.test(environment.name),
+);
+
+const candidates = [];
+for (const environment of previewEnvironments) {
+  candidates.push(await describePreviewEnvironment(environment));
+}
+
+candidates.sort((left, right) => compareDescending(left.sortDate, right.sortDate));
+
+const kept = candidates.slice(0, keepCount);
+const expired = candidates.slice(keepCount);
+const deleted = [];
+const skipped = [];
+
+for (const candidate of expired) {
+  if (candidate.latestStatus !== "inactive") {
+    skipped.push({
+      ...candidate,
+      reason: candidate.latestStatus
+        ? `latest deployment status is ${candidate.latestStatus}`
+        : "no latest deployment status found",
+    });
+    continue;
+  }
+
+  if (dryRun) {
+    skipped.push({ ...candidate, reason: "dry run" });
+    continue;
+  }
+
+  await deleteEnvironment(candidate.name);
+  deleted.push(candidate);
+}
+
+const summaryLines = [
+  "### Preview environment cleanup",
+  "",
+  `- Mode: ${dryRun ? "dry run" : "delete"}`,
+  `- Keep count: ${keepCount}`,
+  `- Preview environments found: ${candidates.length}`,
+  `- Kept as newest: ${kept.length}`,
+  `- Deleted inactive environments: ${deleted.length}`,
+  `- Skipped old environments: ${skipped.length}`,
+  "",
+  "#### Deleted",
+  ...formatRows(deleted, "Deleted none."),
+  "",
+  "#### Skipped",
+  ...formatRows(skipped, "Skipped none."),
+];
+
+console.log(summaryLines.join("\n"));
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await import("node:fs/promises").then(({ appendFile }) =>
+    appendFile(process.env.GITHUB_STEP_SUMMARY, `${summaryLines.join("\n")}\n`),
+  );
+}
+
+async function listEnvironments() {
+  const environments = [];
+  for (let page = 1; ; page += 1) {
+    const response = await githubApi(`/repos/${owner}/${repo}/environments`, {
+      searchParams: { per_page: "100", page: String(page) },
+    });
+    environments.push(...(response.environments || []));
+    if (environments.length >= response.total_count || (response.environments || []).length === 0) {
+      return environments;
+    }
+  }
+}
+
+async function describePreviewEnvironment(environment) {
+  const deployments = await githubApi(`/repos/${owner}/${repo}/deployments`, {
+    searchParams: { environment: environment.name, per_page: "1" },
+  });
+  const latestDeployment = deployments[0] || null;
+  const statuses = latestDeployment
+    ? await githubApi(`/repos/${owner}/${repo}/deployments/${latestDeployment.id}/statuses`, {
+        searchParams: { per_page: "1" },
+      })
+    : [];
+  const latestStatus = statuses[0] || null;
+
+  return {
+    name: environment.name,
+    environmentUpdatedAt: environment.updated_at,
+    latestDeploymentId: latestDeployment?.id ?? null,
+    latestDeploymentCreatedAt: latestDeployment?.created_at ?? null,
+    latestStatus: latestStatus?.state ?? null,
+    latestStatusCreatedAt: latestStatus?.created_at ?? null,
+    sortDate: latestStatus?.created_at || latestDeployment?.created_at || environment.updated_at,
+  };
+}
+
+async function deleteEnvironment(name) {
+  await githubApi(`/repos/${owner}/${repo}/environments/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+    okStatuses: [204],
+  });
+}
+
+async function githubApi(path, options = {}) {
+  const url = new URL(`${apiBase}${path}`);
+  for (const [key, value] of Object.entries(options.searchParams || {})) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url, {
+    method: options.method || "GET",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  const okStatuses = options.okStatuses || [200];
+  if (!okStatuses.includes(response.status)) {
+    const body = await response.text();
+    throw new Error(`${options.method || "GET"} ${path} failed with ${response.status}: ${body}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+function parseBoolean(value) {
+  return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function compareDescending(left, right) {
+  return new Date(right).getTime() - new Date(left).getTime();
+}
+
+function formatRows(rows, emptyText) {
+  if (rows.length === 0) {
+    return [`- ${emptyText}`];
+  }
+
+  return rows.map((row) => {
+    const status = row.latestStatus || "unknown";
+    const reason = row.reason ? ` (${row.reason})` : "";
+    return `- ${row.name}: ${status}${reason}`;
+  });
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Add a manual cleanup workflow for stale `preview-pr-*` GitHub Environments.
- Keep the newest preview environments, defaulting to 10, and only delete older entries whose latest deployment status is `inactive`.
- Add a dry-run default plus a small Node script so the filtering/deletion logic is easier to inspect and validate.
- Document the workflow and optional `GH_ENVIRONMENTS_TOKEN` fallback in `AGENTS.md`.

## Test plan
- `node --check scripts/github/cleanup-preview-environments.mjs`
- `GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=MichaelJ43/card-game KEEP_PREVIEW_ENVIRONMENTS=10 DRY_RUN=true node scripts/github/cleanup-preview-environments.mjs`
- `npm run lint`


Made with [Cursor](https://cursor.com)