### PR TITLE
Add M43 analytics tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches: [main]
     paths:
+      - 'index.html'
+      - 'chat-popout.html'
       - 'src/**'
       - 'lambda/**'
       - 'deploy/terraform/**'

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Choosing another entry in the **Game** menu updates the selection only; press **
 
 Use **Rules** (next to **End game**) to open a modal with the in-app rules for the **currently selected** game (you can read them before **Start deal**).
 
+### Analytics
+
+The browser entries load `https://static.michaelj43.dev/v1/m43-analytics.js` with app id `card-game`. It records pageview events to `https://api.michaelj43.dev/analytics/events?v=1`; add `?m43debug=1` to a page URL to see client diagnostics in the browser console.
+
 Production build and local preview of the built assets:
 
 ```bash

--- a/chat-popout.html
+++ b/chat-popout.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Room chat</title>
+    <script
+      src="https://static.michaelj43.dev/v1/m43-analytics.js"
+      defer
+      data-m43-app="card-game"
+      data-m43-api="https://api.michaelj43.dev"
+      data-m43-spa="true"
+    ></script>
   </head>
   <body>
     <div id="chat-popout-root"></div>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>card-game</title>
+    <script
+      src="https://static.michaelj43.dev/v1/m43-analytics.js"
+      defer
+      data-m43-app="card-game"
+      data-m43-api="https://api.michaelj43.dev"
+      data-m43-spa="true"
+    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Load the M43 analytics browser script in the main app and chat popout HTML entries with app id `card-game`.
- Document the analytics script/API hosts and debug query flag.
- Include HTML entry files in the deploy workflow path filter so merged analytics changes trigger production deploys.

## Test plan
- `npm run lint`
- `npm run build`


Made with [Cursor](https://cursor.com)