### PR TITLE
Add Expert AI difficulty (Skyjo)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ This document summarizes how the **card-game** repository is structured, how gam
 | `src/core/match.ts` | **`MatchState`**, **`applyFinishedRound`**, **`createInitialMatchState`**, end condition **`anyAtOrAbove`**, **`winnerIs`**: `lowest` \| `highest`. |
 | `src/core/table.ts` | **`createEmptyTable`**, **`cloneTable`**, **`moveTop`**, zone helpers. |
 | `src/core/registry.ts` | **`registerGameModule`** / **`getGameModule`** — modules self-register on import. |
-| `src/core/aiContext.ts` | **`AiDifficulty`**: `easy` \| `medium` \| `hard`; **`SelectAiContext`** (difficulty + optional match fields for Skyjo AI). |
+| `src/core/aiContext.ts` | **`AiDifficulty`**: `easy` \| `medium` \| `hard` \| `expert`; **`SelectAiContext`** (difficulty + optional match fields for Skyjo AI). |
+| `docs/ai-behavior.md` | **Table AI**: what each **difficulty** does, which games use **`SelectAiContext`**, and which modules ignore it. |
 | `src/data/manifests.ts` | **`GAME_SOURCES`**, **`DECK_SOURCES`**, **`GAME_IDS`** — Vite `?raw` imports wiring ids to YAML strings. |
 | `src/data/rulesSources.ts` | **`RULES_SOURCES`**, **`rulesTextForGame`**, **`RulesGameId`** — maps each **`GAME_IDS`** entry to `src/rules/*.md` raw markdown. |
 | `src/data/houseRules.ts` | **`localStorage`** persistence for per-game **house rules**; **`createSessionOptionsHouseRules`** merges into **`CreateSessionOptions`**; **`GAMES_WITH_DISCARD_RECYCLE_OPTION`** controls which games show the “reshuffle discard when draw empty” toggle; **`effectiveReshuffleDiscardWhenDrawEmpty`** resolves manifest default + stored preference + session options. |
@@ -117,10 +118,12 @@ Central definition in **`src/core/types.ts`**. Examples: **`skyjoDraw`**, **`sky
 
 ## AI
 
+User-facing details (per-level behavior, per-game) are in **`docs/ai-behavior.md`**.
+
 - **`SelectAiContext`** includes **`difficulty`** and (for Skyjo) optional **`matchCumulativeScores`**, **`matchTargetScore`**.
 - **`gameSupportsConfigurableAi`**: games where the user can set **AI opponent count** (capped at 1 for “heads-up only” ids — see **`HEADS_UP_GAME_IDS`** in **`playerConfig.ts`**).
-- **`gameSupportsPerSeatAiDifficulty`**: currently **`go-fish`** and **`skyjo`** — **`App`** renders per-seat difficulty selects and passes them in **`CreateSessionOptions.aiDifficulties`**.
-- Other titles may use **`selectAiAction`** with a fixed difficulty in **`useEffect`** (e.g. Crazy Eights, Uno) or **`null`** if the game does not use table AI turns the same way.
+- **`gameSupportsPerSeatAiDifficulty`**: currently **`go-fish`** and **`skyjo`** — **`App`** renders per-seat difficulty selects and passes them in **`CreateSessionOptions.aiDifficulties`**. Only those modules *interpret* that field; other titles with timer-driven AI may use a fixed context or ignore **`difficulty`**.
+- Other titles may use **`selectAiAction`** with a fixed difficulty in **`useEffect`** (e.g. Crazy Eights, Uno use `{ difficulty: 'medium' }` even though they do not read it) or **`null`** if the game does not use table AI turns the same way (e.g. War).
 
 When adding AI to a game, implement **`selectAiAction`** and ensure **`getLegalActions`** matches what humans can do.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A **browser-only** card table built with **React**, **TypeScript**, and **Vite**
 
 End-to-end flows (browser shell, **WebRTC** game channel vs **WebSocket** signaling relay, optional **TURN/coturn**, AWS **Lambdas** / **DynamoDB**, and how they connect to deploy) are described in **[`docs/architecture.md`](docs/architecture.md)**. For Terraform inputs, DNS/TLS, and CI deploy steps, that doc points at **[`deploy/terraform/aws/README.md`](deploy/terraform/aws/README.md)**.
 
+**Table AI (easy / medium / hard / expert)** and how each **supported game** uses or ignores difficulty are documented in **[`docs/ai-behavior.md`](docs/ai-behavior.md)**.
+
 ## Requirements
 
 - **Node.js** (20+ or current LTS recommended)

--- a/docs/ai-behavior.md
+++ b/docs/ai-behavior.md
@@ -1,0 +1,71 @@
+# Table AI: difficulties and per-game behavior
+
+The shell moves AI opponents on your behalf by calling each game’s `selectAiAction` with a `SelectAiContext` (see `src/core/aiContext.ts` and `GameModule` in `src/core/gameModule.ts`).
+
+- **`SelectAiContext.difficulty`** is one of **`easy`**, **`medium`**, **`hard`**, or **`expert`**. It is only **meaningful** when the game module actually reads it (today: **Go Fish** and **Skyjo**).
+- **`SelectAiContext.matchCumulativeScores`** and **`matchTargetScore`** are passed for **Skyjo** match play so the AI can consider the finisher-doubling rule.
+
+## Toolbar: per-seat difficulty
+
+The **Game** toolbar shows a difficulty control **only** for games in `gameSupportsPerSeatAiDifficulty` (`src/session/playerConfig.ts`):
+
+| Game        | Per-seat difficulty in UI? |
+|------------|----------------------------|
+| **Go Fish** | Yes (one control per AI seat) |
+| **Skyjo**   | Yes (one control per AI seat) |
+| Other games | No — changing the stored difficulty in state does not affect their logic unless noted below. |
+
+## What each level means (when implemented)
+
+| Level     | Role |
+|-----------|------|
+| **Easy**  | Weaker, more random play; more mistakes. |
+| **Medium** | Baseline: mixed or “reasonable default” heuristics. |
+| **Hard**   | Stronger heuristics; fewer random errors. |
+| **Expert** | Stronger than **hard** where a separate policy exists (only **Skyjo** has extra logic beyond **hard**; **Go Fish** treats **expert** like **hard**). |
+
+## Games that use `difficulty` in `selectAiAction`
+
+### Go Fish (`go-fish`)
+
+- **Medium**: chooses a **uniform random** legal ask (rank + target player) among all legal `goFishAsk` actions.
+- **Hard** and **Expert**: score every legal ask with a small heuristic (favor asking ranks you already hold, and large opponent hands), then pick **uniformly among the highest-scoring** asks. **Expert** is intentionally the same as **hard** here.
+- **Easy**: often picks among the **lowest-scoring** (weaker) asks; some of the time plays a **fully random** legal ask to simulate mistakes.
+
+### Skyjo (`skyjo`)
+
+Match fields (`matchCumulativeScores`, `matchTargetScore`) are used to estimate the cost of **calling/finishing** when the round would end with you as finisher and your row score might be doubled (not lowest).
+
+- **Easy**: more randomness on swaps/dumps, sometimes draws from stock when it should consider discard, and sometimes a random legal move.
+- **Medium**: one tier **between** easy and **hard** / **expert** (e.g. swap/dump thresholds and a lighter finisher model than `hard`).
+- **Hard** and **Expert** share a “smart” line that evaluates swaps and dumps with estimated unknown-card EV, finisher risk, and column-clear bonuses. **Expert** extends **hard** with, among other things: tighter discard-vs-deck choice; multiset-based **probability** and **variance** for hidden cells; extra weight on **not** breaking a good column setup; and more careful **end-of-round** dump pressure when a lot of points are **already face-up** (visible “bad” hands).
+
+(Implementation lives in `selectAiSkyjo` in `src/games/skyjo/index.ts`.)
+
+## Other games: shell-timed AI, but difficulty is not used in the module
+
+The shell’s `useEffect` hooks call `selectAiAction` for several titles, but the modules do **not** read `context.difficulty` (they `void` it or use `_context`). A fixed **`{ difficulty: 'medium' }`** is passed for **Crazy Eights** and **Uno**; for **Thirty-one**, **Euchre**, **Durak**, **Pinochle**, **Canasta**, and **Sequence Race**, the shell passes `difficultyForAiPlayer` from the session, but the **module ignores it** — behavior is the same regardless of the stored per-seat list.
+
+| Game / module        | Shell auto-plays AI turns? | Uses `difficulty`? | Typical `selectAiAction` style |
+|----------------------|----------------------------|--------------------|--------------------------------|
+| **Crazy Eights**     | Yes                        | No (fixed `medium` in `App`) | Random legal play; random suit on 8. |
+| **Uno**              | Yes                        | No (fixed `medium` in `App`) | Heuristic mix of play / draw / pass. |
+| **Thirty-one**       | Yes                        | No                 | Knocks at high score; else random among legal. |
+| **Euchre** / **Pinochle** | Yes                   | No                 | Random among legal card plays. |
+| **Durak**            | Yes                        | No                 | Random attack; random beat; else take. |
+| **Canasta**          | Yes                        | No                 | Draw two then random discard. |
+| **Sequence Race**    | Yes                        | No                 | Random play or end turn. |
+
+## Games with no (or no-op) `selectAiAction` in practice
+
+- **War** — `selectAiAction` always returns `null`. You advance the skirmish with the table control yourself.
+- **Blackjack**, **Baccarat**, **Poker (draw)**, **High-card duel** — `selectAiAction` is `null` or unused; the flow is **button- or step-driven** in the UI (e.g. dealer rules run inside the module on your actions).
+- **Demo custom** — `selectAiAction` is `null`.
+
+## Summary
+
+- Only **Go Fish** and **Skyjo** both **show** the difficulty control **and** **implement** different playstyles per level.
+- **Skyjo** is the only game with an **expert** policy that is **stricter** than **hard**; **Go Fish** maps **expert** to **hard**.
+- Several other games have **timer-driven** AI in the browser, but that AI does **not** follow the easy/medium/hard/expert scale — it uses simple random or fixed heuristics, independent of the saved difficulty (and for most of those games, the toolbar does not even expose the control).
+
+For architecture and how sessions store `aiPlayerConfig.difficulties`, see **`AGENTS.md`** in the repository root (AI section) and `src/App.tsx` (where `difficulty` is passed into `selectAiAction`).

--- a/src/core/aiContext.ts
+++ b/src/core/aiContext.ts
@@ -3,7 +3,10 @@ export type AiDifficulty = 'easy' | 'medium' | 'hard' | 'expert'
 
 export const AI_DIFFICULTY_OPTIONS: readonly AiDifficulty[] = ['easy', 'medium', 'hard', 'expert']
 
-/** Passed to {@link import('./gameModule').GameModule.selectAiAction} for the current AI seat. */
+/**
+ * Passed to {@link import('./gameModule').GameModule.selectAiAction} for the current AI seat.
+ * Not every module reads all fields; see `docs/ai-behavior.md`.
+ */
 export interface SelectAiContext {
   difficulty: AiDifficulty
   /** Cumulative match totals before this round (same length as seats). Used by Skyjo for finisher double penalty. */

--- a/src/core/aiContext.ts
+++ b/src/core/aiContext.ts
@@ -1,7 +1,7 @@
 /** Per-AI policy; locked for the current deal (see session `aiPlayerConfig`). */
-export type AiDifficulty = 'easy' | 'medium' | 'hard'
+export type AiDifficulty = 'easy' | 'medium' | 'hard' | 'expert'
 
-export const AI_DIFFICULTY_OPTIONS: readonly AiDifficulty[] = ['easy', 'medium', 'hard']
+export const AI_DIFFICULTY_OPTIONS: readonly AiDifficulty[] = ['easy', 'medium', 'hard', 'expert']
 
 /** Passed to {@link import('./gameModule').GameModule.selectAiAction} for the current AI seat. */
 export interface SelectAiContext {
@@ -13,5 +13,5 @@ export interface SelectAiContext {
 }
 
 export function normalizeAiDifficulty(v: unknown): AiDifficulty {
-  return v === 'easy' || v === 'hard' || v === 'medium' ? v : 'medium'
+  return v === 'easy' || v === 'hard' || v === 'medium' || v === 'expert' ? v : 'medium'
 }

--- a/src/games/go-fish/index.ts
+++ b/src/games/go-fish/index.ts
@@ -460,7 +460,7 @@ const goFishModule: GameModule<GoFishGameState> = {
       s: a.type === 'goFishAsk' ? scoreGoFishAsk(a, sim, templates, playerIndex) : 0,
     }))
 
-    if (difficulty === 'hard') {
+    if (difficulty === 'hard' || difficulty === 'expert') {
       const maxS = Math.max(...scored.map((x) => x.s))
       const top = scored.filter((x) => x.s === maxS)
       return top[Math.floor(rng() * top.length)]!.a

--- a/src/games/skyjo/index.ts
+++ b/src/games/skyjo/index.ts
@@ -120,6 +120,149 @@ function expectedUnknownCardValue(counts: Record<number, number>, total: number)
   return s / total
 }
 
+/** Second moment; used to weight face-down “fuzzy” uncertainty. */
+function varianceUnknownCard(counts: Record<number, number>, total: number): number {
+  if (total <= 0) return 0
+  const ev = expectedUnknownCardValue(counts, total)
+  let e2 = 0
+  for (const [k, n] of Object.entries(counts)) {
+    if (n <= 0) continue
+    const v = Number(k)
+    e2 += v * v * (n / total)
+  }
+  return Math.max(0, e2 - ev * ev)
+}
+
+function probUnknownIsValue(counts: Record<number, number>, total: number, v: number): number {
+  if (total <= 0) return 0
+  return (counts[v] ?? 0) / total
+}
+
+function sumVisibleFaceUpOnGrid(
+  table: TableState,
+  playerIndex: number,
+  templates: Record<string, CardTemplate>,
+): number {
+  let s = 0
+  for (const c of table.zones[gridZone(playerIndex)]!.cards) {
+    if (!c || isSlot(c.templateId) || !c.faceUp) continue
+    s += cardValue(templates, c.templateId)
+  }
+  return s
+}
+
+/**
+ * If two cards in a column are face up with the same value and the third is still hidden,
+ * placing `pv` on the hidden discards a chance at a high triple when `pv` does not match.
+ */
+function expertClogLastHiddenInPairColumn(
+  table: TableState,
+  playerIndex: number,
+  templates: Record<string, CardTemplate>,
+  placeIdx: number,
+  pv: number,
+  expert: boolean,
+): number {
+  if (!expert) return 0
+  const [a, b, d] = columnIndices(placeIdx % COLS)
+  const g = table.zones[gridZone(playerIndex)]!.cards
+  const idxs: number[] = [a, b, d]
+  let hiddenIdx: number | null = null
+  const face: { v: number; i: number }[] = []
+  for (const i of idxs) {
+    const c = g[i]
+    if (!c || isSlot(c.templateId)) continue
+    if (!c.faceUp) {
+      if (hiddenIdx === null) hiddenIdx = i
+      else return 0
+      continue
+    }
+    face.push({ v: cardValue(templates, c.templateId), i })
+  }
+  if (face.length !== 2 || hiddenIdx === null) return 0
+  if (face[0]!.v !== face[1]!.v) return 0
+  if (placeIdx !== hiddenIdx) return 0
+  const r = face[0]!.v
+  if (pv === r) return 0
+  return 4.5 + Math.max(0, r) * 0.5
+}
+
+/**
+ * Swapping off a card that is part of a face-up pair, while the third column card is still hidden,
+ * hurts odds of a future column triple—more so for higher pairs.
+ */
+function expertLoomingPairBreakPenalty(
+  table: TableState,
+  playerIndex: number,
+  templates: Record<string, CardTemplate>,
+  placeIdx: number,
+  pv: number,
+  expert: boolean,
+): number {
+  if (!expert) return 0
+  const [a, b, d] = columnIndices(placeIdx % COLS)
+  const g = table.zones[gridZone(playerIndex)]!.cards
+  const col = [a, b, d].map((i) => g[i]!)
+  if (col.some((c) => !c || isSlot(c.templateId))) return 0
+  let hiddenN = 0
+  for (const c of col) {
+    if (!c.faceUp) hiddenN++
+  }
+  if (hiddenN !== 1) return 0
+  const faceV: number[] = []
+  for (const c of col) {
+    if (c.faceUp) faceV.push(cardValue(templates, c.templateId))
+  }
+  if (faceV.length !== 2) return 0
+  if (faceV[0] !== faceV[1]) return 0
+  const r = faceV[0]!
+  const cAt = g[placeIdx]!
+  if (!cAt.faceUp || cardValue(templates, cAt.templateId) !== r) return 0
+  if (pv === r) return 0
+  return 5 + (r >= 6 ? r * 0.6 : 0)
+}
+
+/**
+ * Slight “halo” toward a column triple: weight toward matching a lone face-up
+ * (or a pair) using remaining-card P(value).
+ */
+function expertTripleCompletionHalo(
+  table: TableState,
+  playerIndex: number,
+  placeIdx: number,
+  pv: number,
+  templates: Record<string, CardTemplate>,
+  counts: Record<number, number>,
+  total: number,
+  expert: boolean,
+): number {
+  if (!expert) return 0
+  const [a, b, d] = columnIndices(placeIdx % COLS)
+  const g = table.zones[gridZone(playerIndex)]!.cards
+  const peerVals: number[] = []
+  for (const i of [a, b, d]) {
+    if (i === placeIdx) continue
+    const c = g[i]
+    if (!c || isSlot(c.templateId) || !c.faceUp) continue
+    peerVals.push(cardValue(templates, c.templateId))
+  }
+  if (peerVals.length === 2 && peerVals[0] === peerVals[1]) {
+    const v = peerVals[0]!
+    const p3 = probUnknownIsValue(counts, total, v)
+    if (pv === v) return -2.2 * p3
+    return 0
+  }
+  if (peerVals.length === 1) {
+    const v = peerVals[0]!
+    const p3 = probUnknownIsValue(counts, total, v)
+    if (pv === v) return -1.0 * p3
+    if (p3 > 0.12) {
+      return -0.4 * p3 * Math.max(0, 8 - Math.abs(pv - v))
+    }
+  }
+  return 0
+}
+
 /** Average face-up card value on a player’s grid (null if none face-up). */
 function avgFaceUpOnGrid(table: TableState, playerIndex: number, templates: Record<string, CardTemplate>): number | null {
   const g = table.zones[gridZone(playerIndex)]!.cards
@@ -456,6 +599,8 @@ function selectAiSkyjo(
   legal: GameAction[],
 ): GameAction {
   const { difficulty, matchCumulativeScores, matchTargetScore } = context
+  const isExpert = difficulty === 'expert'
+  const isHard = difficulty === 'hard' || isExpert
   const myCum = matchCumulativeScores?.[playerIndex] ?? 0
   const matchTarget = matchTargetScore ?? 100
   const templates = table.templates
@@ -467,11 +612,18 @@ function selectAiSkyjo(
   }
 
   /** Lower score is better (estimated increase to grid sum, minus bonuses). */
-  const bestPendingActionHard = (): GameAction => {
+  const bestPendingActionSmart = (expert: boolean): GameAction => {
     const pv = cardValue(templates, gameState.pendingDraw!.templateId)
     const pCount = gameState.playerCount
     const comp = remainingUnknownComposition(table, templates, pCount)
     const evUnknown = expectedUnknownCardValue(comp.counts, comp.total)
+    const stdU = Math.sqrt(varianceUnknownCard(comp.counts, comp.total))
+    const visSum = sumVisibleFaceUpOnGrid(table, playerIndex, templates)
+    const visW =
+      expert && visSum > 22
+        ? 1 + Math.min(0.2, (visSum - 22) * 0.014)
+        : 1
+    const finM = expert ? 0.88 : 0.62
     const nextP = (playerIndex + 1) % pCount
     const pending = gameState.pendingDraw!
 
@@ -490,6 +642,21 @@ function selectAiSkyjo(
       if (completesColumnTriple(table, playerIndex, templates, i, pv)) {
         score -= 24
       }
+      if (expert) {
+        if (!c.faceUp) score += 0.3 * stdU
+        score += expertClogLastHiddenInPairColumn(table, playerIndex, templates, i, pv, expert)
+        score += expertLoomingPairBreakPenalty(table, playerIndex, templates, i, pv, expert)
+        score += expertTripleCompletionHalo(
+          table,
+          playerIndex,
+          i,
+          pv,
+          templates,
+          comp.counts,
+          comp.total,
+          expert,
+        )
+      }
       const oldToDiscard = c.faceUp ? cardValue(templates, c.templateId) : evUnknown
       const helpsNext = maxDiscardPlacementMerit(table, nextP, templates, oldToDiscard)
       score += helpsNext * 0.45
@@ -505,7 +672,7 @@ function selectAiSkyjo(
         matchTarget,
         gameState.skyjoFinisher,
       )
-      score += finishPen * 0.62
+      score += finishPen * finM * visW
       if (score < bestScore) {
         bestScore = score
         best = a
@@ -521,7 +688,7 @@ function selectAiSkyjo(
       }, Infinity)
 
       /** Swap clearly lowers expected sum — keep the card on the grid. */
-      const swapIsStrong = Number.isFinite(minSwapDelta) && minSwapDelta <= -2
+      const swapIsStrong = Number.isFinite(minSwapDelta) && minSwapDelta <= (expert ? -1.5 : -2)
 
       let bestDump = dumps[0]!
       let dumpRank = -Infinity
@@ -562,7 +729,8 @@ function selectAiSkyjo(
           matchTarget,
           gameState.skyjoFinisher,
         )
-        const adjRank = rank - fpen * 0.95
+        const fMult = expert ? 0.88 : 0.95
+        const adjRank = rank - fpen * fMult
         if (adjRank > dumpRank) {
           dumpRank = adjRank
           bestDump = a
@@ -572,17 +740,25 @@ function selectAiSkyjo(
 
       if (!swapIsStrong) {
         const giftPv = maxDiscardPlacementMerit(table, nextP, templates, pv)
-        const useDump =
-          pv >= 10 ||
-          (pv >= 8 && minSwapDelta >= 0) ||
-          (pv >= 6 && minSwapDelta >= 1.5) ||
-          (pv >= 5 && minSwapDelta >= 3)
+        const useDump = expert
+          ? pv >= 11 ||
+            (pv >= 9 && minSwapDelta >= 0) ||
+            (pv >= 7 && minSwapDelta >= 1) ||
+            (pv >= 5.5 && minSwapDelta >= 2.6)
+          : pv >= 10 ||
+            (pv >= 8 && minSwapDelta >= 0) ||
+            (pv >= 6 && minSwapDelta >= 1.5) ||
+            (pv >= 5 && minSwapDelta >= 3)
         const dumpFeedsNext = pv <= 4 && giftPv > 2.25
-        const dumpTooRisky = dumpFpen * 0.62 > 14 && minSwapDelta <= 2
-        if (useDump && !dumpFeedsNext && !dumpTooRisky) {
+        const fMultRisk = expert ? 0.85 : 0.62
+        const riskTh = expert ? 11 : 14
+        const minDeltaTh = expert ? 2.4 : 2
+        const dumpTooRisky = dumpFpen * fMultRisk > riskTh && minSwapDelta <= minDeltaTh
+        const badVisibleFinish = expert && visSum > 24 && dumpFpen > 7.5
+        if (useDump && !dumpFeedsNext && !dumpTooRisky && !badVisibleFinish) {
           return bestDump
         }
-        if (useDump && dumpFeedsNext && pv >= 9 && !dumpTooRisky) {
+        if (useDump && dumpFeedsNext && pv >= 9 && !dumpTooRisky && !badVisibleFinish) {
           return bestDump
         }
       }
@@ -652,7 +828,7 @@ function selectAiSkyjo(
     return { type: 'skyjoSwapDrawn', gridIndex: bestSwap }
   }
 
-  const noPendingHard = (): GameAction => {
+  const noPendingSmart = (expert: boolean): GameAction => {
     const disc = topDiscard(table)
     const dv = disc ? cardValue(templates, disc.templateId) : 999
     const drawAvail = table.zones.draw!.cards.length > 0
@@ -669,12 +845,25 @@ function selectAiSkyjo(
     const takeActions = legal.filter((a) => a.type === 'skyjoTakeDiscard')
     if (disc && takeActions.length > 0) {
       const giftNextIfWeDraw = maxDiscardPlacementMerit(table, nextP, templates, dv)
-      takeMerit += giftNextIfWeDraw * 0.42
+      takeMerit += giftNextIfWeDraw * (expert ? 0.35 : 0.42)
       const red = rediscardPressureForValue(dv, comp.counts, comp.total, avgPrev)
-      takeMerit -= red * 2.8
-      if (dv <= 2) return takeDiscardAction()
-      if (takeMerit >= drawMerit + 0.25 && dv <= evUnknown + 1.2) return takeDiscardAction()
-      if (dv <= 4 && takeMerit >= -0.5) return takeDiscardAction()
+      takeMerit -= red * (expert ? 3.2 : 2.8)
+      if (expert) {
+        if (dv <= 1) return takeDiscardAction()
+        const needEdge = 0.55 + Math.min(0.9, red * 2.0)
+        if (takeMerit >= drawMerit + needEdge && dv <= evUnknown + 0.45) return takeDiscardAction()
+        if (dv <= 2 && takeMerit >= drawMerit - 0.08) return takeDiscardAction()
+        if (dv <= 3 && takeMerit >= drawMerit + 0.38 && dv <= evUnknown + 0.25) return takeDiscardAction()
+        if (dv < evUnknown - 0.35 && takeMerit < drawMerit + 0.35) {
+          /* low pip but poor fit — prefer stock */
+        } else if (dv <= 4 && takeMerit >= 0.15 && dv <= evUnknown + 0.9) {
+          return takeDiscardAction()
+        }
+      } else {
+        if (dv <= 2) return takeDiscardAction()
+        if (takeMerit >= drawMerit + 0.25 && dv <= evUnknown + 1.2) return takeDiscardAction()
+        if (dv <= 4 && takeMerit >= -0.5) return takeDiscardAction()
+      }
     }
     if (drawAvail) {
       return { type: 'skyjoDraw', from: 'deck' }
@@ -715,7 +904,7 @@ function selectAiSkyjo(
       const pool = [...swaps, ...dumps]
       if (pool.length > 0) return pool[Math.floor(rng() * pool.length)]!
     }
-    if (difficulty === 'hard') return bestPendingActionHard()
+    if (isHard) return bestPendingActionSmart(isExpert)
     return pendingActionMedium()
   }
 
@@ -723,8 +912,8 @@ function selectAiSkyjo(
     return { type: 'skyjoDraw', from: 'deck' }
   }
 
-  if (difficulty === 'hard') {
-    return noPendingHard()
+  if (isHard) {
+    return noPendingSmart(isExpert)
   }
 
   if (difficulty === 'easy' && rng() < 0.42) {


### PR DESCRIPTION
Adds a fourth per-seat option `expert` in **AI player difficulty** (Go Fish: same as hard; **Skyjo**: stronger heuristics).

**Skyjo Expert (vs hard)**
- Uses remaining-deck `P(value)` and variance: extra cost for swapping into face-down cells (fuzzy / uncertain), column "halo" nudges for completing triples, penalties for clogging a pair column or breaking a face-up pair while the third card is still hidden.
- **Discard vs deck**: stricter bar to take the discard; skips low pips that do not sit well (take merit vs draw merit) and weights rediscussion pressure a bit more.
- **End round / last flip**: higher weight on finisher double penalty, scales up when a lot of points are already visible, and is more conservative about high-number dumps to flip (unless swap improvement is strong).

The shell already lists `AI_DIFFICULTY_OPTIONS`, so the new option appears in the Skyjo/Go Fish toolbar select automatically.

Made with [Cursor](https://cursor.com)