### PR TITLE
Tiered AI (easy→expert) for timer games + Go Fish expert

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This document summarizes how the **card-game** repository is structured, how gam
 | `src/core/table.ts` | **`createEmptyTable`**, **`cloneTable`**, **`moveTop`**, zone helpers. |
 | `src/core/registry.ts` | **`registerGameModule`** / **`getGameModule`** — modules self-register on import. |
 | `src/core/aiContext.ts` | **`AiDifficulty`**: `easy` \| `medium` \| `hard` \| `expert`; **`SelectAiContext`** (difficulty + optional match fields for Skyjo AI). |
+| `src/core/aiPlaystyle.ts` | Small helpers: **`aiIsExpert`**, **`aiIsHardOrExpert`** for tier checks in `selectAiAction`. |
 | `docs/ai-behavior.md` | **Table AI**: what each **difficulty** does, which games use **`SelectAiContext`**, and which modules ignore it. |
 | `src/data/manifests.ts` | **`GAME_SOURCES`**, **`DECK_SOURCES`**, **`GAME_IDS`** — Vite `?raw` imports wiring ids to YAML strings. |
 | `src/data/rulesSources.ts` | **`RULES_SOURCES`**, **`rulesTextForGame`**, **`RulesGameId`** — maps each **`GAME_IDS`** entry to `src/rules/*.md` raw markdown. |
@@ -122,8 +123,8 @@ User-facing details (per-level behavior, per-game) are in **`docs/ai-behavior.md
 
 - **`SelectAiContext`** includes **`difficulty`** and (for Skyjo) optional **`matchCumulativeScores`**, **`matchTargetScore`**.
 - **`gameSupportsConfigurableAi`**: games where the user can set **AI opponent count** (capped at 1 for “heads-up only” ids — see **`HEADS_UP_GAME_IDS`** in **`playerConfig.ts`**).
-- **`gameSupportsPerSeatAiDifficulty`**: currently **`go-fish`** and **`skyjo`** — **`App`** renders per-seat difficulty selects and passes them in **`CreateSessionOptions.aiDifficulties`**. Only those modules *interpret* that field; other titles with timer-driven AI may use a fixed context or ignore **`difficulty`**.
-- Other titles may use **`selectAiAction`** with a fixed difficulty in **`useEffect`** (e.g. Crazy Eights, Uno use `{ difficulty: 'medium' }` even though they do not read it) or **`null`** if the game does not use table AI turns the same way (e.g. War).
+- **`gameSupportsPerSeatAiDifficulty`**: e.g. **`go-fish`**, **`skyjo`**, **`crazy-eights`**, **`switch`**, **`uno`**, **`thirty-one`**, **`euchre`**, **`durak`**, **`pinochle`**, **`canasta`**, **`sequence-race`** — **`App`** renders per-seat difficulty and passes them in **`CreateSessionOptions.aiDifficulties`**. (See **`docs/ai-behavior.md`** for what each level does in each game.)
+- Other timer-driven titles, if any, may still use a fixed context or ignore **`difficulty`**. Titles with **`selectAiAction`** returning **`null`** (e.g. War) are **not** under table AI.
 
 When adding AI to a game, implement **`selectAiAction`** and ensure **`getLegalActions`** matches what humans can do.
 

--- a/docs/ai-behavior.md
+++ b/docs/ai-behavior.md
@@ -2,70 +2,112 @@
 
 The shell moves AI opponents on your behalf by calling each game’s `selectAiAction` with a `SelectAiContext` (see `src/core/aiContext.ts` and `GameModule` in `src/core/gameModule.ts`).
 
-- **`SelectAiContext.difficulty`** is one of **`easy`**, **`medium`**, **`hard`**, or **`expert`**. It is only **meaningful** when the game module actually reads it (today: **Go Fish** and **Skyjo**).
-- **`SelectAiContext.matchCumulativeScores`** and **`matchTargetScore`** are passed for **Skyjo** match play so the AI can consider the finisher-doubling rule.
+- **`SelectAiContext.difficulty`** is one of **`easy`**, **`medium`**, **`hard`**, or **`expert`**.
+- **`SelectAiContext.matchCumulativeScores`** and **`matchTargetScore`** are passed for **Skyjo** match play (finisher doubling).
 
 ## Toolbar: per-seat difficulty
 
-The **Game** toolbar shows a difficulty control **only** for games in `gameSupportsPerSeatAiDifficulty` (`src/session/playerConfig.ts`):
+The **Game** toolbar shows a difficulty control for every game in `gameSupportsPerSeatAiDifficulty` (`src/session/playerConfig.ts`): **Go Fish**, **Skyjo**, **Crazy Eights**, **Switch**, **Uno**, **Thirty-one**, **Euchre**, **Durak**, **Pinochle**, **Canasta**, and **Sequence Race**. The shell passes the chosen value into `selectAiAction` for those titles (see `src/App.tsx`).
 
-| Game        | Per-seat difficulty in UI? |
-|------------|----------------------------|
-| **Go Fish** | Yes (one control per AI seat) |
-| **Skyjo**   | Yes (one control per AI seat) |
-| Other games | No — changing the stored difficulty in state does not affect their logic unless noted below. |
-
-## What each level means (when implemented)
+## What each level means (global)
 
 | Level     | Role |
 |-----------|------|
-| **Easy**  | Weaker, more random play; more mistakes. |
-| **Medium** | Baseline: mixed or “reasonable default” heuristics. |
-| **Hard**   | Stronger heuristics; fewer random errors. |
-| **Expert** | Stronger than **hard** where a separate policy exists (only **Skyjo** has extra logic beyond **hard**; **Go Fish** treats **expert** like **hard**). |
+| **Easy**  | Weaker play, more random mistakes and suboptimal moves. |
+| **Medium** | Baseline heuristics with occasional randomness. |
+| **Hard**   | Strong, “by the book” moves: maximize score / minimize risk with little randomness. |
+| **Expert** | Often **hard**-like, but adds **advanced or non-obvious** choices: second-best plays for unpredictability, partner/position tactics, holding key cards, or intentional “slow” or risky lines. |
 
-## Games that use `difficulty` in `selectAiAction`
+---
 
-### Go Fish (`go-fish`)
+## Go Fish
 
-- **Medium**: chooses a **uniform random** legal ask (rank + target player) among all legal `goFishAsk` actions.
-- **Hard** and **Expert**: score every legal ask with a small heuristic (favor asking ranks you already hold, and large opponent hands), then pick **uniformly among the highest-scoring** asks. **Expert** is intentionally the same as **hard** here.
-- **Easy**: often picks among the **lowest-scoring** (weaker) asks; some of the time plays a **fully random** legal ask to simulate mistakes.
+- **Medium**: uniform random among legal `goFishAsk` actions.
+- **Hard**: score asks with a small heuristic (favor ranks you already hold, larger opponent hands), pick uniformly among top scores.
+- **Easy**: often picks **low**-scoring asks; sometimes fully random.
+- **Expert**: uses a **stronger** score (bonuses for being **one away from a book**, penalties for asking players with only 0–1 cards, extra weight to fish large hands) and about **12%** of the time takes the **second**-best ask so responses are not always predictable.
 
-### Skyjo (`skyjo`)
+---
 
-Match fields (`matchCumulativeScores`, `matchTargetScore`) are used to estimate the cost of **calling/finishing** when the round would end with you as finisher and your row score might be doubled (not lowest).
+## Skyjo
 
-- **Easy**: more randomness on swaps/dumps, sometimes draws from stock when it should consider discard, and sometimes a random legal move.
-- **Medium**: one tier **between** easy and **hard** / **expert** (e.g. swap/dump thresholds and a lighter finisher model than `hard`).
-- **Hard** and **Expert** share a “smart” line that evaluates swaps and dumps with estimated unknown-card EV, finisher risk, and column-clear bonuses. **Expert** extends **hard** with, among other things: tighter discard-vs-deck choice; multiset-based **probability** and **variance** for hidden cells; extra weight on **not** breaking a good column setup; and more careful **end-of-round** dump pressure when a lot of points are **already face-up** (visible “bad” hands).
+(Implementation in `selectAiSkyjo` in `src/games/skyjo/index.ts`.)
 
-(Implementation lives in `selectAiSkyjo` in `src/games/skyjo/index.ts`.)
+- **Easy**: more randomness, occasional poor draw/discard and random move noise.
+- **Medium**: between easy and the smart line, lighter finisher model.
+- **Hard** / **Expert**: value draws/swap/dump with unknown-card **EV**, finisher / match **double** risk, and column-triple weighting. **Expert** adds: **variance** on face-down cells, column **pair** pressure, stricter **discard vs deck**, and more caution when a lot of points are already **face-up** and when ending the round.
 
-## Other games: shell-timed AI, but difficulty is not used in the module
+---
 
-The shell’s `useEffect` hooks call `selectAiAction` for several titles, but the modules do **not** read `context.difficulty` (they `void` it or use `_context`). A fixed **`{ difficulty: 'medium' }`** is passed for **Crazy Eights** and **Uno**; for **Thirty-one**, **Euchre**, **Durak**, **Pinochle**, **Canasta**, and **Sequence Race**, the shell passes `difficultyForAiPlayer` from the session, but the **module ignores it** — behavior is the same regardless of the stored per-seat list.
+## Uno
 
-| Game / module        | Shell auto-plays AI turns? | Uses `difficulty`? | Typical `selectAiAction` style |
-|----------------------|----------------------------|--------------------|--------------------------------|
-| **Crazy Eights**     | Yes                        | No (fixed `medium` in `App`) | Random legal play; random suit on 8. |
-| **Uno**              | Yes                        | No (fixed `medium` in `App`) | Heuristic mix of play / draw / pass. |
-| **Thirty-one**       | Yes                        | No                 | Knocks at high score; else random among legal. |
-| **Euchre** / **Pinochle** | Yes                   | No                 | Random among legal card plays. |
-| **Durak**            | Yes                        | No                 | Random attack; random beat; else take. |
-| **Canasta**          | Yes                        | No                 | Draw two then random discard. |
-| **Sequence Race**    | Yes                        | No                 | Random play or end turn. |
+- **Easy** / **Medium**: the older random mix; easy passes more after drawing.
+- **Hard**: **scores** `unoPlay` actions (favor your strong colors, action cards when the next hand is tiny, play over pass after draw more reliably).
+- **Expert**: as **hard**, but can **refuse to burn a wild** when a cheap number play exists, and rarely takes the second-ranked play for variety.
 
-## Games with no (or no-op) `selectAiAction` in practice
+## Crazy Eights & Switch (same `crazy-eights` module)
 
-- **War** — `selectAiAction` always returns `null`. You advance the skirmish with the table control yourself.
-- **Blackjack**, **Baccarat**, **Poker (draw)**, **High-card duel** — `selectAiAction` is `null` or unused; the flow is **button- or step-driven** in the UI (e.g. dealer rules run inside the module on your actions).
+- **Easy**: may **draw** even with a legal play; else random play; randomish 8 suit.
+- **Medium**: random legal play; 8 suit from a simple rule.
+- **Hard**: avoid drawing when possible; **shed** high non-8s first, **save 8s**; on 8, call the **suit** you hold the most of.
+- **Expert**: as **hard**, plus sometimes **holds** an 8, and with low probability a **less obvious** 8 **suit**.
+
+---
+
+## Thirty-one
+
+Uses the **known** top **stock** card in simulation for hard+expert (full table state in single-player is available to the module).
+
+- **Easy**: very loose knock thresholds and **random** draw/swap.
+- **Medium**: knocks at **28+** with a bit of noise; ~55% pick the **best** simulated hand after draw/take.
+- **Hard**: knocks at **27+** (always at **29+**); always picks the action that **maximizes** single-suit total after the swap, when the top stock card is known.
+- **Expert**: as **hard**, but with slightly **higher** knock standards on medium totals, **slow-play** (skip knock) a small fraction of the time, and a rare **intentional** suboptimal swap.
+
+---
+
+## Euchre (4 players)
+
+- **Easy** / **Medium**: a lot of **random** among legal cards; medium is slightly tighter.
+- **Hard**: on the **last** card to the trick, win with the **cheapest** winner if possible, else **dump** lowest; on **lead**, prefer a **low non-trump** if you have one.
+- **Expert**: same core as **hard**, but may **throw off** to a partner who already has the trick won, and rarely picks a **second**-best winning card to stay ambiguous.
+
+---
+
+## Pinochle (2 players)
+
+No partner: heads-up only.
+
+- **Easy** / **Medium**: more random; medium a bit less.
+- **Hard** / **Expert**: on the **second** (final) card to a trick, take the trick with **minimum** power if you can, else **dump** lowest; on **lead**, low **non-trump** when possible. **Expert** sometimes plays the **next**-cheapest winner.
+
+---
+
+## Durak (2 players)
+
+- **Easy** / **Medium**: more random **attack** card; defender sometimes picks a **random** beating card.
+- **Hard**: as attacker with a follow-up, prefer **reusing the attack rank**; otherwise play **lowest** rank. Defender beats with the **lowest** legal card; **expert** occasionally **takes** the stack even when a beat exists (8%) to **reshape** the hand.
+
+---
+
+## Canasta (practice)
+
+- **Easy** / **Medium**: often **random** discard; medium less so.
+- **Hard**: discards the **highest** penalty card (A/K/Q/10 vs low numbers, joker worst).
+- **Expert**: as **hard**, but **holds** pairs (same template) much longer when it would break a **duplicate**; rarely discards the **second**-worst card.
+
+---
+
+## Sequence Race
+
+- **Easy** / **Medium**: random **play** when any legal.
+- **Hard** / **Expert**: **score** each play (prefer advancing piles that are closer to 12, favor higher “need” numbers slightly). **Expert** adds a little noise and sometimes the **second**-best scored play to avoid a fixed pattern, and rare **misplay** down-weighting.
+
+---
+
+## Games with no `selectAiAction` in practice
+
+- **War** — `selectAiAction` is `null`; you press **Step** yourself.
+- **Blackjack**, **Baccarat**, **Poker (draw)**, **High-card duel** — `selectAiAction` is `null` or unused; the UI drives betting and play.
 - **Demo custom** — `selectAiAction` is `null`.
 
-## Summary
-
-- Only **Go Fish** and **Skyjo** both **show** the difficulty control **and** **implement** different playstyles per level.
-- **Skyjo** is the only game with an **expert** policy that is **stricter** than **hard**; **Go Fish** maps **expert** to **hard**.
-- Several other games have **timer-driven** AI in the browser, but that AI does **not** follow the easy/medium/hard/expert scale — it uses simple random or fixed heuristics, independent of the saved difficulty (and for most of those games, the toolbar does not even expose the control).
-
-For architecture and how sessions store `aiPlayerConfig.difficulties`, see **`AGENTS.md`** in the repository root (AI section) and `src/App.tsx` (where `difficulty` is passed into `selectAiAction`).
+For architecture, see **`AGENTS.md`** and `src/App.tsx` (where `difficulty` is passed into `selectAiAction`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -333,6 +333,12 @@ function difficultyForAiPlayer(session: GameSession, playerIndex: number): AiDif
   return cfg && ix >= 0 && ix < cfg.length ? normalizeAiDifficulty(cfg[ix]) : 'medium'
 }
 
+function defaultAiCountForGame(gameId: (typeof GAME_IDS)[number]): number {
+  const raw = GAME_SOURCES[gameId]
+  if (!raw) return 0
+  return parseGameManifestYaml(raw).players.ai
+}
+
 function App() {
   const [gameId, setGameId] = useState<(typeof GAME_IDS)[number]>('war')
   const [aiOpponents, setAiOpponents] = useState(1)
@@ -491,13 +497,23 @@ function App() {
       difficultyList?: AiDifficulty[],
     ): CreateSessionOptions | undefined => {
       const house = createSessionOptionsHouseRules(forGameId as RulesGameId)
+      const difficultySeatCount = gameSupportsConfigurableAi(forGameId)
+        ? aiOpponents
+        : defaultAiCountForGame(forGameId)
+      const diffs = difficultyList ?? aiDifficulties
       if (!gameSupportsConfigurableAi(forGameId)) {
+        if (gameSupportsPerSeatAiDifficulty(forGameId) && difficultySeatCount > 0) {
+          return {
+            aiDifficulties: normalizeAiDifficultiesForCount(difficultySeatCount, diffs),
+            ...(skipMatch ? { skipMatch: true } : {}),
+            ...house,
+          }
+        }
         if (skipMatch) {
           return { skipMatch: true, ...house }
         }
         return Object.keys(house).length ? house : undefined
       }
-      const diffs = difficultyList ?? aiDifficulties
       return {
         aiCount: aiOpponents,
         aiDifficulties: normalizeAiDifficultiesForCount(aiOpponents, diffs),
@@ -1457,9 +1473,9 @@ function App() {
                   </div>
                 </div>
               </div>
-              {gameSupportsPerSeatAiDifficulty(gameId) && aiOpponents >= 1 && (
+              {gameSupportsPerSeatAiDifficulty(gameId) && (gameSupportsConfigurableAi(gameId) ? aiOpponents : defaultAiCountForGame(gameId)) >= 1 && (
                 <div className="app__toolbarRow app__toolbarRow--diff" role="group" aria-label="AI player difficulty">
-                  {Array.from({ length: aiOpponents }, (_, i) => (
+                  {Array.from({ length: gameSupportsConfigurableAi(gameId) ? aiOpponents : defaultAiCountForGame(gameId) }, (_, i) => (
                     <label key={i} className="app__label app__label--inline">
                       {aiPlayerMenuLabel(i)}
                       <select

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1104,7 +1104,7 @@ function App() {
           prev.gameState,
           g.currentPlayer!,
           Math.random,
-          { difficulty: 'medium' },
+          { difficulty: difficultyForAiPlayer(prev, g.currentPlayer!) },
         )
         if (!act) return prev
         const r = prev.module.applyAction(prev.table, prev.gameState, act)
@@ -1143,7 +1143,7 @@ function App() {
           prev.gameState,
           g.currentPlayer!,
           Math.random,
-          { difficulty: 'medium' },
+          { difficulty: difficultyForAiPlayer(prev, g.currentPlayer!) },
         )
         if (!act) return prev
         const r = prev.module.applyAction(prev.table, prev.gameState, act)

--- a/src/core/aiPlaystyle.ts
+++ b/src/core/aiPlaystyle.ts
@@ -1,0 +1,9 @@
+import type { AiDifficulty } from './aiContext'
+
+export function aiIsExpert(d: AiDifficulty): boolean {
+  return d === 'expert'
+}
+
+export function aiIsHardOrExpert(d: AiDifficulty): boolean {
+  return d === 'hard' || d === 'expert'
+}

--- a/src/games/aiDifficultySelection.test.ts
+++ b/src/games/aiDifficultySelection.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { getGameModule } from '../core/registry'
+import type { CardInstance, CardTemplate, TableState, Zone } from '../core/types'
+import './crazy-eights'
+import './euchre'
+
+function card(instanceId: string, templateId: string): CardInstance {
+  return { instanceId, templateId, faceUp: true }
+}
+
+function zone(id: string, cards: CardInstance[], ownerPlayerIndex?: number): Zone {
+  return { id, kind: 'spread', defaultFaceUp: true, ownerPlayerIndex, cards }
+}
+
+describe('difficulty-aware AI selection', () => {
+  it('crazy eights hard saves an 8 when a normal card is playable', () => {
+    const mod = getGameModule('crazy-eights')!
+    const templates: Record<string, CardTemplate> = {
+      '8S': { id: '8S', rank: '8', suit: 'spades' },
+      KH: { id: 'KH', rank: 'K', suit: 'hearts' },
+      '5H': { id: '5H', rank: '5', suit: 'hearts' },
+    }
+    const table: TableState = {
+      templates,
+      zoneOrder: ['discard', 'draw', 'hand:1'],
+      zones: {
+        discard: zone('discard', [card('d1', '5H')]),
+        draw: zone('draw', []),
+        'hand:1': zone('hand:1', [card('c1', '8S'), card('c2', 'KH')], 1),
+      },
+    }
+
+    const action = mod.selectAiAction!(
+      table,
+      {
+        phase: 'play',
+        currentPlayer: 1,
+        currentSuit: 'hearts',
+        message: '',
+        roundScores: null,
+        reshuffleDiscardWhenDrawEmpty: false,
+      },
+      1,
+      () => 0.99,
+      { difficulty: 'hard' },
+    )
+
+    expect(action).toEqual({ type: 'custom', payload: { cmd: 'c8Play', index: 1 } })
+  })
+
+  it('euchre expert sloughs when partner already has the trick', () => {
+    const mod = getGameModule('euchre')!
+    const templates: Record<string, CardTemplate> = {
+      '9H': { id: '9H', rank: '9', suit: 'hearts' },
+      AH: { id: 'AH', rank: 'A', suit: 'hearts' },
+      TH: { id: 'TH', rank: '10', suit: 'hearts' },
+      JS: { id: 'JS', rank: 'J', suit: 'spades' },
+      '9C': { id: '9C', rank: '9', suit: 'clubs' },
+    }
+    const table: TableState = {
+      templates,
+      zoneOrder: ['trick', 'hand:3'],
+      zones: {
+        trick: zone('trick', []),
+        'hand:3': zone('hand:3', [card('c1', 'JS'), card('c2', '9C')], 3),
+      },
+    }
+
+    const action = mod.selectAiAction!(
+      table,
+      {
+        phase: 'play',
+        currentPlayer: 3,
+        trumpSuit: 'spades',
+        trick: [
+          { player: 0, templateId: '9H' },
+          { player: 1, templateId: 'AH' },
+          { player: 2, templateId: 'TH' },
+        ],
+        tricksWon: [0, 0, 0, 0],
+        tricksPlayed: 0,
+        message: '',
+        roundScores: null,
+      },
+      3,
+      () => 0.1,
+      { difficulty: 'expert' },
+    )
+
+    expect(action).toEqual({ type: 'custom', payload: { cmd: 'echPlay', index: 1 } })
+  })
+})

--- a/src/games/canasta/index.ts
+++ b/src/games/canasta/index.ts
@@ -1,7 +1,8 @@
 import { recycleDiscardIntoDrawWhenEmpty, isDeckDrawAvailableAfterOptionalRecycle } from '../../core/discardRecycle'
+import type { AiDifficulty } from '../../core/aiContext'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import { newInstanceId } from '../../core/deck'
-import type { CardInstance, GameAction, GameManifestYaml } from '../../core/types'
+import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
 import { mulberry32, shuffleInPlace } from '../../core/shuffle'
 import { cloneTable, createEmptyTable, moveTop } from '../../core/table'
@@ -20,6 +21,17 @@ function cmd(p: Record<string, unknown> | undefined): string {
 
 function isJokerTemplate(id: string): boolean {
   return id.startsWith('joker')
+}
+
+function canastaCardWeight(tid: string, templates: Record<string, CardTemplate>): number {
+  if (isJokerTemplate(tid)) return 30
+  const r = templates[tid]?.rank
+  if (r === 'A') return 20
+  if (r === 'K' || r === 'Q' || r === 'J' || r === '10') return 10
+  if (r === '9' || r === '8' || r === '7' || r === '6' || r === '5' || r === '4' || r === '3' || r === '2') {
+    return 5
+  }
+  return 4
 }
 
 export interface CanastaGameState {
@@ -172,8 +184,8 @@ const canastaModule: GameModule<CanastaGameState> = {
   },
 
   selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext) {
-    void context
     if (gs.phase !== 'play' || playerIndex !== gs.currentPlayer) return null
+    const d: AiDifficulty = context.difficulty
     if (!gs.drewThisTurn) {
       if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
         return { type: 'custom', payload: { cmd: 'cnsDrawTwo' } }
@@ -181,8 +193,30 @@ const canastaModule: GameModule<CanastaGameState> = {
     }
     const hand = table.zones[handId(playerIndex)]!.cards
     if (!hand.length) return null
-    const i = Math.floor(rng() * hand.length)
-    return { type: 'custom', payload: { cmd: 'cnsDiscard', index: i } }
+    if (d === 'easy' && rng() < 0.35) {
+      return { type: 'custom', payload: { cmd: 'cnsDiscard', index: Math.floor(rng() * hand.length) } }
+    }
+    if (d === 'medium' && rng() < 0.2) {
+      return { type: 'custom', payload: { cmd: 'cnsDiscard', index: Math.floor(rng() * hand.length) } }
+    }
+    const tpl = table.templates
+    const byRank = (tid: string) => canastaCardWeight(tid, tpl)
+    const countBy = new Map<string, number>()
+    for (const c of hand) {
+      const k = c.templateId
+      countBy.set(k, (countBy.get(k) ?? 0) + 1)
+    }
+    const scored = hand.map((c, i) => {
+      let s = byRank(c.templateId)
+      if (d === 'expert' && (countBy.get(c.templateId) ?? 0) >= 2) s -= 18
+      return { i, s }
+    })
+    if (d === 'expert' && rng() < 0.11 && scored.length > 1) {
+      scored.sort((a, b) => b.s - a.s)
+      return { type: 'custom', payload: { cmd: 'cnsDiscard', index: scored[1]!.i } }
+    }
+    scored.sort((a, b) => b.s - a.s)
+    return { type: 'custom', payload: { cmd: 'cnsDiscard', index: scored[0]!.i } }
   },
 
   statusText(table, gs) {

--- a/src/games/crazy-eights/index.ts
+++ b/src/games/crazy-eights/index.ts
@@ -1,5 +1,7 @@
+import type { AiDifficulty } from '../../core/aiContext'
+import { aiIsExpert } from '../../core/aiPlaystyle'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
-import type { CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
+import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
 import { recycleDiscardIntoDrawWhenEmpty, isDeckDrawAvailableAfterOptionalRecycle } from '../../core/discardRecycle'
 import { mulberry32, shuffleInPlace } from '../../core/shuffle'
@@ -48,6 +50,61 @@ function canPlay(
 }
 
 const SUITS = ['spades', 'hearts', 'diamonds', 'clubs'] as const
+
+function rankC8Strength(rank: string | undefined): number {
+  if (!rank) return 0
+  if (rank === 'A') return 14
+  if (rank === 'K') return 13
+  if (rank === 'Q') return 12
+  if (rank === 'J') return 11
+  if (rank === '8') return 0
+  const n = Number(rank)
+  return Number.isFinite(n) ? n : 0
+}
+
+function enumerateCrazy8Plays(
+  table: TableState,
+  gs: Crazy8sGameState,
+  playerIndex: number,
+): GameAction[] {
+  const top = topDiscard(table)
+  if (!top) return []
+  const hz = table.zones[handId(playerIndex)]!.cards
+  const out: GameAction[] = []
+  hz.forEach((c, i) => {
+    if (canPlay(table.templates, c.templateId, top, gs.currentSuit)) {
+      if (table.templates[c.templateId]?.rank === '8') {
+        for (const s of SUITS) {
+          out.push({ type: 'custom', payload: { cmd: 'c8Play', index: i, suit: s } })
+        }
+      } else {
+        out.push({ type: 'custom', payload: { cmd: 'c8Play', index: i } })
+      }
+    }
+  })
+  if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
+    out.push({ type: 'custom', payload: { cmd: 'c8Draw' } })
+  }
+  return out
+}
+
+function bestSuitOnEight(
+  _table: TableState,
+  hand: CardInstance[],
+  playIndex: number,
+  templates: Record<string, CardTemplate>,
+  rng: () => number,
+  d: AiDifficulty,
+): (typeof SUITS)[number] {
+  const rem = hand.filter((_, j) => j !== playIndex)
+  const countBySuit = (s: string) =>
+    rem.filter((c) => (templates[c.templateId]?.suit as string | undefined) === s).length
+  const scored = SUITS.map((s) => ({ s, n: countBySuit(s) })).sort((a, b) => b.n - a.n)
+  if (d === 'easy' || d === 'medium') return scored[Math.floor(rng() * scored.length)]!.s
+  if (d === 'hard') return scored[0]!.s
+  if (aiIsExpert(d) && rng() < 0.14 && scored.length > 1) return scored[1]!.s
+  return scored[0]!.s
+}
 
 const crazy8sModule: GameModule<Crazy8sGameState> = {
   moduleId: 'crazy-eights',
@@ -202,28 +259,74 @@ const crazy8sModule: GameModule<Crazy8sGameState> = {
     return { table: t, gameState: gs, error: 'Unknown.' }
   },
 
-  selectAiAction(table, gs, playerIndex, rng, _ctx: SelectAiContext): GameAction | null {
+  selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext): GameAction | null {
     if (gs.phase !== 'play' || gs.currentPlayer !== playerIndex) return null
-    const top = topDiscard(table)
-    if (!top) return null
+    const d = context.difficulty
+    const tpl = table.templates
     const hz = table.zones[handId(playerIndex)]!.cards
-    const legalIdx: number[] = []
-    hz.forEach((c, i) => {
-      if (canPlay(table.templates, c.templateId, top, gs.currentSuit)) legalIdx.push(i)
-    })
-    if (legalIdx.length > 0) {
-      const pick = legalIdx[Math.floor(rng() * legalIdx.length)]!
-      const card = hz[pick]!
-      if (table.templates[card.templateId]?.rank === '8') {
-        const s = SUITS[Math.floor(rng() * 4)]!
-        return { type: 'custom', payload: { cmd: 'c8Play', index: pick, suit: s } }
+    const actions = enumerateCrazy8Plays(table, gs, playerIndex)
+    if (actions.length === 0) return null
+
+    type CustomA = Extract<GameAction, { type: 'custom' }>
+    const plays = actions.filter((a): a is CustomA => a.type === 'custom' && cmd(a.payload) === 'c8Play')
+    const draws = actions.filter((a): a is CustomA => a.type === 'custom' && cmd(a.payload) === 'c8Draw')
+
+    const hasPlay = plays.length > 0
+    if (d === 'easy' && hasPlay && draws.length > 0 && rng() < 0.28) {
+      return draws[0]!
+    }
+
+    if (!hasPlay) return draws[0] ?? null
+
+    if (d === 'easy' || d === 'medium') {
+      const a = plays[Math.floor(rng() * plays.length)]!
+      const p = a.payload as { index?: number; suit?: string }
+      const i = Number(p.index)
+      const c = hz[i]!
+      if (tpl[c.templateId]?.rank === '8') {
+        const s = p.suit && SUITS.includes(p.suit as (typeof SUITS)[number]) ? p.suit : bestSuitOnEight(table, hz, i, tpl, rng, d)
+        return { type: 'custom', payload: { cmd: 'c8Play', index: i, suit: s } }
       }
-      return { type: 'custom', payload: { cmd: 'c8Play', index: pick } }
+      return { type: 'custom', payload: { cmd: 'c8Play', index: i } }
     }
-    if (isDeckDrawAvailableAfterOptionalRecycle(table, gs.reshuffleDiscardWhenDrawEmpty, true)) {
-      return { type: 'custom', payload: { cmd: 'c8Draw' } }
+
+    const score = (a: CustomA): number => {
+      const c0 = cmd(a.payload as Record<string, unknown>)
+      if (c0 === 'c8Draw') return 5000
+      const p = a.payload as { index?: number }
+      const i = Number(p.index)
+      const t = hz[i]!
+      const r = tpl[t.templateId]?.rank
+      if (r === '8') return 300
+      return 1000 - rankC8Strength(r)
     }
-    return null
+
+    if (d === 'hard' || d === 'expert') {
+      if (d === 'expert' && rng() < 0.12) {
+        const eights = plays.filter((a) => {
+          const i = Number((a.payload as { index?: number }).index)
+          return tpl[hz[i]!.templateId]?.rank === '8'
+        })
+        const non8 = plays.filter((a) => {
+          const i2 = Number((a.payload as { index?: number }).index)
+          return tpl[hz[i2]!.templateId]?.rank !== '8'
+        })
+        if (eights.length > 0 && non8.length > 0 && rng() < 0.55) {
+          const a = non8.sort((a, b) => score(a) - score(b))[0]!
+          const p = a.payload as { index?: number }
+          return { type: 'custom', payload: { cmd: 'c8Play', index: p.index } }
+        }
+      }
+      const best = plays.slice().sort((a, b) => score(a) - score(b))[0]!
+      const p = best.payload as { index?: number; suit?: string }
+      const i = Number(p.index)
+      if (tpl[hz[i]!.templateId]?.rank === '8') {
+        const s = bestSuitOnEight(table, hz, i, tpl, rng, d)
+        return { type: 'custom', payload: { cmd: 'c8Play', index: i, suit: s } }
+      }
+      return { type: 'custom', payload: { cmd: 'c8Play', index: i } }
+    }
+    return plays[0]!
   },
 
   statusText(_t, gs) {

--- a/src/games/crazy-eights/index.ts
+++ b/src/games/crazy-eights/index.ts
@@ -297,7 +297,7 @@ const crazy8sModule: GameModule<Crazy8sGameState> = {
       const i = Number(p.index)
       const t = hz[i]!
       const r = tpl[t.templateId]?.rank
-      if (r === '8') return 300
+      if (r === '8') return 1200
       return 1000 - rankC8Strength(r)
     }
 

--- a/src/games/durak/index.ts
+++ b/src/games/durak/index.ts
@@ -1,3 +1,5 @@
+import type { AiDifficulty } from '../../core/aiContext'
+import { aiIsHardOrExpert } from '../../core/aiPlaystyle'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
@@ -256,13 +258,36 @@ const durakModule: GameModule<DurakGameState> = {
   },
 
   selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext) {
-    void context
     if (gs.phase !== 'play' || playerIndex !== gs.currentPlayer) return null
+    const d: AiDifficulty = context.difficulty
+    const templates = table.templates
     if (gs.sub === 'attack') {
       const hz = table.zones[handId(gs.attacker)]!.cards
       if (!hz.length) return null
-      const i = Math.floor(rng() * hz.length)
-      return { type: 'custom', payload: { cmd: 'dukAttack', index: i } }
+      if (d === 'easy' || d === 'medium') {
+        return { type: 'custom', payload: { cmd: 'dukAttack', index: Math.floor(rng() * hz.length) } }
+      }
+      const battle0 = table.zones.battle?.cards[0]
+      if (aiIsHardOrExpert(d) && battle0) {
+        const at = battle0.templateId
+        const ar = templates[at]!.rank as string
+        const same = hz
+          .map((c, i) => ({ c, i }))
+          .filter((x) => (templates[x.c.templateId]!.rank as string) === ar)
+        if (same.length > 0) {
+          return {
+            type: 'custom',
+            payload: { cmd: 'dukAttack', index: same[Math.floor(rng() * same.length)]!.i },
+          }
+        }
+      }
+      const byPow = [...hz.map((c, i) => ({ i, p: rankPower(templates[c.templateId]!.rank as string) }))].sort(
+        (a, b) => a.p - b.p,
+      )
+      if (d === 'expert' && rng() < 0.1) {
+        return { type: 'custom', payload: { cmd: 'dukAttack', index: byPow[byPow.length - 1]!.i } }
+      }
+      return { type: 'custom', payload: { cmd: 'dukAttack', index: byPow[0]!.i } }
     }
     const battle = table.zones.battle!.cards
     if (battle.length !== 1) return null
@@ -272,8 +297,19 @@ const durakModule: GameModule<DurakGameState> = {
       .map((c, i) => (canBeat(table.templates, attackTid, c.templateId, gs.trumpSuit) ? i : -1))
       .filter((i) => i >= 0)
     if (beats.length > 0) {
-      const i = beats[Math.floor(rng() * beats.length)]!
-      return { type: 'custom', payload: { cmd: 'dukDefend', index: i } }
+      if (d === 'easy' && rng() < 0.32) {
+        return { type: 'custom', payload: { cmd: 'dukDefend', index: beats[Math.floor(rng() * beats.length)]! } }
+      }
+      if (d === 'medium' && rng() < 0.2) {
+        return { type: 'custom', payload: { cmd: 'dukDefend', index: beats[Math.floor(rng() * beats.length)]! } }
+      }
+      const byMin = beats.sort(
+        (a, b) => rankPower(templates[hz[a]!.templateId]!.rank as string) - rankPower(templates[hz[b]!.templateId]!.rank as string),
+      )[0]!
+      if (d === 'expert' && rng() < 0.08) {
+        return { type: 'custom', payload: { cmd: 'dukTake' } }
+      }
+      return { type: 'custom', payload: { cmd: 'dukDefend', index: byMin } }
     }
     return { type: 'custom', payload: { cmd: 'dukTake' } }
   },

--- a/src/games/euchre/index.ts
+++ b/src/games/euchre/index.ts
@@ -119,6 +119,15 @@ function selectEuchreTrickIndex(
       const p = trickPower(templates, tid, trump, leadSuit0)
       return { i, winner, p }
     })
+    const currentWinner = resolveTrick(templates, trick, trump)
+    if (d === 'expert' && currentWinner === partner) {
+      const keepsPartnerWinning = scored.filter((x) => x.winner === partner)
+      if (keepsPartnerWinning.length > 0 && rng() < 0.86) {
+        const m = Math.min(...keepsPartnerWinning.map((x) => x.p))
+        const pool = keepsPartnerWinning.filter((x) => x.p === m)
+        return pool[Math.floor(rng() * pool.length)]!.i
+      }
+    }
     const weWin = scored.filter((x) => x.winner === playerIndex)
     const pWin = scored.filter((x) => x.winner === partner)
     if (d === 'expert' && pWin.length > 0 && weWin.length === 0) {

--- a/src/games/euchre/index.ts
+++ b/src/games/euchre/index.ts
@@ -1,3 +1,4 @@
+import type { AiDifficulty } from '../../core/aiContext'
 import type { GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
@@ -80,6 +81,84 @@ function legalPlays(
     if (!mustFollow || s === leadSuit) out.push(i)
   })
   return out
+}
+
+function selectEuchreTrickIndex(
+  templates: Record<string, CardTemplate>,
+  gs: EuchreGameState,
+  playerIndex: number,
+  hand: CardInstance[],
+  legalIdx: number[],
+  rng: () => number,
+  d: AiDifficulty,
+): number {
+  const partner = (playerIndex + 2) % 4
+  const trump = gs.trumpSuit
+  const trick = gs.trick
+  const leadSuit0 =
+    trick.length > 0
+      ? String(
+          (templates[trick[0]!.templateId] as { suit?: string } | undefined)?.suit ?? '',
+        )
+      : ''
+
+  if (legalIdx.length === 0) return 0
+  if (legalIdx.length === 1) return legalIdx[0]!
+
+  if (d === 'easy' && rng() < 0.38) {
+    return legalIdx[Math.floor(rng() * legalIdx.length)]!
+  }
+  if (d === 'medium' && rng() < 0.22) {
+    return legalIdx[Math.floor(rng() * legalIdx.length)]!
+  }
+
+  if (trick.length === 3) {
+    const scored = legalIdx.map((i) => {
+      const tid = hand[i]!.templateId
+      const winner = resolveTrick(templates, [...trick, { player: playerIndex, templateId: tid }], trump)
+      const p = trickPower(templates, tid, trump, leadSuit0)
+      return { i, winner, p }
+    })
+    const weWin = scored.filter((x) => x.winner === playerIndex)
+    const pWin = scored.filter((x) => x.winner === partner)
+    if (d === 'expert' && pWin.length > 0 && weWin.length === 0) {
+      const m = Math.min(...pWin.map((x) => x.p))
+      const pool = pWin.filter((x) => x.p === m)
+      if (rng() < 0.45) {
+        return pool[Math.floor(rng() * pool.length)]!.i
+      }
+    }
+    if (weWin.length > 0) {
+      const m = Math.min(...weWin.map((x) => x.p))
+      const pool = weWin.filter((x) => x.p === m)
+      if (d === 'expert' && weWin.length > 1 && rng() < 0.11) {
+        const oth = [...weWin].sort((a, b) => a.p - b.p)
+        if (oth[1]) return oth[1]!.i
+      }
+      return pool[Math.floor(rng() * pool.length)]!.i
+    }
+    return scored.sort((a, b) => a.p - b.p)[0]!.i
+  }
+
+  if (trick.length === 0) {
+    if (d === 'medium' && rng() < 0.25) {
+      return legalIdx[Math.floor(rng() * legalIdx.length)]!
+    }
+    const scored = legalIdx.map((i) => {
+      const tid = hand[i]!.templateId
+      const ls = String(templates[tid]?.suit ?? '')
+      return { i, p: trickPower(templates, tid, trump, ls) }
+    })
+    const nts = scored.filter((s) => String(templates[hand[s.i]!.templateId]!.suit) !== trump)
+    const use = nts.length > 0 ? nts : scored
+    return use.sort((a, b) => a.p - b.p)[0]!.i
+  }
+
+  return legalIdx.sort(
+    (a, b) =>
+      trickPower(templates, hand[a]!.templateId, trump, leadSuit0) -
+      trickPower(templates, hand[b]!.templateId, trump, leadSuit0),
+  )[0]!
 }
 
 export interface EuchreGameState {
@@ -221,12 +300,19 @@ const euchreModule: GameModule<EuchreGameState> = {
   },
 
   selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext) {
-    void context
     if (gs.phase !== 'play' || playerIndex !== gs.currentPlayer) return null
     const hand = table.zones[handId(playerIndex)]!.cards
     const idxs = legalPlays(table.templates, hand, gs.trick)
     if (!idxs.length) return null
-    const i = idxs[Math.floor(rng() * idxs.length)]!
+    const i = selectEuchreTrickIndex(
+      table.templates,
+      gs,
+      playerIndex,
+      hand,
+      idxs,
+      rng,
+      context.difficulty,
+    )
     return { type: 'custom', payload: { cmd: 'echPlay', index: i } }
   },
 

--- a/src/games/go-fish/index.ts
+++ b/src/games/go-fish/index.ts
@@ -132,6 +132,26 @@ function scoreGoFishAsk(
   return my * 20 + theirHand * 3
 }
 
+/** Expert: one-card-from-a-book, table politics, and avoid fishing empty seats. */
+function scoreGoFishAskExpert(
+  action: GameAction,
+  table: TableState,
+  templates: Record<string, CardTemplate>,
+  currentPlayer: number,
+): number {
+  if (action.type !== 'goFishAsk') return -Infinity
+  const { targetPlayer, rank } = action
+  const hz = table.zones[handId(currentPlayer)]!.cards
+  const my = countRankInHand(hz, templates, rank)
+  const theirHand = table.zones[handId(targetPlayer)]!.cards.length
+  let s = scoreGoFishAsk(action, table, templates, currentPlayer)
+  if (my === 3) s += 120
+  else if (my === 2) s += 32
+  if (theirHand <= 1) s -= 45
+  else s += theirHand * 1.2
+  return s
+}
+
 function enumerateLegalAsks(
   table: TableState,
   templates: Record<string, CardTemplate>,
@@ -460,10 +480,24 @@ const goFishModule: GameModule<GoFishGameState> = {
       s: a.type === 'goFishAsk' ? scoreGoFishAsk(a, sim, templates, playerIndex) : 0,
     }))
 
-    if (difficulty === 'hard' || difficulty === 'expert') {
+    if (difficulty === 'hard') {
       const maxS = Math.max(...scored.map((x) => x.s))
       const top = scored.filter((x) => x.s === maxS)
       return top[Math.floor(rng() * top.length)]!.a
+    }
+
+    if (difficulty === 'expert') {
+      const exp = legal.map((a) => ({
+        a,
+        s: a.type === 'goFishAsk' ? scoreGoFishAskExpert(a, sim, templates, playerIndex) : 0,
+      }))
+      const sorted = [...exp].sort((x, y) => y.s - x.s)
+      if (sorted.length > 1 && rng() < 0.12) {
+        return sorted[1]!.a
+      }
+      const maxE = Math.max(...exp.map((x) => x.s))
+      const topE = exp.filter((x) => x.s === maxE)
+      return topE[Math.floor(rng() * topE.length)]!.a
     }
 
     // easy: prefer weaker asks; mix in random mistakes

--- a/src/games/pinochle/index.ts
+++ b/src/games/pinochle/index.ts
@@ -1,3 +1,4 @@
+import type { AiDifficulty } from '../../core/aiContext'
 import type { GameModule, SelectAiContext } from '../../core/gameModule'
 import { newInstanceId } from '../../core/deck'
 import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
@@ -92,6 +93,76 @@ export interface PinochleGameState {
   tricksPlayed: number
   message: string
   roundScores: number[] | null
+}
+
+/** 2-player pinochle: heads-up trick logic (no partner feeding). */
+function selectPinochleTrickIndex(
+  templates: Record<string, CardTemplate>,
+  gs: PinochleGameState,
+  playerIndex: number,
+  hand: CardInstance[],
+  legalIdx: number[],
+  rng: () => number,
+  d: AiDifficulty,
+): number {
+  const trump = gs.trumpSuit
+  const trick = gs.trick
+  const leadSuit0 =
+    trick.length > 0
+      ? String(
+          (templates[trick[0]!.templateId] as { suit?: string } | undefined)?.suit ?? '',
+        )
+      : ''
+
+  if (legalIdx.length === 0) return 0
+  if (legalIdx.length === 1) return legalIdx[0]!
+
+  if (d === 'easy' && rng() < 0.38) {
+    return legalIdx[Math.floor(rng() * legalIdx.length)]!
+  }
+  if (d === 'medium' && rng() < 0.22) {
+    return legalIdx[Math.floor(rng() * legalIdx.length)]!
+  }
+
+  if (trick.length === 1) {
+    const scored = legalIdx.map((i) => {
+      const tid = hand[i]!.templateId
+      const winner = resolveTrick(templates, [...trick, { player: playerIndex, templateId: tid }], trump)
+      const p = trickPower(templates, tid, trump, leadSuit0)
+      return { i, winner, p }
+    })
+    const weWin = scored.filter((x) => x.winner === playerIndex)
+    if (weWin.length > 0) {
+      const m = Math.min(...weWin.map((x) => x.p))
+      const pool = weWin.filter((x) => x.p === m)
+      if (d === 'expert' && weWin.length > 1 && rng() < 0.11) {
+        const oth = [...weWin].sort((a, b) => a.p - b.p)
+        if (oth[1]) return oth[1]!.i
+      }
+      return pool[Math.floor(rng() * pool.length)]!.i
+    }
+    return scored.sort((a, b) => a.p - b.p)[0]!.i
+  }
+
+  if (trick.length === 0) {
+    if (d === 'medium' && rng() < 0.25) {
+      return legalIdx[Math.floor(rng() * legalIdx.length)]!
+    }
+    const scored = legalIdx.map((i) => {
+      const tid = hand[i]!.templateId
+      const ls = String(templates[tid]?.suit ?? '')
+      return { i, p: trickPower(templates, tid, trump, ls) }
+    })
+    const nts = scored.filter((s) => String(templates[hand[s.i]!.templateId]!.suit) !== trump)
+    const use = nts.length > 0 ? nts : scored
+    return use.sort((a, b) => a.p - b.p)[0]!.i
+  }
+
+  return legalIdx.sort(
+    (a, b) =>
+      trickPower(templates, hand[a]!.templateId, trump, leadSuit0) -
+      trickPower(templates, hand[b]!.templateId, trump, leadSuit0),
+  )[0]!
 }
 
 const pinochleModule: GameModule<PinochleGameState> = {
@@ -225,12 +296,19 @@ const pinochleModule: GameModule<PinochleGameState> = {
   },
 
   selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext) {
-    void context
     if (gs.phase !== 'play' || playerIndex !== gs.currentPlayer) return null
     const hand = table.zones[handId(playerIndex)]!.cards
     const idxs = legalPlays(table.templates, hand, gs.trick)
     if (!idxs.length) return null
-    const i = idxs[Math.floor(rng() * idxs.length)]!
+    const i = selectPinochleTrickIndex(
+      table.templates,
+      gs,
+      playerIndex,
+      hand,
+      idxs,
+      rng,
+      context.difficulty,
+    )
     return { type: 'custom', payload: { cmd: 'pncPlay', index: i } }
   },
 

--- a/src/games/sequence-race/index.ts
+++ b/src/games/sequence-race/index.ts
@@ -1,3 +1,5 @@
+import type { AiDifficulty } from '../../core/aiContext'
+import { aiIsHardOrExpert } from '../../core/aiPlaystyle'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
@@ -191,10 +193,35 @@ const sequenceRaceModule: GameModule<SequenceRaceGameState> = {
   },
 
   selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext) {
-    void context
     if (gs.phase !== 'play' || playerIndex !== gs.currentPlayer) return null
+    const d: AiDifficulty = context.difficulty
     const plays = legalPlays(table, gs.piles, playerIndex)
-    if (plays.length > 0) return plays[Math.floor(rng() * plays.length)]!
+    if (plays.length > 0) {
+      if (d === 'easy' && rng() < 0.35) {
+        return plays[Math.floor(rng() * plays.length)]!
+      }
+      if (d === 'medium' && rng() < 0.22) {
+        return plays[Math.floor(rng() * plays.length)]!
+      }
+      if (aiIsHardOrExpert(d)) {
+        const score = (a: (typeof plays)[0]): number => {
+          if (a.type !== 'custom' || cmd(a.payload) !== 'srPlay') return -100
+          const pi = Number((a.payload as { pileIndex?: number }).pileIndex)
+          const hi = Number((a.payload as { handIndex?: number }).handIndex)
+          const v = cardValue(table.templates, table.zones[handId(playerIndex)]!.cards[hi]!.templateId)
+          const need = gs.piles[pi]!
+          if (v !== 0 && v !== need) return -200
+          let s = 40
+          s += (13 - need) * 0.5
+          if (d === 'expert' && rng() < 0.1) s -= 4
+          return s
+        }
+        const ranked = plays.map((a) => ({ a, s: score(a) })).sort((x, y) => y.s - x.s)
+        if (d === 'expert' && ranked.length > 1 && rng() < 0.12) return ranked[1]!.a
+        return ranked[0]!.a
+      }
+      return plays[Math.floor(rng() * plays.length)]!
+    }
     return { type: 'custom', payload: { cmd: 'srEndTurn' } }
   },
 

--- a/src/games/thirty-one/index.ts
+++ b/src/games/thirty-one/index.ts
@@ -1,4 +1,5 @@
 import { recycleDiscardIntoDrawWhenEmpty, isDeckDrawAvailableAfterOptionalRecycle } from '../../core/discardRecycle'
+import type { AiDifficulty } from '../../core/aiContext'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
@@ -221,17 +222,95 @@ const thirtyOneModule: GameModule<ThirtyOneGameState> = {
   },
 
   selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext) {
-    void context
     if (gs.phase !== 'play' || playerIndex !== gs.currentPlayer) return null
+    const d: AiDifficulty = context.difficulty
+    const templates = table.templates
     const legal = legalForSeat(table, gs, playerIndex)
     const hz = table.zones[handId(playerIndex)]!.cards
-    const score = handScore31(table.templates, hz)
-    if (score >= 28 && legal.some((a) => a.type === 'custom' && cmd(a.payload as Record<string, unknown>) === 't31Knock')) {
+    const myScore = handScore31(templates, hz)
+    const canKnock = legal.some(
+      (a) => a.type === 'custom' && cmd(a.payload as Record<string, unknown>) === 't31Knock',
+    )
+
+    if (canKnock) {
+      let wantKnock = false
+      if (d === 'easy') {
+        if (myScore >= 30) wantKnock = true
+        else if (myScore >= 28) wantKnock = rng() < 0.7
+        else if (myScore >= 27) wantKnock = rng() < 0.4
+        else if (myScore >= 25) wantKnock = rng() < 0.15
+        if (wantKnock && rng() < 0.18) wantKnock = false
+      } else if (d === 'medium') {
+        wantKnock = myScore >= 28
+        if (myScore >= 30) wantKnock = true
+      } else if (d === 'hard') {
+        wantKnock = myScore >= 27
+        if (myScore >= 29) wantKnock = true
+      } else {
+        if (myScore >= 30) wantKnock = true
+        else if (myScore >= 28) {
+          wantKnock = rng() < 0.78
+        } else if (myScore >= 27) {
+          wantKnock = rng() < 0.35
+        }
+        if (d === 'expert' && myScore < 30 && myScore >= 27 && rng() < 0.12) {
+          wantKnock = false
+        }
+      }
+      if (wantKnock) return { type: 'custom', payload: { cmd: 't31Knock' } }
+    }
+
+    const nonKnock = legal.filter((a) => a.type === 'custom' && cmd(a.payload as Record<string, unknown>) !== 't31Knock')
+    if (nonKnock.length === 0) {
       return { type: 'custom', payload: { cmd: 't31Knock' } }
     }
-    const acts = legal.filter((a) => a.type === 'custom')
-    if (!acts.length) return null
-    return acts[Math.floor(rng() * acts.length)]!
+
+    if (d === 'easy') {
+      return nonKnock[Math.floor(rng() * nonKnock.length)]!
+    }
+    if (d === 'medium') {
+      if (rng() < 0.2) return nonKnock[Math.floor(rng() * nonKnock.length)]!
+    }
+
+    const topDisc = table.zones.discard?.cards[table.zones.discard!.cards.length - 1] ?? null
+    const drawPile = table.zones.draw?.cards
+    const topDraw = drawPile && drawPile.length > 0 ? drawPile[drawPile.length - 1]! : null
+
+    const evalScoreAfter = (nextHand: CardInstance[]): number => handScore31(templates, nextHand)
+
+    let best: GameAction = nonKnock[0]!
+    let bestV = -1
+    for (const a of nonKnock) {
+      if (a.type !== 'custom') continue
+      const c = cmd(a.payload as Record<string, unknown>)
+      let v = -1
+      if (c === 't31TakeDiscard' && topDisc) {
+        const di = Number((a.payload as { discardIndex?: number }).discardIndex)
+        if (!Number.isInteger(di) || di < 0 || di >= hz.length) continue
+        const next = [...hz]
+        next[di] = { ...topDisc, faceUp: true }
+        v = evalScoreAfter(next)
+      } else if (c === 't31DrawStock' && topDraw) {
+        const di = Number((a.payload as { discardIndex?: number }).discardIndex)
+        if (!Number.isInteger(di) || di < 0 || di >= hz.length) continue
+        const next: CardInstance[] = hz.filter((_, j) => j !== di)
+        next.push({ ...topDraw, faceUp: true })
+        v = evalScoreAfter(next)
+      }
+      if (v > bestV) {
+        bestV = v
+        best = a
+      }
+    }
+    if (d === 'medium' && bestV >= 0) {
+      if (rng() < 0.55) return best
+    }
+    if (d === 'hard' && bestV >= 0) return best
+    if (d === 'expert') {
+      if (rng() < 0.09) return nonKnock[Math.floor(rng() * nonKnock.length)]!
+      if (bestV >= 0) return best
+    }
+    return bestV >= 0 ? best : nonKnock[Math.floor(rng() * nonKnock.length)]!
   },
 
   statusText(table, gs) {

--- a/src/games/uno/index.ts
+++ b/src/games/uno/index.ts
@@ -1,3 +1,4 @@
+import { aiIsHardOrExpert } from '../../core/aiPlaystyle'
 import type { ApplyResult, GameModule, SelectAiContext } from '../../core/gameModule'
 import type { CardInstance, CardTemplate, GameAction, GameManifestYaml } from '../../core/types'
 import { registerGameModule } from '../../core/registry'
@@ -67,6 +68,47 @@ function step(cur: number, direction: number, n: number): number {
 
 function ensureDraw(table: TableState, rng: () => number, reshuffleEnabled: boolean): void {
   recycleDiscardIntoDrawWhenEmpty(table, rng, { enabled: reshuffleEnabled, preserveTopDiscard: true })
+}
+
+function countColorInHand(
+  templates: Record<string, CardTemplate>,
+  hz: CardInstance[],
+  col: UnoColor,
+): number {
+  let n = 0
+  for (const c of hz) {
+    const t = templates[c.templateId]!
+    if (uc(t) === col || uc(t) === 'w') n += 1
+  }
+  return n
+}
+
+function scoreUnoAction(
+  a: GameAction,
+  table: TableState,
+  gs: UnoGameState,
+  playerIndex: number,
+): number {
+  if (a.type !== 'custom') return -9999
+  const c0 = cmd(a.payload)
+  if (c0 === 'unoDraw' || c0 === 'unoPass' || c0 === 'unoPassAfterDraw') return -100
+  if (c0 !== 'unoPlay') return 0
+  const pCount = Object.keys(table.zones).filter((k) => k.startsWith('hand:')).length
+  const nextP = step(playerIndex, gs.direction, pCount)
+  const nextHandN = table.zones[handId(nextP)]!.cards.length
+  const hz = table.zones[handId(playerIndex)]!.cards
+  const ix = Number((a.payload as { index?: number }).index)
+  const card = hz[ix]!
+  const ct = table.templates[card.templateId]!
+  const colPick = (a.payload as { color?: string }).color as UnoColor | undefined
+  const uf0 = uface(ct)
+  let s = 200
+  if (uc(ct) === 'w') s -= 40
+  else s -= handValue(table.templates, [card]) * 0.4
+  if (colPick) s += countColorInHand(table.templates, hz, colPick) * 2.1
+  if (nextHandN <= 2 && (uf0 === 'd2' || uf0 === 'w4' || uf0 === 'sk')) s += 35
+  if (uf0 === 'd2' || uf0 === 'w4' || uf0 === 'sk' || uf0 === 'rev') s += 8
+  return s
 }
 
 function handValue(templates: Record<string, CardTemplate>, cards: CardInstance[]): number {
@@ -402,17 +444,23 @@ const unoModule: GameModule<UnoGameState> = {
     }
   },
 
-  selectAiAction(table, gs, playerIndex, rng, _ctx: SelectAiContext): GameAction | null {
+  selectAiAction(table, gs, playerIndex, rng, context: SelectAiContext): GameAction | null {
     type CustomAction = Extract<GameAction, { type: 'custom' }>
+    const d = context.difficulty
     const legals = computeLegalActions(table, gs, playerIndex, rng) as CustomAction[]
     if (legals.length === 0) return null
 
     const byCmd = (s: string) => legals.filter((a) => cmd(a.payload) === s)
-
     const passAfter = byCmd('unoPassAfterDraw')
     const playActs = byCmd('unoPlay')
     if (passAfter.length && playActs.length > 0) {
-      return rng() < 0.72 ? playActs[Math.floor(rng() * playActs.length)]! : passAfter[0]!
+      if (d === 'easy' && rng() < 0.35) return passAfter[0]!
+      if (d === 'medium' && rng() < 0.25) return passAfter[0]!
+      if (aiIsHardOrExpert(d) && rng() < 0.08) return passAfter[0]!
+      if (d === 'easy' || d === 'medium') {
+        return rng() < 0.72 ? playActs[Math.floor(rng() * playActs.length)]! : passAfter[0]!
+      }
+      return playActs.sort((a, b) => scoreUnoAction(b, table, gs, playerIndex) - scoreUnoAction(a, table, gs, playerIndex))[0]!
     }
     if (passAfter.length === legals.length) return passAfter[0]!
 
@@ -424,13 +472,40 @@ const unoModule: GameModule<UnoGameState> = {
       return draws[0] ?? byCmd('unoPass')[0] ?? null
     }
 
-    const nonWild = plays.filter((a) => {
-      const ix = Number((a.payload as { index?: number }).index)
-      const h = table.zones[handId(playerIndex)]!.cards[ix]
-      return h && uc(tpl(table.templates, h.templateId)) !== 'w'
-    })
-    const pool = nonWild.length > 0 ? nonWild : plays
-    return pool[Math.floor(rng() * pool.length)]!
+    if (d === 'easy' && rng() < 0.4) {
+      return plays[Math.floor(rng() * plays.length)]!
+    }
+    if (d === 'medium') {
+      const nonWild = plays.filter((a) => {
+        const ix = Number((a.payload as { index?: number }).index)
+        const h = table.zones[handId(playerIndex)]!.cards[ix]
+        return h && uc(tpl(table.templates, h.templateId)) !== 'w'
+      })
+      const pool = nonWild.length > 0 ? nonWild : plays
+      return pool[Math.floor(rng() * pool.length)]!
+    }
+
+    if (d === 'hard' || d === 'expert') {
+      if (d === 'expert' && rng() < 0.14) {
+        const nonWild = plays.filter((a) => {
+          const ix = Number((a.payload as { index?: number }).index)
+          const h = table.zones[handId(playerIndex)]!.cards[ix]
+          return h && uc(tpl(table.templates, h.templateId)) !== 'w'
+        })
+        if (nonWild.length > 0 && plays.some((a) => {
+          const ix = Number((a.payload as { index?: number }).index)
+          return uc(tpl(table.templates, table.zones[handId(playerIndex)]!.cards[ix]!.templateId)) === 'w'
+        }) && rng() < 0.45) {
+          return nonWild[Math.floor(rng() * nonWild.length)]!
+        }
+      }
+      const sorted = plays
+        .map((a) => ({ a, s: scoreUnoAction(a, table, gs, playerIndex) }))
+        .sort((x, y) => y.s - x.s)
+      if (d === 'expert' && sorted.length > 1 && rng() < 0.11) return sorted[1]!.a
+      return sorted[0]!.a
+    }
+    return plays[0]!
   },
 
   statusText(_t, gs) {

--- a/src/session/playerConfig.ts
+++ b/src/session/playerConfig.ts
@@ -57,8 +57,20 @@ const CONFIGURABLE_AI_GAME_IDS = new Set([
   'sequence-race',
 ])
 
-/** Games where `selectAiAction` uses {@link AiDifficulty} (per-seat). */
-const AI_DIFFICULTY_GAME_IDS = new Set(['go-fish', 'skyjo'])
+/** Games where `selectAiAction` uses {@link AiDifficulty} (per-seat); toolbar shows difficulty. */
+const AI_DIFFICULTY_GAME_IDS = new Set([
+  'go-fish',
+  'skyjo',
+  'crazy-eights',
+  'switch',
+  'uno',
+  'thirty-one',
+  'euchre',
+  'durak',
+  'pinochle',
+  'canasta',
+  'sequence-race',
+])
 
 export function gameSupportsPerSeatAiDifficulty(gameId: string): boolean {
   return AI_DIFFICULTY_GAME_IDS.has(gameId)


### PR DESCRIPTION
## Summary
Adds **easy / medium / hard / expert** behavior to the **eight** shell-timer games that previously ignored or fixed `difficulty`, and upgrades **Go Fish expert** beyond hard.

### UI
`gameSupportsPerSeatAiDifficulty` now includes: **crazy-eights**, **switch**, **uno**, **thirty-one**, **euchre**, **durak**, **pinochle**, **canasta**, **sequence-race** (plus existing go-fish & skyjo). The toolbar shows one difficulty control per AI seat when the game has AI.

### App
- **Crazy Eights** and **Uno** now pass `difficultyForAiPlayer` (was fixed `medium`).

### Go Fish expert
- Stronger ask score (one-card-from-book bonuses, avoid nearly empty opponent hands).
- ~12% second-best ask for unpredictability.

### Per-game (brief)
- **Crazy Eights / Switch**: shed high, save 8s, smart 8 suit; expert holds 8 / misdeclares suit sometimes.
- **Uno**: scored plays; expert may keep wilds.
- **Thirty-one**: knock thresholds + best swap using known stock top.
- **Euchre 4p**: trick power, partner throw-offs, expert ambiguity.
- **Pinochle 2p**: two-card trick minimax.
- **Durak**: low attacks, cheap beats, expert occasional take.
- **Canasta**: high-point discards; expert keeps pairs.
- **Sequence race**: pile-priority scoring; expert second-best / noise.

### Docs
`docs/ai-behavior.md` and `AGENTS.md` updated.

**Build / lint / tests:** `npm run build`, `npm run lint`, `npm run test:ci` — all pass.

Made with [Cursor](https://cursor.com)