### PR TITLE
Integrate m43 shell, auth bar, and HTTPS dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'index.html'
       - 'chat-popout.html'
+      - 'vite.config.ts'
       - 'src/**'
       - 'lambda/**'
       - 'deploy/terraform/**'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Start the dev server (hot reload):
 npm run dev
 ```
 
-Then open the URL Vite prints (usually `http://localhost:5173`).
+Then open the **https** URL Vite prints (for example `https://localhost:5173`). The dev server uses a generated certificate (`@vitejs/plugin-basic-ssl`); your browser may ask you to trust it once. HTTPS keeps `returnUrl` flows aligned with production auth (`https` only on the API).
 
 ### Online multiplayer (local)
 
@@ -42,6 +42,12 @@ In a live room, use **Open chat** in the **Online play** strip for [ephemeral ro
 Choosing another entry in the **Game** menu updates the selection only; press **Start deal** (or **New deal** when a hand is already on the table) to shuffle and play.
 
 Use **Rules** (next to **End game**) to open a modal with the in-app rules for the **currently selected** game (you can read them before **Start deal**).
+
+### m43 shell and auth
+
+The app loads shared **m43** CSS from `https://static.michaelj43.dev/v1/` (`m43-tokens.css`, `m43-shell.css`, `m43-primitives.css`) and the **`m43-auth-header.js`** top bar (Log in / profile against `https://api.michaelj43.dev` / `https://auth.michaelj43.dev`). **Home** in the bar points at `https://michaelj43.dev/`. Add `?m43debug=1` for auth header console diagnostics.
+
+Wide layout uses **`m43-page--content-wide`** and **`m43-*--wide`** classes; that needs **`--m43-content-max-xl`** in the published token/shell CSS ([static-assets](https://github.com/MichaelJ43/static-assets) wide-layout release).
 
 ### Analytics
 

--- a/chat-popout.html
+++ b/chat-popout.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Room chat</title>
+    <link rel="stylesheet" href="https://static.michaelj43.dev/v1/m43-tokens.css" />
+    <link rel="stylesheet" href="https://static.michaelj43.dev/v1/m43-shell.css" />
+    <link rel="stylesheet" href="https://static.michaelj43.dev/v1/m43-primitives.css" />
     <script
       src="https://static.michaelj43.dev/v1/m43-analytics.js"
       defer
@@ -12,7 +15,7 @@
       data-m43-spa="true"
     ></script>
   </head>
-  <body>
+  <body class="m43">
     <div id="chat-popout-root"></div>
     <script type="module" src="/src/chat-popout/main.tsx"></script>
   </body>

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -1,6 +1,8 @@
 # Shell UI design
 
-Conventions for the **app chrome** around the table: header toolbar, dialogs that reuse shell styles, and the **Online play** (`MultiplayerPanel`) block. Implementation lives primarily in [`src/App.css`](../src/App.css); the shell is [`src/App.tsx`](../src/App.tsx).
+The page uses the shared **m43** design system (tokens, shell, primitives) from `https://static.michaelj43.dev/v1/` plus a fixed **auth top bar** (`m43-auth-header.js`). Product-specific chrome (toolbar, multiplayer strip, modals) still uses the `app__*` classes in [`src/App.css`](../src/App.css) and [`src/App.tsx`](../src/App.tsx); [`src/index.css`](../src/index.css) maps legacy CSS variables (`--text`, `--bg`, …) to **`--m43-*`** so existing styles track the shared palette.
+
+Conventions for the **app chrome** around the table: header toolbar, dialogs that reuse shell styles, and the **Online play** (`MultiplayerPanel`) block.
 
 ## Toolbar buttons (header)
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>card-game</title>
+    <link rel="stylesheet" href="https://static.michaelj43.dev/v1/m43-tokens.css" />
+    <link rel="stylesheet" href="https://static.michaelj43.dev/v1/m43-shell.css" />
+    <link rel="stylesheet" href="https://static.michaelj43.dev/v1/m43-primitives.css" />
     <script
       src="https://static.michaelj43.dev/v1/m43-analytics.js"
       defer
@@ -13,8 +16,19 @@
       data-m43-spa="true"
     ></script>
   </head>
-  <body>
-    <div id="root"></div>
+  <body class="m43 m43-page m43-page--content-wide">
+    <div data-m43-auth-header></div>
+    <div class="m43-page__body m43">
+      <div id="root"></div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
+    <script
+      src="https://static.michaelj43.dev/v1/m43-auth-header.js"
+      defer
+      data-m43-auth
+      data-m43-api="https://api.michaelj43.dev"
+      data-m43-auth-origin="https://auth.michaelj43.dev"
+      data-m43-home-url="https://michaelj43.dev/"
+    ></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -1241,6 +1242,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz",
+      "integrity": "sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,14 +1,14 @@
 .app {
   width: 100%;
-  max-width: 72rem;
+  max-width: none;
   margin: 0 auto;
-  padding: 1.5rem 1rem 2.5rem;
+  padding: 0;
   text-align: left;
   box-sizing: border-box;
 }
 
-.app__header {
-  margin-bottom: 1rem;
+.app__header.m43-site-header {
+  margin-bottom: 0;
 }
 
 .app__headerRow {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1390,7 +1390,7 @@ function App() {
 
   return (
     <div className="app">
-      <header className="app__header">
+      <header className="m43-site-header m43-site-header--wide app__header">
         <div className="app__headerRow">
           <h1 className="app__title">Card table</h1>
           <AudioCueBar inRoom={multiplayerHostActive || joinedAsClient} />
@@ -1547,6 +1547,7 @@ function App() {
         </div>
       </header>
 
+      <main className="m43-main m43-main--wide app__main">
       {gameSupportsOnlineMultiplayer(gameId) && (
         <MultiplayerPanel
           gameId={gameId}
@@ -1709,7 +1710,7 @@ function App() {
             )}
           </div>
 
-          <footer className="app__footer">
+          <footer className="m43-site-footer m43-site-footer--wide app__footer">
             <span>
               {session.manifest.name} — deck <code>{session.manifest.deck}</code> — module{' '}
               <code>{session.manifest.module}</code>
@@ -1717,6 +1718,7 @@ function App() {
           </footer>
         </>
       )}
+      </main>
 
       <RulesModal
         open={rulesOpen}

--- a/src/index.css
+++ b/src/index.css
@@ -1,19 +1,19 @@
+/* App variables track m43 tokens (m43-*.css loaded from index.html before this bundle). */
 :root {
-  --text: #6b6375;
-  --text-h: #08060d;
-  --bg: #fff;
-  --border: #e5e4e7;
-  --code-bg: #f4f3ec;
-  --accent: #aa3bff;
-  --accent-bg: rgba(170, 59, 255, 0.1);
-  --accent-border: rgba(170, 59, 255, 0.5);
-  --social-bg: rgba(244, 243, 236, 0.5);
+  --text: var(--m43-muted);
+  --text-h: var(--m43-text);
+  --text-muted: var(--m43-muted);
+  --bg: var(--m43-bg);
+  --border: var(--m43-border);
+  --code-bg: var(--m43-surface-inset);
+  --accent: var(--m43-accent);
+  --accent-bg: color-mix(in srgb, var(--m43-accent) 14%, transparent);
+  --accent-border: color-mix(in srgb, var(--m43-accent) 50%, var(--m43-border));
+  --social-bg: color-mix(in srgb, var(--m43-muted) 14%, var(--m43-bg));
   --shadow:
     rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 
-  --text-muted: #5c566a;
-
-  /* Cumulative score panel (toolbar + table; light mode = high contrast on white) */
+  /* Cumulative score panel */
   --match-cumulative-surface: color-mix(in srgb, var(--text-h) 4.5%, var(--bg));
   --match-cumulative-border: color-mix(in srgb, var(--text-h) 14%, var(--border));
   --match-cumulative-inset: color-mix(in srgb, var(--bg) 70%, var(--text-h) 30%);
@@ -29,9 +29,9 @@
   --match-cumulative-total-border: #059669;
   --match-cumulative-meta: var(--text-muted);
 
-  --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
-  --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
-  --mono: ui-monospace, Consolas, monospace;
+  --sans: var(--m43-font-sans);
+  --heading: var(--m43-font-sans);
+  --mono: var(--m43-font-mono);
 
   font: 18px/145% var(--sans);
   letter-spacing: 0.18px;
@@ -50,12 +50,6 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --text: #9ca3af;
-    --text-h: #f3f4f6;
-    --bg: #16171d;
-    --border: #2e303a;
-    --text-muted: #9ca3af;
-
     --match-cumulative-surface: color-mix(in srgb, var(--text-h) 7%, var(--bg));
     --match-cumulative-border: color-mix(in srgb, var(--text-h) 22%, var(--border));
     --match-cumulative-inset: color-mix(in srgb, var(--text-h) 8%, transparent);
@@ -70,11 +64,6 @@
     --match-cumulative-total-fg: #a7f3d0;
     --match-cumulative-total-border: #34d399;
     --match-cumulative-meta: #a1a1aa;
-    --code-bg: #1f2028;
-    --accent: #c084fc;
-    --accent-bg: rgba(192, 132, 252, 0.15);
-    --accent-border: rgba(192, 132, 252, 0.5);
-    --social-bg: rgba(47, 48, 58, 0.5);
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -7,7 +8,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), basicSsl()],
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- Load **m43** CSS (`m43-tokens`, `m43-shell`, `m43-primitives`) and **`m43-auth-header.js`** with portfolio **Home** (`https://michaelj43.dev/`), API + auth SPA defaults.
- Restructure **`index.html`**: `m43-page` + `m43-page--content-wide`, auth mount as first body child, app root inside `m43-page__body`.
- Map legacy **`src/index.css`** variables to **`--m43-*`**; wrap app regions in **`m43-site-header--wide`**, **`m43-main--wide`**, **`m43-site-footer--wide`**.
- **`chat-popout.html`**: m43 CSS only (no auth chrome).
- **Dev:** `@vitejs/plugin-basic-ssl` so `npm run dev` serves **HTTPS** (better alignment with auth `returnUrl`).
- Deploy workflow: trigger on **`vite.config.ts`** changes.

## Dependency
**`m43-page--content-wide`** and **`--wide`** shell classes need **`--m43-content-max-xl`** and the new shell rules from static-assets — merge/deploy [static-assets#12](https://github.com/MichaelJ43/static-assets/pull/12) (or equivalent) so the CDN picks up the wide layout CSS.

## Test plan
- `npm run lint`
- `npm run build`
- Manual: `npm run dev`, open **https** URL, confirm top bar + layout; `?m43debug=1` for auth logs.

Made with [Cursor](https://cursor.com)