### PR TITLE
Multi-round scoring UI: immediate R# column, shorter actions, Skyjo penalty

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -327,6 +327,15 @@
   font-variant-numeric: tabular-nums;
 }
 
+.matchCumulative__roundPenalty {
+  color: var(--match-cumulative-penalty, #b91c1c);
+  font-weight: 700;
+  cursor: help;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
 .matchCumulative__totalCell {
   background: var(--match-cumulative-total-bg);
   font-weight: 700;
@@ -369,13 +378,6 @@
     margin-left: 0;
     text-align: left;
   }
-}
-
-.app__matchPreview {
-  margin: 0 0 0.75rem;
-  font-size: 0.85rem;
-  opacity: 0.92;
-  text-align: center;
 }
 
 .app__matchActions {

--- a/src/App.css
+++ b/src/App.css
@@ -329,7 +329,6 @@
 
 .matchCumulative__roundPenalty {
   color: var(--match-cumulative-penalty, #b91c1c);
-  font-weight: 700;
   cursor: help;
   text-decoration: underline;
   text-decoration-style: dotted;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,7 @@ function MatchCumulativePanel({
   caption = 'Cumulative scores',
   scoringMode = 'points',
   pendingRoundScores,
+  pendingRoundCellNotes,
   playerSeatCaption,
 }: {
   match: MatchState
@@ -124,8 +125,10 @@ function MatchCumulativePanel({
   scoreColumnLabel?: string
   caption?: string
   scoringMode?: 'points' | 'chips'
-  /** Round scored in game state but not yet merged — updates Total column only (no layout change). */
+  /** Round scored in game state but not yet merged — show as latest R# column; Total includes this round. */
   pendingRoundScores?: number[] | null
+  /** Per-seat tooltip / penalty hints for the pending R# column (see {@link GameModule.extractMatchRoundScoreCellNotes}). */
+  pendingRoundCellNotes?: (string | null)[] | null
   /** Row header for each seat (defaults to {@link playerSeatLabel}). */
   playerSeatCaption?: (playerIndex: number) => string
 }) {
@@ -134,23 +137,19 @@ function MatchCumulativePanel({
   const n = match.cumulativeScores.length
   const pending =
     pendingRoundScores && pendingRoundScores.length === n ? pendingRoundScores : null
+  const pendingNotes =
+    pending && pendingRoundCellNotes && pendingRoundCellNotes.length === n ? pendingRoundCellNotes : null
   const displayTotals = pending
     ? match.cumulativeScores.map((c, i) => c + (pending[i] ?? 0))
     : match.cumulativeScores
+  const pendingStripe: 'a' | 'b' = history.length % 2 === 0 ? 'a' : 'b'
 
   const rowCaption = playerSeatCaption ?? ((pi: number) => playerSeatLabel(pi))
 
   return (
     <div className={`matchCumulative${toolbar ? ' matchCumulative--toolbar' : ''}`}>
       <div className="matchCumulative__scroll">
-        <table
-          className="matchCumulative__table"
-          title={
-            pending
-              ? `${scoreColumnLabel} shows the result after merging this round (before you click Next round).`
-              : undefined
-          }
-        >
+        <table className="matchCumulative__table">
           <caption>{caption}</caption>
           <thead>
             <tr>
@@ -166,6 +165,14 @@ function MatchCumulativePanel({
                   R{ri + 1}
                 </th>
               ))}
+              {pending && (
+                <th
+                  scope="col"
+                  className={`matchCumulative__thRound matchCumulative__thRound--${pendingStripe}`}
+                >
+                  R{history.length + 1}
+                </th>
+              )}
               <th scope="col" className="matchCumulative__thTotal">
                 {scoreColumnLabel}
               </th>
@@ -185,6 +192,19 @@ function MatchCumulativePanel({
                     {roundVec[pi] ?? '—'}
                   </td>
                 ))}
+                {pending && (
+                  <td
+                    className={`matchCumulative__roundCell matchCumulative__roundCell--${pendingStripe}`}
+                  >
+                    {pendingNotes?.[pi] ? (
+                      <span className="matchCumulative__roundPenalty" title={pendingNotes[pi]!}>
+                        {pending[pi] ?? '—'}
+                      </span>
+                    ) : (
+                      (pending[pi] ?? '—')
+                    )}
+                  </td>
+                )}
                 <td className="matchCumulative__totalCell">
                   {displayTotals[pi] ?? '—'}
                 </td>
@@ -981,12 +1001,35 @@ function App() {
     return rs
   }, [session])
 
-  const matchPreviewTotals = useMemo(() => {
-    if (!session || !pendingMergeRoundScores) return null
+  const pendingMergeRoundCellNotes = useMemo((): (string | null)[] | null => {
+    if (!session) return null
     const m = session.match
     if (!m?.config || m.complete) return null
-    return m.cumulativeScores.map((c, i) => c + (pendingMergeRoundScores[i] ?? 0))
+    const mod = session.module
+    if (!mod.isMatchRoundFinished?.(session.gameState)) return null
+    return mod.extractMatchRoundScoreCellNotes?.(session.gameState) ?? null
+  }, [session])
+
+  const nextMatchRoundLabel = useMemo(() => {
+    if (!session?.match || !pendingMergeRoundScores) return 'Next round'
+    const m = session.match
+    if (m.complete) return 'Start a new deal'
+    const next = m.cumulativeScores.map((c, i) => c + (pendingMergeRoundScores[i] ?? 0))
+    if (m.config.endCondition === 'anyAtOrAbove' && next.some((s) => s >= m.config.targetScore)) {
+      return 'Start a new deal'
+    }
+    return 'Next Round'
   }, [session, pendingMergeRoundScores])
+
+  const mainStatusLine = useMemo(() => {
+    if (pendingMergeRoundScores) {
+      return networkSpectator ? 'Spectating until the next deal.' : null
+    }
+    if (networkSpectator) {
+      return `${status} (spectating until the next deal)`
+    }
+    return status
+  }, [pendingMergeRoundScores, networkSpectator, status])
 
   const primaryLabel = gameId === 'demo-custom' ? 'Reveal winner' : 'Play round'
 
@@ -1539,6 +1582,7 @@ function App() {
                   }
                   scoringMode={session.manifest.match?.scoringMode === 'chips' ? 'chips' : 'points'}
                   pendingRoundScores={pendingMergeRoundScores}
+                  pendingRoundCellNotes={pendingMergeRoundCellNotes}
                   playerSeatCaption={cumulativeRowCaption}
                 />
               </div>
@@ -1589,21 +1633,12 @@ function App() {
 
       {session && (
         <>
-          <p className="app__status" role="status">
-            {networkSpectator ? `${status} (spectating until the next deal)` : status}
-          </p>
-
-          {matchPreviewTotals && session.match && !session.match.complete && (
-            <p className="app__matchPreview" role="status">
-              Totals if you merge this round:{' '}
-              {matchPreviewTotals.map((s, i) => (
-                <span key={i}>
-                  {cumulativeRowCaption(i)}: {s}
-                  {i < matchPreviewTotals.length - 1 ? ' · ' : ''}
-                </span>
-              ))}
+          {mainStatusLine != null && mainStatusLine !== '' && (
+            <p className="app__status" role="status">
+              {mainStatusLine}
             </p>
           )}
+
           {canAdvanceMatch && (
             <div className="app__matchActions">
               <button
@@ -1613,7 +1648,7 @@ function App() {
                 disabled={!!session?.net}
                 title={session?.net ? 'Only the host can advance the match.' : undefined}
               >
-                Next round (apply scores)
+                {nextMatchRoundLabel}
               </button>
             </div>
           )}

--- a/src/core/gameModule.ts
+++ b/src/core/gameModule.ts
@@ -55,6 +55,12 @@ export interface GameModule<TGame = unknown> {
    * points for that round. Return null if not in a finished-round state.
    */
   extractMatchRoundScores?(gameState: TGame): number[] | null
+  /**
+   * Optional per-player hover notes for the **pending** (not yet merged) round column on the
+   * cumulative board — e.g. end-of-round penalties (non-null = emphasize that cell, use string as
+   * `title` / tooltip blurb).
+   */
+  extractMatchRoundScoreCellNotes?(gameState: TGame): (string | null)[] | null
   /** True when this game state represents a completed round ready to merge into cumulative scores. */
   isMatchRoundFinished?(gameState: TGame): boolean
 }

--- a/src/games/skyjo/index.ts
+++ b/src/games/skyjo/index.ts
@@ -1289,6 +1289,17 @@ const skyjoModule: GameModule<SkyjoGameState> = {
     if (gs.phase !== 'roundOver' || !gs.roundScores?.length) return null
     return gs.roundScores
   },
+
+  extractMatchRoundScoreCellNotes(gs) {
+    if (gs.phase !== 'roundOver' || !gs.roundScores?.length) return null
+    const n = gs.roundScores.length
+    if (!gs.finisherDoubled) return Array.from({ length: n }, () => null)
+    const fin = gs.skyjoFinisher
+    if (fin == null || fin < 0 || fin >= n) return Array.from({ length: n }, () => null)
+    return Array.from({ length: n }, (_, i) =>
+      i === fin ? 'This score was doubled: first to go out, but not the lowest (or tied lowest) value.' : null,
+    )
+  },
 }
 
 registerGameModule(skyjoModule)

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,7 @@
   --match-cumulative-total-bg: #d1fae5;
   --match-cumulative-total-fg: #065f46;
   --match-cumulative-total-border: #059669;
+  --match-cumulative-penalty: #b91c1c;
   --match-cumulative-meta: var(--text-muted);
 
   --sans: var(--m43-font-sans);
@@ -63,6 +64,7 @@
     --match-cumulative-total-bg: color-mix(in srgb, #10b981 20%, var(--bg));
     --match-cumulative-total-fg: #a7f3d0;
     --match-cumulative-total-border: #34d399;
+    --match-cumulative-penalty: #f87171;
     --match-cumulative-meta: #a1a1aa;
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;


### PR DESCRIPTION
This PR updates the multi-round match scoreboard and related copy.

**Score table**
- As soon as a round ends, the latest round appears in a new `R#` column (not only after merge). Running totals already reflected the pending round; now the column layout matches.
- Removed the centered `Totals if you merge this round` line.

**Status / copy**
- Suppresses the long `Round over…` status line while scores are pending merge (spectators still see a short spectating line when applicable).
- Primary action is `Next Round` when another deal will follow, and `Start a new deal` when the upcoming merge will end the match (someone reaches the target).

**Skyjo end-of-round double**
- `GameModule` adds optional `extractMatchRoundScoreCellNotes`. Skyjo uses it for the not-lowest finisher: that round score is styled in red with a `title` tooltip explaining the double.

**Theming**
- `--match-cumulative-penalty` in light/dark, plus `.matchCumulative__roundPenalty` (dotted underline, `cursor: help`).

Made with [Cursor](https://cursor.com)