### PR TITLE
Toolbar: align controls, widen AI opponents, drop Actions label

### DIFF
--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -9,7 +9,7 @@ Conventions for the **app chrome** around the table: header toolbar, dialogs tha
 Secondary actions in the header (e.g. **Rules**, **New deal**, **End game**, AI difficulty controls) use:
 
 - `app__btnSecondary` — base secondary button (border, transparent fill, theme text color).
-- `app__btnToolbar` — toolbar sizing: `min-height: 2.25rem`, slightly tighter horizontal padding than the default `app__btnSecondary` alone.
+- `app__btnToolbar` — shared shell button sizing: `min-height: 2.5rem` (header toolbar row unifies with selects/inputs). Slightly tighter horizontal padding than the default `app__btnSecondary` alone.
 
 **Pattern:** combine both classes on `<button>` elements:
 

--- a/src/App.css
+++ b/src/App.css
@@ -79,12 +79,34 @@
 }
 
 .app__toolbarControls {
+  --app-toolbar-control-minh: 2.5rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem 1rem;
   align-items: flex-end;
   width: 100%;
   min-width: 0;
+}
+
+/* Shared height / padding so game select, AI count, and action buttons line up */
+.app__toolbarControls .app__select,
+.app__toolbarControls .app__inputNumber,
+.app__toolbarControls .app__btnToolbar {
+  min-height: var(--app-toolbar-control-minh);
+  box-sizing: border-box;
+  line-height: 1.25;
+}
+
+.app__toolbarControls .app__select,
+.app__toolbarControls .app__inputNumber {
+  padding: 0.4rem 0.6rem;
+}
+
+.app__toolbarControls .app__btnToolbar {
+  padding: 0.4rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .app__toolbarScores {
@@ -117,16 +139,9 @@
 
 .app__toolbarActions {
   display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  flex-direction: row;
+  align-items: flex-end;
   flex: 0 0 auto;
-}
-
-.app__toolbarActionsLabel {
-  font-size: 0.85rem;
-  font-weight: 600;
-  line-height: 1.2;
-  color: inherit;
 }
 
 .app__toolbarActionsBtns {
@@ -138,7 +153,7 @@
 
 .app__btnToolbar {
   padding: 0.42rem 0.85rem;
-  min-height: 2.25rem;
+  min-height: 2.5rem;
   box-sizing: border-box;
 }
 
@@ -159,6 +174,19 @@
   gap: 0.35rem;
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+/* At least as wide as the "AI opponents" line; number field fills the label */
+.app__label--aiOpponents {
+  flex: 0 1 auto;
+  min-width: 14ch;
+  max-width: 100%;
+}
+
+.app__label--aiOpponents .app__inputNumber {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .app__select {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1465,7 +1465,7 @@ function App() {
                     </select>
                   </label>
                   {gameSupportsConfigurableAi(gameId) && (
-                    <label className="app__label">
+                    <label className="app__label app__label--aiOpponents">
                       AI opponents
                       <input
                         className="app__inputNumber"
@@ -1489,7 +1489,6 @@ function App() {
                     </label>
                   )}
                   <div className="app__toolbarActions">
-                    {!onlineClientShell && <span className="app__toolbarActionsLabel">Actions</span>}
                     <div className="app__toolbarActionsBtns">
                       {!onlineClientShell && (
                         <button


### PR DESCRIPTION
- **Removed** the "Actions" heading; the Start deal / Rules / End game group stands on its own\n- **Toolbar row** uses a shared `min-height` (2.5rem), `line-height`, and matched padding for the game `select`, AI `input`, and `app__btnToolbar` buttons so heights line up\n- **AI opponents** uses `app__label--aiOpponents` with `min-width: 14ch` and a full-width number field so the box is at least as wide as the label text\n- **Base** `.app__btnToolbar` keeps a 2.5rem min-height for Rules modal, multiplayer, etc.; `docs/ui-design.md` updated accordingly

Made with [Cursor](https://cursor.com)