### PR TITLE
Uno: click draw pile + draw-until-playable house rule

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -502,6 +502,61 @@
   max-height: min(90vh, 42rem);
 }
 
+.app__modal--unoWild {
+  width: min(22rem, 100%);
+  max-height: min(90vh, 24rem);
+}
+
+.app__modalBody--unoWild {
+  padding-top: 0.5rem;
+}
+
+.app__unoColorGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.65rem;
+  margin-top: 0.75rem;
+}
+
+.app__unoColorBtn {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 0.4rem;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.app__unoColorSwatch--r {
+  background: #c41e1e;
+}
+.app__unoColorSwatch--r:hover {
+  filter: brightness(1.1);
+}
+.app__unoColorSwatch--y {
+  background: #c9a000;
+}
+.app__unoColorSwatch--y:hover {
+  filter: brightness(1.1);
+}
+.app__unoColorSwatch--g {
+  background: #16803c;
+}
+.app__unoColorSwatch--g:hover {
+  filter: brightness(1.1);
+}
+.app__unoColorSwatch--b {
+  background: #1a56b8;
+}
+.app__unoColorSwatch--b:hover {
+  filter: brightness(1.1);
+}
+
 .app__modalHeader {
   display: flex;
   flex-wrap: wrap;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1310,6 +1310,17 @@ function App() {
   const tableIntentZones = useMemo((): readonly string[] | undefined => {
     if (!session || networkSpectator) return undefined
     const sh = shellHumanSeat(session)
+    if (isUnoSession(session) && (session.gameState as { phase?: string }).phase === 'play') {
+      const cp = (session.gameState as { currentPlayer: number }).currentPlayer
+      if (cp !== sh) return undefined
+      const legals = session.module.getLegalActions(session.table, session.gameState)
+      const canDraw = legals.some((a) => {
+        if (a.type !== 'custom') return false
+        const cmd = (a.payload as { cmd?: unknown }).cmd
+        return cmd === 'unoDraw'
+      })
+      return canDraw ? (['draw'] as const) : undefined
+    }
     if (isSkyjoSession(session) && session.gameState.phase !== 'roundOver' && session.gameState.currentPlayer === sh) {
       const gs = session.gameState
       if (gs.pendingDraw) {
@@ -1334,6 +1345,22 @@ function App() {
       const sh = shellHumanSeat(session)
       const myGrid = `grid:${sh}`
       const myHand = `hand:${sh}`
+
+      if (isUnoSession(session)) {
+        const g = session.gameState as { phase?: string; currentPlayer?: number }
+        if (g.phase !== 'play' || g.currentPlayer !== sh) return
+        if (intent.kind === 'stack' && intent.zoneId === 'draw') {
+          const action: GameAction = { type: 'custom', payload: { cmd: 'unoDraw' } }
+          const preview = session.module.applyAction(session.table, session.gameState, action)
+          if (preview.error) {
+            window.alert(preview.error)
+            return
+          }
+          dispatchAction(action)
+        }
+        return
+      }
+
       if (isSkyjoSession(session)) {
         const gs = session.gameState
         if (gs.phase === 'roundOver' || gs.currentPlayer !== sh) return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { ChatToastStack } from './ui/ChatToastStack'
 import { MultiplayerPanel } from './ui/MultiplayerPanel'
 import { openChatPopoutWindow } from './ui/openChatPopout'
 import { RulesModal } from './ui/RulesModal'
+import { UnoWildColorModal, type UnoWildColor } from './ui/UnoWildColorModal'
 import { TableView, type ActiveTurnHighlight, type TableIntent } from './ui/TableView'
 import { skyjoDumpUiStepShouldReset, type SkyjoDumpUiStep } from './ui/tableUiFlow'
 import type { GameAction } from './core/types'
@@ -377,6 +378,8 @@ function App() {
   const [gfRank, setGfRank] = useState('A')
   const [skyjoDumpStep, setSkyjoDumpStep] = useState<SkyjoDumpUiStep>('idle')
   const [rulesOpen, setRulesOpen] = useState(false)
+  /** Pending legal wild play actions (same index, different colors) when the color modal is open. */
+  const [unoWildPlayActions, setUnoWildPlayActions] = useState<GameAction[]>([])
   const [hostClientRoster, setHostClientRoster] = useState<HostedPeer[]>([])
   /** True while this browser is an active room host (not ref-driven — avoids reading refs during render). */
   const [multiplayerHostActive, setMultiplayerHostActive] = useState(false)
@@ -1305,6 +1308,17 @@ function App() {
     }
   }, [session])
 
+  useEffect(() => {
+    if (!session || !isUnoSession(session)) {
+      setUnoWildPlayActions([])
+      return
+    }
+    const g = session.gameState as { phase?: string; currentPlayer?: number }
+    if (g.phase !== 'play' || g.currentPlayer !== shellHumanSeat(session)) {
+      setUnoWildPlayActions([])
+    }
+  }, [session])
+
   const aiCountLocked = Boolean(session?.match && !session.match.complete)
 
   const tableIntentZones = useMemo((): readonly string[] | undefined => {
@@ -1314,12 +1328,24 @@ function App() {
       const cp = (session.gameState as { currentPlayer: number }).currentPlayer
       if (cp !== sh) return undefined
       const legals = session.module.getLegalActions(session.table, session.gameState)
-      const canDraw = legals.some((a) => {
-        if (a.type !== 'custom') return false
-        const cmd = (a.payload as { cmd?: unknown }).cmd
-        return cmd === 'unoDraw'
-      })
-      return canDraw ? (['draw'] as const) : undefined
+      const zones: string[] = []
+      if (
+        legals.some((a) => {
+          if (a.type !== 'custom') return false
+          return (a.payload as { cmd?: unknown }).cmd === 'unoDraw'
+        })
+      ) {
+        zones.push('draw')
+      }
+      if (
+        legals.some((a) => {
+          if (a.type !== 'custom') return false
+          return (a.payload as { cmd?: unknown }).cmd === 'unoPlay'
+        })
+      ) {
+        zones.push(`hand:${sh}`)
+      }
+      return zones.length > 0 ? zones : undefined
     }
     if (isSkyjoSession(session) && session.gameState.phase !== 'roundOver' && session.gameState.currentPlayer === sh) {
       const gs = session.gameState
@@ -1357,6 +1383,26 @@ function App() {
             return
           }
           dispatchAction(action)
+          return
+        }
+        if (intent.kind === 'card' && intent.zoneId === myHand) {
+          const cardIndex = intent.cardIndex
+          const legals = session.module.getLegalActions(session.table, session.gameState)
+          const plays = legals.filter(
+            (a): a is Extract<GameAction, { type: 'custom' }> =>
+              a.type === 'custom' &&
+              (a.payload as { cmd?: string }).cmd === 'unoPlay' &&
+              Number((a.payload as { index?: number }).index) === cardIndex,
+          )
+          if (plays.length === 0) {
+            window.alert('That card is not a legal play right now.')
+            return
+          }
+          if (plays.length === 1) {
+            dispatchAction(plays[0]!)
+            return
+          }
+          setUnoWildPlayActions(plays)
         }
         return
       }
@@ -1456,6 +1502,20 @@ function App() {
       }
     },
     [session, networkSpectator, dispatchAction, skyjoDumpStep, gfAwaitingOpponent, gfRank, humanRanks],
+  )
+
+  const onUnoWildColorPick = useCallback(
+    (col: UnoWildColor) => {
+      const a = unoWildPlayActions.find(
+        (x) =>
+          x.type === 'custom' &&
+          (x.payload as { cmd?: string; color?: string }).cmd === 'unoPlay' &&
+          (x.payload as { color?: string }).color === col,
+      )
+      setUnoWildPlayActions([])
+      if (a) dispatchAction(a)
+    },
+    [unoWildPlayActions, dispatchAction],
   )
 
   return (
@@ -1741,6 +1801,16 @@ function App() {
                 </div>
               )}
 
+            {gameId === 'uno' &&
+              isUnoSession(session) &&
+              (session.gameState as { phase?: string }).phase === 'play' &&
+              (session.gameState as { currentPlayer: number }).currentPlayer === shellHumanSeat(session) && (
+                <p className="app__tableIntentHint">
+                  Click a card in your hand to play, or the draw pile to draw when you have no play. Wild cards open
+                  a color chooser.
+                </p>
+              )}
+
             {legalCustomActions.length > 0 && (
               <div className="app__customActions" role="group" aria-label="Game actions">
                 {legalCustomActions.map((a) => (
@@ -1781,6 +1851,11 @@ function App() {
       )}
       </main>
 
+      <UnoWildColorModal
+        open={unoWildPlayActions.length > 0}
+        onClose={() => setUnoWildPlayActions([])}
+        onChooseColor={onUnoWildColorPick}
+      />
       <RulesModal
         open={rulesOpen}
         onClose={() => setRulesOpen(false)}

--- a/src/core/gameModule.ts
+++ b/src/core/gameModule.ts
@@ -18,6 +18,11 @@ export interface GameModuleContext {
    * Games without both `draw` and `discard` zones ignore this. Omitted or false = no recycle.
    */
   reshuffleDiscardWhenDrawEmpty?: boolean
+  /**
+   * Uno: when true, a player with no play draws repeatedly until a playable card (or the deck is exhausted);
+   * if a playable is drawn, they must play that card. Omitted = off.
+   */
+  unoDrawUntilPlayable?: boolean
 }
 
 export interface ApplyResult<TGame> {

--- a/src/data/houseRules.ts
+++ b/src/data/houseRules.ts
@@ -19,6 +19,8 @@ export interface GameHouseRules {
    * Omitted = use manifest default or built-in per-game default.
    */
   reshuffleDiscardWhenDrawEmpty?: boolean
+  /** Uno: keep drawing from the pile until a card can be played, then you must play that card. */
+  unoDrawUntilPlayable?: boolean
 }
 
 /** Games that expose the discard→draw recycle toggle in Rules → Options. */
@@ -124,5 +126,14 @@ export function createSessionOptionsHouseRules(gameId: RulesGameId): Partial<Cre
   if (hr.warTieDownCards === 1 || hr.warTieDownCards === 3) o.warTieDownCards = hr.warTieDownCards
   if (hr.reshuffleDiscardWhenDrawEmpty === true) o.reshuffleDiscardWhenDrawEmpty = true
   if (hr.reshuffleDiscardWhenDrawEmpty === false) o.reshuffleDiscardWhenDrawEmpty = false
+  if (hr.unoDrawUntilPlayable === true) o.unoDrawUntilPlayable = true
+  if (hr.unoDrawUntilPlayable === false) o.unoDrawUntilPlayable = false
   return o
+}
+
+export function effectiveUnoDrawUntilPlayable(gameId: RulesGameId, options?: CreateSessionOptions): boolean {
+  if (gameId !== 'uno') return false
+  if (options?.unoDrawUntilPlayable === true) return true
+  if (options?.unoDrawUntilPlayable === false) return false
+  return !!getHouseRulesForGame('uno').unoDrawUntilPlayable
 }

--- a/src/games/uno/index.ts
+++ b/src/games/uno/index.ts
@@ -134,6 +134,13 @@ export interface UnoGameState {
   currentColor: UnoColor
   drewThisTurn: boolean
   drawSlot: number | null
+  /**
+   * When true, after drawing you must play the card at `drawSlot` (cannot pass).
+   * Set when the optional “draw until playable” house rule is on and a playable card was drawn.
+   */
+  mustPlayDrawnCard: boolean
+  /** House rule: kept for UI / next round; immutable during a round. */
+  drawUntilPlayable: boolean
   message: string
   roundScores: number[] | null
   reshuffleDiscardWhenDrawEmpty: boolean
@@ -170,7 +177,11 @@ function computeLegalActions(
   const hz = table.zones[handId(playerIndex)]!.cards
   const out: GameAction[] = []
 
-  if (gs.drewThisTurn && gs.drawSlot !== null) {
+  if (gs.drewThisTurn) {
+    if (gs.drawSlot === null) {
+      out.push({ type: 'custom', payload: { cmd: 'unoPassAfterDraw' } })
+      return out
+    }
     const idx = gs.drawSlot
     const card = hz[idx]
     if (!card) {
@@ -186,8 +197,12 @@ function computeLegalActions(
       } else {
         out.push({ type: 'custom', payload: { cmd: 'unoPlay', index: idx } })
       }
+      if (!gs.mustPlayDrawnCard) {
+        out.push({ type: 'custom', payload: { cmd: 'unoPassAfterDraw' } })
+      }
+    } else {
+      out.push({ type: 'custom', payload: { cmd: 'unoPassAfterDraw' } })
     }
-    out.push({ type: 'custom', payload: { cmd: 'unoPassAfterDraw' } })
     return out
   }
 
@@ -268,6 +283,8 @@ const unoModule: GameModule<UnoGameState> = {
         currentColor: startColor,
         drewThisTurn: false,
         drawSlot: null,
+        mustPlayDrawnCard: false,
+        drawUntilPlayable: ctx.unoDrawUntilPlayable === true,
         message: 'Match color or number — Wilds are always playable.',
         roundScores: null,
         reshuffleDiscardWhenDrawEmpty: ctx.reshuffleDiscardWhenDrawEmpty ?? false,
@@ -294,6 +311,17 @@ const unoModule: GameModule<UnoGameState> = {
 
     if (c === 'unoPassAfterDraw') {
       if (!gs.drewThisTurn) return { table: t, gameState: gs, error: 'Pass only after drawing.' }
+      if (gs.mustPlayDrawnCard && gs.drawSlot !== null) {
+        const up = topDiscard(t)
+        const c0 = hz[gs.drawSlot]
+        if (c0 && up) {
+          const t0 = templates[c0.templateId]!
+          const tTop = templates[up.templateId]!
+          if (canPlay(t0, tTop, gs.currentColor)) {
+            return { table: t, gameState: gs, error: 'You must play the drawn card.' }
+          }
+        }
+      }
       const next = step(cp, gs.direction, pCount)
       return {
         table: t,
@@ -302,6 +330,7 @@ const unoModule: GameModule<UnoGameState> = {
           currentPlayer: next,
           drewThisTurn: false,
           drawSlot: null,
+          mustPlayDrawnCard: false,
           message: next === 0 ? 'Your turn.' : `Player ${next}'s turn.`,
         },
       }
@@ -329,6 +358,49 @@ const unoModule: GameModule<UnoGameState> = {
       const topTpl = templates[top.templateId]!
       const hasPlay = hz.some((card) => canPlay(templates[card.templateId]!, topTpl, gs.currentColor))
       if (hasPlay) return { table: t, gameState: gs, error: 'You have a playable card.' }
+
+      if (gs.drawUntilPlayable) {
+        let newSlot: number | null = null
+        let foundPlayable = false
+        for (;;) {
+          ensureDraw(t, rng, gs.reshuffleDiscardWhenDrawEmpty)
+          if (t.zones.draw!.cards.length === 0) break
+          moveTop(t, 'draw', hid, cp === 0)
+          newSlot = hz.length - 1
+          const drawn = hz[newSlot]!
+          const dTpl = templates[drawn.templateId]!
+          if (canPlay(dTpl, topTpl, gs.currentColor)) {
+            foundPlayable = true
+            break
+          }
+        }
+        if (foundPlayable && newSlot !== null) {
+          return {
+            table: t,
+            gameState: {
+              ...gs,
+              drewThisTurn: true,
+              drawSlot: newSlot,
+              mustPlayDrawnCard: true,
+              message: 'You must play the drawn card.',
+            },
+          }
+        }
+        if (newSlot !== null) {
+          return {
+            table: t,
+            gameState: {
+              ...gs,
+              drewThisTurn: true,
+              drawSlot: null,
+              mustPlayDrawnCard: false,
+              message: 'No playable card; end your turn.',
+            },
+          }
+        }
+        return { table: t, gameState: gs, error: 'Cannot draw.' }
+      }
+
       ensureDraw(t, rng, gs.reshuffleDiscardWhenDrawEmpty)
       if (t.zones.draw!.cards.length === 0) return { table: t, gameState: gs, error: 'Cannot draw.' }
       moveTop(t, 'draw', hid, cp === 0)
@@ -339,6 +411,7 @@ const unoModule: GameModule<UnoGameState> = {
           ...gs,
           drewThisTurn: true,
           drawSlot: newSlot,
+          mustPlayDrawnCard: false,
           message: 'Play the drawn card or end turn.',
         },
       }
@@ -358,7 +431,7 @@ const unoModule: GameModule<UnoGameState> = {
     if (!canPlay(playTpl, topTpl, gs.currentColor)) {
       return { table: t, gameState: gs, error: 'Illegal play.' }
     }
-    if (gs.drewThisTurn && gs.drawSlot !== idx) {
+    if (gs.drewThisTurn && gs.drawSlot != null && gs.drawSlot !== idx) {
       return { table: t, gameState: gs, error: 'Play the drawn card or pass.' }
     }
     const colorPick = (action.payload as { color?: string }).color
@@ -390,6 +463,8 @@ const unoModule: GameModule<UnoGameState> = {
           currentColor: newColor,
           drewThisTurn: false,
           drawSlot: null,
+          mustPlayDrawnCard: false,
+          drawUntilPlayable: gs.drawUntilPlayable,
           message: `Player ${cp} went out!`,
           roundScores: scores,
           reshuffleDiscardWhenDrawEmpty: gs.reshuffleDiscardWhenDrawEmpty,
@@ -439,6 +514,7 @@ const unoModule: GameModule<UnoGameState> = {
         currentColor: newColor,
         drewThisTurn: false,
         drawSlot: null,
+        mustPlayDrawnCard: false,
         message: next === 0 ? 'Your turn.' : `Player ${next}'s turn.`,
       },
     }

--- a/src/rules/uno.md
+++ b/src/rules/uno.md
@@ -22,9 +22,13 @@ Uno-style play: get rid of your cards first by matching **color** or **symbol** 
 
 ## Drawing when stuck
 
-1. If you cannot play, **draw** one card from the pile.
+1. If you cannot play, **draw** one card from the pile. You can **click the draw pile** on the table or use the on-screen **Draw** control.
 1. If that new card **can be played**, you may play it immediately.
-1. Otherwise you typically **end your turn** without playing (this app exposes **Draw** / pass-style actions as appropriate).
+1. Otherwise you typically **end your turn** without playing (this app exposes pass-style actions as appropriate).
+
+## Optional house rule (Rules → Options)
+
+1. **Draw until you can play, then you must play that card:** when you have no play, the app can keep drawing for you until a card *can* be played on the discard, or the deck is exhausted. If a playable card is drawn, you **must** play it (no passing it). If the deck runs out first, you add any unplayable cards to your hand and end your turn.
 
 ## Special cards (typical meanings)
 
@@ -46,5 +50,5 @@ Uno-style play: get rid of your cards first by matching **color** or **symbol** 
 
 ## Playing in this app
 
-1. Use on-screen **custom actions** for draw and play; wilds prompt for **color** where needed.
+1. Use on-screen **custom actions** for play; **click the draw pile** or the **Draw** control to draw. Wilds prompt for **color** where needed.
 1. Watch the **status** line for skips and draws.

--- a/src/rules/uno.md
+++ b/src/rules/uno.md
@@ -50,5 +50,5 @@ Uno-style play: get rid of your cards first by matching **color** or **symbol** 
 
 ## Playing in this app
 
-1. Use on-screen **custom actions** for play; **click the draw pile** or the **Draw** control to draw. Wilds prompt for **color** where needed.
+1. **Click a card in your hand** to play, **click the draw pile** (or **Draw**) to draw when you have no play, and use on-screen **custom actions** as an alternative. **Wilds** open a color chooser; you can still use the labeled wild buttons in the action row if you prefer.
 1. Watch the **status** line for skips and draws.

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,7 +13,12 @@ import {
   type CreateSessionOptions,
 } from './session/playerConfig'
 import type { SeatProfile } from './session/seatProfiles'
-import { clampMatchTargetScore, createSessionOptionsHouseRules, effectiveReshuffleDiscardWhenDrawEmpty } from './data/houseRules'
+import {
+  clampMatchTargetScore,
+  createSessionOptionsHouseRules,
+  effectiveReshuffleDiscardWhenDrawEmpty,
+  effectiveUnoDrawUntilPlayable,
+} from './data/houseRules'
 import type { RulesGameId } from './data/rulesSources'
 
 export type { MatchState } from './core/match'
@@ -93,6 +98,7 @@ export function createSession(
     manifest,
     options,
   )
+  const unoDrawUntilPlayable = effectiveUnoDrawUntilPlayable(gameId as RulesGameId, options)
 
   const { table, gameState } = mod.setup(
     {
@@ -104,6 +110,7 @@ export function createSession(
       warTieDownCards: options?.warTieDownCards,
       skyjoDiscardSwapFaceUpOnly: options?.skyjoDiscardSwapFaceUpOnly,
       reshuffleDiscardWhenDrawEmpty,
+      unoDrawUntilPlayable,
     },
     instances,
   )
@@ -163,6 +170,10 @@ export function continuationOptionsFromSession(prev: GameSession): CreateSession
   }
   if (prev.manifest.module === 'war' && (gs.tieDownCards === 1 || gs.tieDownCards === 3)) {
     base.warTieDownCards = gs.tieDownCards
+  }
+  if (prev.manifest.module === 'uno' && typeof (gs as { drawUntilPlayable?: boolean }).drawUntilPlayable === 'boolean') {
+    const u = gs as { drawUntilPlayable: boolean }
+    base.unoDrawUntilPlayable = u.drawUntilPlayable
   }
   return base
 }

--- a/src/session/playerConfig.ts
+++ b/src/session/playerConfig.ts
@@ -30,6 +30,8 @@ export interface CreateSessionOptions {
    * Override “shuffle discard into draw when draw is empty” for games that support it (see house rules).
    */
   reshuffleDiscardWhenDrawEmpty?: boolean
+  /** Uno: draw until a playable card, then must play that card (house rule). */
+  unoDrawUntilPlayable?: boolean
   /**
    * Remote human opponents (networked peers). Applied only for games in {@link gameSupportsOnlineMultiplayer}.
    * Player 0 is always the local human; remote humans occupy 1..N before any AI seats.

--- a/src/ui/GameHouseRulesPanel.tsx
+++ b/src/ui/GameHouseRulesPanel.tsx
@@ -33,6 +33,9 @@ export function GameHouseRulesPanel({ gameId, manifest, readOnly = false }: Game
   const [warTie, setWarTie] = useState<'1' | '3'>(() =>
     getHouseRulesForGame(gameId).warTieDownCards === 1 ? '1' : '3',
   )
+  const [unoDrawChain, setUnoDrawChain] = useState(
+    () => getHouseRulesForGame('uno').unoDrawUntilPlayable === true,
+  )
   const [houseRulesGen, bumpHouseRules] = useReducer((x: number) => x + 1, 0)
   const houseRules = useMemo(() => {
     void houseRulesGen
@@ -47,6 +50,7 @@ export function GameHouseRulesPanel({ gameId, manifest, readOnly = false }: Game
     setSkyjoDiscardOnly(!!h.skyjoDiscardSwapFaceUpOnly)
     setDealerSoft17(!!h.dealerHitsSoft17)
     setWarTie(h.warTieDownCards === 1 ? '1' : '3')
+    setUnoDrawChain(h.unoDrawUntilPlayable === true)
   }, [gameId, defaultTarget])
 
   const onTargetBlur = () => {
@@ -108,6 +112,24 @@ export function GameHouseRulesPanel({ gameId, manifest, readOnly = false }: Game
           <span>
             When the <strong>draw pile</strong> is empty, shuffle the <strong>discard pile</strong> into a new draw pile
             (top discard stays face-up).
+          </span>
+        </label>
+      )}
+
+      {gameId === 'uno' && (
+        <label className="app__houseRulesCheck">
+          <input
+            type="checkbox"
+            checked={unoDrawChain}
+            onChange={(e) => {
+              const on = e.target.checked
+              setUnoDrawChain(on)
+              patchHouseRulesForGame('uno', { unoDrawUntilPlayable: on ? true : null })
+            }}
+          />
+          <span>
+            When you must draw, <strong>keep drawing</strong> until a card can be played on the discard; you must then
+            play that card (cannot pass it).
           </span>
         </label>
       )}

--- a/src/ui/UnoWildColorModal.tsx
+++ b/src/ui/UnoWildColorModal.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useId } from 'react'
+
+export type UnoWildColor = 'r' | 'y' | 'g' | 'b'
+
+const COLORS: { id: UnoWildColor; label: string; swatch: string }[] = [
+  { id: 'r', label: 'Red', swatch: 'app__unoColorSwatch--r' },
+  { id: 'y', label: 'Yellow', swatch: 'app__unoColorSwatch--y' },
+  { id: 'g', label: 'Green', swatch: 'app__unoColorSwatch--g' },
+  { id: 'b', label: 'Blue', swatch: 'app__unoColorSwatch--b' },
+]
+
+export interface UnoWildColorModalProps {
+  open: boolean
+  onClose: () => void
+  onChooseColor: (color: UnoWildColor) => void
+}
+
+export function UnoWildColorModal({ open, onClose, onChooseColor }: UnoWildColorModalProps) {
+  const titleId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className="app__modalBackdrop" role="presentation" onClick={onClose}>
+      <div
+        className="app__modal app__modal--unoWild"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="app__modalHeader">
+          <h2 id={titleId} className="app__modalTitle">
+            Wild — choose a color
+          </h2>
+          <button type="button" className="app__btnSecondary app__btnToolbar" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+        <div className="app__modalBody app__modalBody--unoWild">
+          <p className="app__tableIntentHint">The next color in play will be the one you pick.</p>
+          <div className="app__unoColorGrid" role="group" aria-label="Uno color choice">
+            {COLORS.map(({ id, label, swatch }) => (
+              <button
+                key={id}
+                type="button"
+                className={`app__unoColorBtn ${swatch}`}
+                onClick={() => onChooseColor(id)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Click the draw pile** to take a card when drawing is your only legal action (same as the Draw control).
- **Optional house rule** (Rules → Options): if you have no play, the game keeps drawing until a card *can* be played on the discard, or the deck is exhausted. If a playable card is drawn, you must play that card. If the deck runs out first, the drawn cards stay in your hand and you end your turn.

## Notes

- House rule is persisted in localStorage; start a new deal (or next match round) to apply.
- The next match round copies the current table's draw-until setting from the finished session into create-session options.

Build, lint, and test:ci pass.