### PR TITLE
feat(analytics): m43 game_start and match_round_start events

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Wide layout uses **`m43-page--content-wide`** and **`m43-*--wide`** classes; tha
 
 ### Analytics
 
-The browser entries load `https://static.michaelj43.dev/v1/m43-analytics.js` with app id `card-game`. It records pageview events to `https://api.michaelj43.dev/analytics/events?v=1`; add `?m43debug=1` to a page URL to see client diagnostics in the browser console.
+The browser entries load `https://static.michaelj43.dev/v1/m43-analytics.js` with app id `card-game`. It records pageview events to `https://api.michaelj43.dev/analytics/events?v=1`; add `?m43debug=1` to a page URL to see client diagnostics in the browser console. The app also sends **`game_start`** when a deal begins (and **`match_round_start`** when continuing a multi-round match); event metadata is in **`context`** (stored server-side under **`properties`**), including game id, AI count, human/remote seat counts, spectator flag, and whether the browser is hosting or a joined client—see [`src/analytics/m43GameAnalytics.ts`](src/analytics/m43GameAnalytics.ts).
 
 Production build and local preview of the built assets:
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import { playAudioCue } from './audio/playCue'
 import { tableCardFingerprint } from './audio/tableFingerprint'
 import { turnSignalFromSession } from './audio/turnSignal'
 import { AudioCueBar } from './ui/AudioCueBar'
+import { trackGameStart, trackMatchRoundStart } from './analytics/m43GameAnalytics'
 
 function attachHostSeatProfilesIfNeeded(
   sess: GameSession,
@@ -393,6 +394,8 @@ function App() {
   const prevTurnSigRef = useRef<string | null>(null)
   const prevTableFpRef = useRef<string | null>(null)
   const flipSoundTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
+  /** Joining client: emit at most one game_start snapshot per tab for the first received table state. Resets when leaving multiplayer. */
+  const clientDealAnalyticsEmittedRef = useRef(false)
   const { toasts: mainChatToasts, pushToast: pushMainChatToast, clearToasts: clearMainChatToasts } =
     useChatToasts(5, 3000)
 
@@ -562,6 +565,11 @@ function App() {
         id,
         hosting,
       )
+      const role = hosting ? 'host' : 'solo'
+      trackGameStart(sess, role, {
+        hosting,
+        remotePeersOpen: openRemotes,
+      })
       setSession(sess)
       setGfAwaitingOpponent(false)
       setGfRank('A')
@@ -627,6 +635,12 @@ function App() {
     clientRemoteSeatRef.current = snap.seat
     const parsed = parseSessionSnapshot(snap.state, snap.seat)
     if (!parsed) return
+    if (joinedAsClient && !clientDealAnalyticsEmittedRef.current) {
+      clientDealAnalyticsEmittedRef.current = true
+      trackGameStart(parsed, parsed.net?.spectator ? 'spectator' : 'client', {
+        joinedClient: true,
+      })
+    }
     setSession(parsed)
     setGameId(parsed.manifest.id as (typeof GAME_IDS)[number])
     if (gameSupportsConfigurableAi(parsed.manifest.id)) {
@@ -638,7 +652,7 @@ function App() {
     setGfAwaitingOpponent(false)
     setGfRank('A')
     setSkyjoDumpStep('idle')
-  }, [])
+  }, [joinedAsClient])
 
   const onRemoteSetDisplayName = useCallback((msg: PeerClientSetDisplayName, fromPeerId: string) => {
     const host = roomHostRef.current
@@ -864,6 +878,7 @@ function App() {
     }
     chatPopoutRef.current = null
     clientRemoteSeatRef.current = null
+    clientDealAnalyticsEmittedRef.current = false
   }, [clearMainChatToasts])
 
   const onHostingRosterChange = useCallback((peers?: HostedPeer[]) => {
@@ -874,11 +889,9 @@ function App() {
   const onNextMatchRound = useCallback(() => {
     if (!session || session.net) return
     try {
-      const next = attachHostSeatProfilesIfNeeded(
-        startNextMatchRound(session, gameId),
-        gameId,
-        !!roomHostRef.current,
-      )
+      const hosting = !!roomHostRef.current
+      const next = attachHostSeatProfilesIfNeeded(startNextMatchRound(session, gameId), gameId, hosting)
+      trackMatchRoundStart(next, hosting ? 'host' : 'solo', { hosting })
       setSession(next)
     } catch (e) {
       window.alert(e instanceof Error ? e.message : String(e))
@@ -1633,16 +1646,7 @@ function App() {
                           while (next.length < aiOpponents) next.push('medium')
                           setAiDifficulties(next)
                           if (session) {
-                            const hosting = !!roomHostRef.current
-                            const s = attachHostSeatProfilesIfNeeded(
-                              createSession(gameId, Math.random, undefined, makeDealOptions(undefined, gameId, next)),
-                              gameId,
-                              hosting,
-                            )
-                            setSession(s)
-                            setSkyjoDumpStep('idle')
-                            setGfAwaitingOpponent(false)
-                            setGfRank('A')
+                            applyFreshDeal(gameId, makeDealOptions(undefined, gameId, next))
                           }
                         }}
                       >

--- a/src/analytics/m43GameAnalytics.ts
+++ b/src/analytics/m43GameAnalytics.ts
@@ -1,0 +1,82 @@
+import type { AiDifficulty } from '../core/aiContext'
+import type { GameManifestYaml } from '../core/types'
+import type { GameSession } from '../session'
+
+export type GameTableRole = 'solo' | 'host' | 'client' | 'spectator'
+
+const EVENT_GAME_START = 'game_start'
+const EVENT_MATCH_ROUND_START = 'match_round_start'
+
+function track(eventType: string, context: Record<string, unknown>, path?: string): void {
+  const m43 = (globalThis as unknown as { M43Analytics?: { trackPageview?: (p?: unknown) => void } }).M43Analytics
+  if (typeof m43?.trackPageview !== 'function') return
+  try {
+    const p =
+      typeof location !== 'undefined'
+        ? `${location.pathname}${location.search}`
+        : '/'
+    m43.trackPageview({
+      eventType,
+      context,
+      path: path ?? p,
+    })
+  } catch {
+    /* ignore */
+  }
+}
+
+function manifestTotals(manifest: GameManifestYaml): {
+  aiCount: number
+  localHumans: number
+  totalSeats: number
+} {
+  const human = manifest.players.human
+  const ai = manifest.players.ai
+  return { aiCount: ai, localHumans: human, totalSeats: human + ai }
+}
+
+function stringifyDifficulties(d: AiDifficulty[] | undefined): string[] | undefined {
+  if (!d?.length) return undefined
+  return d.slice()
+}
+
+/**
+ * Payload `context` for m43 ingest (persisted API-side under `properties`).
+ */
+export function buildGameTableContext(
+  sess: GameSession,
+  role: GameTableRole,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> {
+  const { aiCount, localHumans, totalSeats } = manifestTotals(sess.manifest)
+  const human = sess.manifest.players.human
+  const remoteHumans = Math.max(0, human - 1)
+  const spectator = !!sess.net?.spectator
+  const base: Record<string, unknown> = {
+    game: String(sess.manifest.id),
+    aiCount,
+    localHumans,
+    remoteHumans,
+    totalSeats,
+    spectator,
+    multiplayer: !!(sess.net || remoteHumans > 0),
+    role,
+    matchRoundIndex: sess.match?.completedRoundScores?.length ?? 0,
+  }
+  const diff = stringifyDifficulties(sess.aiPlayerConfig?.difficulties)
+  if (diff) base.aiDifficulties = diff
+
+  return { ...base, ...(extra ?? {}) }
+}
+
+export function trackGameStart(sess: GameSession, role: GameTableRole, extra?: Record<string, unknown>): void {
+  track(EVENT_GAME_START, buildGameTableContext(sess, role, { matchContinuation: false, ...extra }))
+}
+
+/** Next hand in the same match (scores carry across rounds). */
+export function trackMatchRoundStart(sess: GameSession, role: GameTableRole, extra?: Record<string, unknown>): void {
+  track(
+    EVENT_MATCH_ROUND_START,
+    buildGameTableContext(sess, role, { matchContinuation: true, ...extra }),
+  )
+}


### PR DESCRIPTION
## Summary

Sends typed analytics alongside existing pageviews using the bundled `m43-analytics.js` client (`M43Analytics.trackPageview`) and the shared API ingest path.

### Events
- **`game_start`** — new deal / table: host or solo (**`applyFreshDeal`**), AI difficulty change that reshuffles (`joinedClient: false` path). Joining clients get one event on the **first** successful snapshot (**`joinedClient: true`**); ref resets when leaving multiplayer so a later join can count again.
- **`match_round_start`** — next round within the same cumulative match (**`onNextMatchRound`**), local sessions only (`session.net` guarded as before).

### Context fields (stored API-side as `properties`)
`game`, seat counts (**`aiCount`, `localHumans`, `remoteHumans`, `totalSeats`**), flags (**`spectator`, `multiplayer`**), **`role`** (`solo` \| `host` \| `client` \| `spectator`), **`matchRoundIndex`** (completed rounds count), optional **`aiDifficulties`**, optional **`hosting`**, **`remotePeersOpen`**, **`joinedClient`**, plus **`matchContinuation`**.

Implementation: [`src/analytics/m43GameAnalytics.ts`](src/analytics/m43GameAnalytics.ts).

### Tests / checks
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test:ci`


Made with [Cursor](https://cursor.com)