### PR TITLE
Skyjo: interactive opening + prep card emphasis

### DIFF
--- a/docs/games/skyjo.md
+++ b/docs/games/skyjo.md
@@ -6,7 +6,7 @@ Skyjo-style round play: grid of face-down/face-up cards, draw pile, discard, and
 
 **Players:** human vs one or more AIs; per-seat **AI difficulty** is supported.
 
-**UI:** follow the on-screen hints for dump & flip, swap, and discard flows.
+**UI:** each round starts with an **opening** step (every grid card is face-down; each player flips two of their own cards in seat order). Then follow the on-screen hints for dump & flip, swap, and discard flows. Legal grid targets for your current action are slightly enlarged on hover/focus so the intended card is easier to spot.
 
 See [`src/games/skyjo/skyjo.yaml`](../../src/games/skyjo/skyjo.yaml) for bundled match parameters.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -699,6 +699,13 @@ function App() {
       return
     }
     const action = msg.action as GameAction
+    if (isSkyjoSession(prev)) {
+      const skyjoGs = prev.gameState
+      if (skyjoGs.phase !== 'roundOver' && msg.seat !== skyjoGs.currentPlayer) {
+        host.ack(fromPeerId, msg.nonce, false, 'Not your turn.')
+        return
+      }
+    }
     const result = prev.module.applyAction(prev.table, prev.gameState, action)
     if (result.error) {
       host.ack(fromPeerId, msg.nonce, false, result.error)
@@ -1362,6 +1369,9 @@ function App() {
     }
     if (isSkyjoSession(session) && session.gameState.phase !== 'roundOver' && session.gameState.currentPlayer === sh) {
       const gs = session.gameState
+      if (gs.phase === 'opening') {
+        return [`grid:${sh}`]
+      }
       if (gs.pendingDraw) {
         if (gs.pendingFromDiscard) return [`grid:${sh}`]
         return [`grid:${sh}`, 'discard']
@@ -1377,6 +1387,40 @@ function App() {
     }
     return undefined
   }, [session, gfAwaitingOpponent, networkSpectator])
+
+  const skyjoPrepTarget = useMemo((): { zoneId: string; indices: ReadonlySet<number> } | undefined => {
+    if (!session || networkSpectator || !isSkyjoSession(session)) return undefined
+    const gs = session.gameState
+    if (gs.phase === 'roundOver') return undefined
+    const sh = shellHumanSeat(session)
+    if (gs.currentPlayer !== sh) return undefined
+    const legals = session.module.getLegalActions(session.table, session.gameState)
+    const zoneId = `grid:${sh}`
+    const out = new Set<number>()
+    if (gs.phase === 'opening') {
+      for (const a of legals) {
+        if (a.type === 'skyjoOpeningFlip') out.add(a.gridIndex)
+      }
+      return out.size ? { zoneId, indices: out } : undefined
+    }
+    if (gs.pendingDraw) {
+      if (skyjoDumpStep === 'selectFlip') {
+        for (const a of legals) {
+          if (a.type === 'skyjoDumpDraw') out.add(a.flipIndex)
+        }
+      } else {
+        for (const a of legals) {
+          if (a.type === 'skyjoSwapDrawn') out.add(a.gridIndex)
+          if (a.type === 'skyjoDumpDraw') out.add(a.flipIndex)
+        }
+      }
+      return out.size ? { zoneId, indices: out } : undefined
+    }
+    for (const a of legals) {
+      if (a.type === 'skyjoTakeDiscard') out.add(a.gridIndex)
+    }
+    return out.size ? { zoneId, indices: out } : undefined
+  }, [session, networkSpectator, skyjoDumpStep])
 
   const handleTableIntent = useCallback(
     (intent: TableIntent) => {
@@ -1423,6 +1467,13 @@ function App() {
       if (isSkyjoSession(session)) {
         const gs = session.gameState
         if (gs.phase === 'roundOver' || gs.currentPlayer !== sh) return
+
+        if (gs.phase === 'opening') {
+          if (intent.kind === 'card' && intent.zoneId === myGrid) {
+            dispatchAction({ type: 'skyjoOpeningFlip', gridIndex: intent.cardIndex })
+          }
+          return
+        }
 
         if (intent.kind === 'stack' && intent.zoneId === 'draw') {
           dispatchAction({ type: 'skyjoDraw', from: 'deck' })
@@ -1759,6 +1810,7 @@ function App() {
                 : undefined
             }
             activeTurnHighlight={activeTurnHighlight}
+            prepTarget={skyjoPrepTarget}
           />
 
           <div className="app__actions">
@@ -1790,12 +1842,19 @@ function App() {
               session.gameState.phase !== 'roundOver' &&
               session.gameState.currentPlayer === shellHumanSeat(session) && (
                 <div className="app__skyjo">
-                  <p className="app__tableIntentHint">
-                    Draw from the deck (left). With a pending card from the deck, click the discard pile to start dump
-                    &amp; flip, then a face-down grid card — or Shift+click a face-down card to do it in one step. Click
-                    the grid to swap, or (no pending) click the grid to take the visible discard. Pending from the
-                    discard pile must be placed (no dump).
-                  </p>
+                  {session.gameState.phase === 'opening' ? (
+                    <p className="app__tableIntentHint">
+                      Flip two face-down cards on your grid, one at a time. After everyone reveals two starters, the
+                      player with the highest sum goes first.
+                    </p>
+                  ) : (
+                    <p className="app__tableIntentHint">
+                      Draw from the deck (left). With a pending card from the deck, click the discard pile to start
+                      dump &amp; flip, then a face-down grid card — or Shift+click a face-down card to do it in one step.
+                      Click the grid to swap, or (no pending) click the grid to take the visible discard. Pending from
+                      the discard pile must be placed (no dump).
+                    </p>
+                  )}
                   {session.gameState.discardSwapFaceUpOnly && (
                     <p className="app__tableIntentHint app__tableIntentHint--sub">
                       House rule: you may only take the discard by choosing a <strong>face-up</strong> card to replace;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -129,4 +129,6 @@ export type GameAction =
   | { type: 'skyjoDumpDraw'; flipIndex: number }
   /** Replace grid cell with top discard (no pending draw). */
   | { type: 'skyjoTakeDiscard'; gridIndex: number }
+  /** Skyjo opening: flip one face-down grid card (each player reveals two before play). */
+  | { type: 'skyjoOpeningFlip'; gridIndex: number }
   | { type: 'custom'; payload: Record<string, unknown> }

--- a/src/games/skyjo/index.ts
+++ b/src/games/skyjo/index.ts
@@ -497,21 +497,46 @@ function pendingActionFinisherPenalty(
   return expectedFinisherDoublePain(myRaw, minOther, cumulative, target)
 }
 
+function countFaceUpNonSlotOnGrid(table: TableState, playerIndex: number): number {
+  let n = 0
+  for (const c of table.zones[gridZone(playerIndex)]!.cards) {
+    if (c && !isSlot(c.templateId) && c.faceUp) n++
+  }
+  return n
+}
+
+function sumOpeningVisibleOnGrid(
+  table: TableState,
+  templates: Record<string, CardTemplate>,
+  playerIndex: number,
+): number {
+  let sum = 0
+  for (const c of table.zones[gridZone(playerIndex)]!.cards) {
+    if (!c || isSlot(c.templateId) || !c.faceUp) continue
+    sum += cardValue(templates, c.templateId)
+  }
+  return sum
+}
+
+/** First player: highest sum of face-up starters (ties → lowest seat index wins). */
 function starterFromOpening(table: TableState, templates: Record<string, CardTemplate>, pCount: number): number {
   let best = -Infinity
   let leader = 0
   for (let p = 0; p < pCount; p++) {
-    let sum = 0
-    for (const i of [0, 1]) {
-      const c = table.zones[gridZone(p)]!.cards[i]
-      if (c) sum += cardValue(templates, c.templateId)
-    }
+    const sum = sumOpeningVisibleOnGrid(table, templates, p)
     if (sum > best) {
       best = sum
       leader = p
     }
   }
   return leader
+}
+
+function allPlayersOpeningReady(table: TableState, pCount: number): boolean {
+  for (let p = 0; p < pCount; p++) {
+    if (countFaceUpNonSlotOnGrid(table, p) !== 2) return false
+  }
+  return true
 }
 
 function othersAfterSkyjo(finisher: number, pCount: number): number[] {
@@ -527,7 +552,7 @@ function ensureSlotTemplate(templates: Record<string, CardTemplate>): void {
 }
 
 export interface SkyjoGameState {
-  phase: 'play' | 'final' | 'roundOver'
+  phase: 'opening' | 'play' | 'final' | 'roundOver'
   playerCount: number
   currentPlayer: number
   message: string
@@ -551,6 +576,19 @@ function buildLegalActions(table: TableState, gs: SkyjoGameState): GameAction[] 
   if (gs.phase === 'roundOver') return []
   const p = gs.currentPlayer
   if (gs.phase === 'final' && gs.finalQueue.length > 0 && gs.finalQueue[0] !== p) return []
+
+  if (gs.phase === 'opening') {
+    const actions: GameAction[] = []
+    const g = table.zones[gridZone(p)]!.cards
+    if (countFaceUpNonSlotOnGrid(table, p) >= 2) return []
+    for (let i = 0; i < GRID; i++) {
+      const c = g[i]
+      if (c && !isSlot(c.templateId) && !c.faceUp) {
+        actions.push({ type: 'skyjoOpeningFlip', gridIndex: i })
+      }
+    }
+    return actions
+  }
 
   if (gs.pendingDraw) {
     const actions: GameAction[] = []
@@ -897,6 +935,12 @@ function selectAiSkyjo(
     return legal[Math.floor(rng() * legal.length)]!
   }
 
+  if (gameState.phase === 'opening') {
+    const flips = legal.filter((a): a is Extract<GameAction, { type: 'skyjoOpeningFlip' }> => a.type === 'skyjoOpeningFlip')
+    if (flips.length === 0) return legal[0]!
+    return flips[Math.floor(rng() * flips.length)]!
+  }
+
   if (gameState.pendingDraw) {
     if (difficulty === 'easy' && rng() < 0.4) {
       const swaps = legal.filter((a) => a.type === 'skyjoSwapDrawn')
@@ -1013,23 +1057,13 @@ const skyjoModule: GameModule<SkyjoGameState> = {
       pushDiscard(table, starterCard)
     }
 
-    for (let p = 0; p < pCount; p++) {
-      const g = table.zones[gridZone(p)]!.cards
-      for (const idx of [0, 1]) {
-        const c = g[idx]
-        if (c) c.faceUp = true
-      }
-    }
-
-    const first = starterFromOpening(table, merged, pCount)
-
     return {
       table,
       gameState: {
-        phase: 'play',
+        phase: 'opening',
         playerCount: pCount,
-        currentPlayer: first,
-        message: `${first === 0 ? 'You start' : `${playerSeatLabel(first)} starts`} (highest sum of two opening cards). Draw or take discard.`,
+        currentPlayer: 0,
+        message: `${playerSeatLabel(0)} — flip two face-down cards on your grid (then each other player, in turn).`,
         pendingDraw: null,
         pendingFromDiscard: false,
         skyjoFinisher: null,
@@ -1065,6 +1099,68 @@ const skyjoModule: GameModule<SkyjoGameState> = {
     recycleDiscardIfDrawEmpty(t, rngFn, gameState.reshuffleDiscardWhenDrawEmpty)
 
     const gs = gameState
+
+    if (gs.phase === 'opening') {
+      if (action.type !== 'skyjoOpeningFlip') {
+        return { table, gameState, error: 'Flip a face-down card on your grid.' }
+      }
+      const i = action.gridIndex
+      if (i < 0 || i >= GRID) return { table, gameState, error: 'Bad grid index.' }
+      const gOpen = t.zones[gridZone(current)]!.cards
+      const target = gOpen[i]
+      if (!target || isSlot(target.templateId) || target.faceUp) {
+        return { table, gameState, error: 'Choose a face-down card on your grid.' }
+      }
+      if (countFaceUpNonSlotOnGrid(t, current) >= 2) {
+        return { table, gameState, error: 'You have already flipped two cards.' }
+      }
+      target.faceUp = true
+      for (let k = 0; k < 8; k++) {
+        if (!clearMatchingColumns(t, current, templates)) break
+      }
+
+      if (allPlayersOpeningReady(t, pCount)) {
+        const first = starterFromOpening(t, templates, pCount)
+        return {
+          table: t,
+          gameState: {
+            ...gs,
+            phase: 'play',
+            currentPlayer: first,
+            pendingDraw: null,
+            pendingFromDiscard: false,
+            message: `${first === 0 ? 'You start' : `${playerSeatLabel(first)} starts`} (highest sum of two opening cards). Draw or take discard.`,
+          },
+        }
+      }
+
+      const nowUp = countFaceUpNonSlotOnGrid(t, current)
+      if (nowUp >= 2) {
+        const nx = (current + 1) % pCount
+        return {
+          table: t,
+          gameState: {
+            ...gs,
+            phase: 'opening',
+            currentPlayer: nx,
+            pendingDraw: null,
+            pendingFromDiscard: false,
+            message:
+              nx === 0
+                ? 'Your turn — flip two face-down cards on your grid.'
+                : `${playerSeatLabel(nx)} — flip two face-down cards on your grid.`,
+          },
+        }
+      }
+
+      return {
+        table: t,
+        gameState: {
+          ...gs,
+          message: 'Flip one more face-down card on your grid.',
+        },
+      }
+    }
 
     const endTurn = (next: Partial<SkyjoGameState>, finished: number): ApplyResult<SkyjoGameState> => {
       recycleDiscardIfDrawEmpty(t, rngFn, gs.reshuffleDiscardWhenDrawEmpty)

--- a/src/games/skyjo/skyjo.test.ts
+++ b/src/games/skyjo/skyjo.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import '../../bootstrap'
 import { createSession } from '../../session'
-import type { GameAction } from '../../core/types'
-import type { TableState } from '../../core/types'
+import type { CardTemplate, GameAction, TableState } from '../../core/types'
 import type { SkyjoGameState } from './index'
 
 function visibleOpeningSum(table: TableState, templates: Record<string, CardTemplate>, p: number): number {
@@ -52,14 +51,14 @@ describe('Skyjo opening phase', () => {
   it('rejects flipping a face-up cell', () => {
     const session = createSession('skyjo', () => 0.42, undefined, { skipMatch: true, aiCount: 0 })
     const mod = session.module
-    let { table, gameState } = session
-    const gs0 = gameState as SkyjoGameState
-    expect(gs0.phase).toBe('opening')
+    let { table } = session
+    let gameState = session.gameState as SkyjoGameState
+    expect(gameState.phase).toBe('opening')
 
     const r1 = mod.applyAction(table, gameState, { type: 'skyjoOpeningFlip', gridIndex: 0 } as GameAction)
     expect(r1.error).toBeUndefined()
     table = r1.table
-    gameState = r1.gameState
+    gameState = r1.gameState as SkyjoGameState
 
     const rBad = mod.applyAction(table, gameState, { type: 'skyjoOpeningFlip', gridIndex: 0 } as GameAction)
     expect(rBad.error).toBeDefined()
@@ -68,7 +67,8 @@ describe('Skyjo opening phase', () => {
   it('after two flips for one player, advances to play with correct starter', () => {
     const session = createSession('skyjo', () => 0.42, undefined, { skipMatch: true, aiCount: 0 })
     const mod = session.module
-    let { table, gameState } = session
+    let { table } = session
+    let gameState = session.gameState as SkyjoGameState
     const templates = table.templates
 
     const r1 = mod.applyAction(table, gameState, { type: 'skyjoOpeningFlip', gridIndex: 2 } as GameAction)
@@ -89,13 +89,13 @@ describe('Skyjo opening phase', () => {
   it('two-player opening completes and starter has max visible sum', () => {
     const session = createSession('skyjo', () => 0.77, undefined, { skipMatch: true, aiCount: 1 })
     const mod = session.module
-    let { table, gameState } = session
+    let { table } = session
+    let gameState = session.gameState as SkyjoGameState
     const templates = table.templates
-    const pCount = (gameState as SkyjoGameState).playerCount
+    const pCount = gameState.playerCount
     expect(pCount).toBe(2)
 
-    while ((gameState as SkyjoGameState).phase === 'opening') {
-      const gs = gameState as SkyjoGameState
+    while (gameState.phase === 'opening') {
       const legals = mod.getLegalActions(table, gameState)
       const flips = legals.filter((a): a is Extract<GameAction, { type: 'skyjoOpeningFlip' }> => a.type === 'skyjoOpeningFlip')
       expect(flips.length).toBeGreaterThan(0)
@@ -103,10 +103,10 @@ describe('Skyjo opening phase', () => {
       const r = mod.applyAction(table, gameState, pick)
       expect(r.error).toBeUndefined()
       table = r.table
-      gameState = r.gameState
+      gameState = r.gameState as SkyjoGameState
     }
 
-    const final = gameState as SkyjoGameState
+    const final = gameState
     expect(final.phase).toBe('play')
     expect(countFaceUpNonSlot(table, 0)).toBe(2)
     expect(countFaceUpNonSlot(table, 1)).toBe(2)

--- a/src/games/skyjo/skyjo.test.ts
+++ b/src/games/skyjo/skyjo.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import '../../bootstrap'
+import { createSession } from '../../session'
+import type { GameAction } from '../../core/types'
+import type { TableState } from '../../core/types'
+import type { SkyjoGameState } from './index'
+
+function visibleOpeningSum(table: TableState, templates: Record<string, CardTemplate>, p: number): number {
+  let s = 0
+  for (const c of table.zones[`grid:${p}`]!.cards) {
+    if (!c || c.templateId === '__slot__' || !c.faceUp) continue
+    const v = templates[c.templateId]?.value
+    if (typeof v === 'number') s += v
+  }
+  return s
+}
+
+function countFaceUpNonSlot(table: TableState, p: number): number {
+  let n = 0
+  for (const c of table.zones[`grid:${p}`]!.cards) {
+    if (c && c.templateId !== '__slot__' && c.faceUp) n++
+  }
+  return n
+}
+
+function expectedStarter(table: TableState, templates: Record<string, CardTemplate>, pCount: number): number {
+  let best = -Infinity
+  let leader = 0
+  for (let p = 0; p < pCount; p++) {
+    const sum = visibleOpeningSum(table, templates, p)
+    if (sum > best) {
+      best = sum
+      leader = p
+    }
+  }
+  return leader
+}
+
+describe('Skyjo opening phase', () => {
+  it('starts in opening with all grid cards face-down', () => {
+    const session = createSession('skyjo', () => 0.42, undefined, { skipMatch: true, aiCount: 0 })
+    const gs = session.gameState as SkyjoGameState
+    expect(gs.phase).toBe('opening')
+    expect(gs.currentPlayer).toBe(0)
+    const g0 = session.table.zones['grid:0']!.cards
+    expect(g0.length).toBe(12)
+    for (const c of g0) {
+      expect(c?.faceUp).toBe(false)
+    }
+  })
+
+  it('rejects flipping a face-up cell', () => {
+    const session = createSession('skyjo', () => 0.42, undefined, { skipMatch: true, aiCount: 0 })
+    const mod = session.module
+    let { table, gameState } = session
+    const gs0 = gameState as SkyjoGameState
+    expect(gs0.phase).toBe('opening')
+
+    const r1 = mod.applyAction(table, gameState, { type: 'skyjoOpeningFlip', gridIndex: 0 } as GameAction)
+    expect(r1.error).toBeUndefined()
+    table = r1.table
+    gameState = r1.gameState
+
+    const rBad = mod.applyAction(table, gameState, { type: 'skyjoOpeningFlip', gridIndex: 0 } as GameAction)
+    expect(rBad.error).toBeDefined()
+  })
+
+  it('after two flips for one player, advances to play with correct starter', () => {
+    const session = createSession('skyjo', () => 0.42, undefined, { skipMatch: true, aiCount: 0 })
+    const mod = session.module
+    let { table, gameState } = session
+    const templates = table.templates
+
+    const r1 = mod.applyAction(table, gameState, { type: 'skyjoOpeningFlip', gridIndex: 2 } as GameAction)
+    expect(r1.error).toBeUndefined()
+    table = r1.table
+    gameState = r1.gameState as SkyjoGameState
+    expect(gameState.phase).toBe('opening')
+
+    const r2 = mod.applyAction(table, gameState, { type: 'skyjoOpeningFlip', gridIndex: 5 } as GameAction)
+    expect(r2.error).toBeUndefined()
+    table = r2.table
+    gameState = r2.gameState as SkyjoGameState
+
+    expect(gameState.phase).toBe('play')
+    expect(gameState.currentPlayer).toBe(expectedStarter(table, templates, 1))
+  })
+
+  it('two-player opening completes and starter has max visible sum', () => {
+    const session = createSession('skyjo', () => 0.77, undefined, { skipMatch: true, aiCount: 1 })
+    const mod = session.module
+    let { table, gameState } = session
+    const templates = table.templates
+    const pCount = (gameState as SkyjoGameState).playerCount
+    expect(pCount).toBe(2)
+
+    while ((gameState as SkyjoGameState).phase === 'opening') {
+      const gs = gameState as SkyjoGameState
+      const legals = mod.getLegalActions(table, gameState)
+      const flips = legals.filter((a): a is Extract<GameAction, { type: 'skyjoOpeningFlip' }> => a.type === 'skyjoOpeningFlip')
+      expect(flips.length).toBeGreaterThan(0)
+      const pick = flips[0]!
+      const r = mod.applyAction(table, gameState, pick)
+      expect(r.error).toBeUndefined()
+      table = r.table
+      gameState = r.gameState
+    }
+
+    const final = gameState as SkyjoGameState
+    expect(final.phase).toBe('play')
+    expect(countFaceUpNonSlot(table, 0)).toBe(2)
+    expect(countFaceUpNonSlot(table, 1)).toBe(2)
+    expect(final.currentPlayer).toBe(expectedStarter(table, templates, pCount))
+  })
+})

--- a/src/rules/skyjo.md
+++ b/src/rules/skyjo.md
@@ -12,9 +12,9 @@ Skyjo is a card game for several players. Everyone has their own **grid** of twe
 ## Setup (typical)
 
 1. Each player gets twelve cards on a grid, all face-down at first.
-1. Two starting cards per player are turned face-up (which two varies by group; this app follows the module’s deal).
+1. Two starting cards per player are turned face-up (which two varies by group). **In this app**, each player **chooses** two face-down cards on their own grid to flip, one at a time, in seat order, before the round proper begins.
 1. One starter card may start the discard pile; the rest form a draw pile.
-1. The first player is often whoever has the highest sum on their two visible starters (this app uses that rule).
+1. The first player is whoever has the **highest sum** on their two visible starters (ties go to the earlier seat in table order).
 
 ## Your turn (summary)
 
@@ -56,4 +56,5 @@ Skyjo is a card game for several players. Everyone has their own **grid** of twe
 
 1. Use **Start deal** / **New deal** after changing options so the next deal uses them.
 1. Per-seat **AI difficulty** applies to computer players.
-1. Follow the on-screen hints for draw, discard, swap, and dump-and-flip.
+1. When a new round begins, **flip two cards** on your grid when it is your turn in the opening step; then follow the on-screen hints for draw, discard, swap, and dump-and-flip.
+1. Legal grid targets for the current action are slightly **emphasized on hover** (and keyboard focus) so the card you are about to use is easier to see.

--- a/src/ui/TableView.css
+++ b/src/ui/TableView.css
@@ -337,6 +337,28 @@
   align-items: center;
 }
 
+/* Legal prep targets (e.g. Skyjo): subtle lift on hover/focus so the actionable card reads clearly */
+.tableView__cardSlot--prepTarget .tableView__cardSlotPose {
+  transition: transform 0.15s ease;
+}
+
+.tableView__cardSlot--prepTarget:hover .tableView__cardSlotPose,
+.tableView__cardSlot--prepTarget:focus-within .tableView__cardSlotPose {
+  transform: scale(1.1);
+  z-index: 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tableView__cardSlot--prepTarget .tableView__cardSlotPose {
+    transition: none;
+  }
+
+  .tableView__cardSlot--prepTarget:hover .tableView__cardSlotPose,
+  .tableView__cardSlot--prepTarget:focus-within .tableView__cardSlotPose {
+    transform: none;
+  }
+}
+
 .tableView__cards--stack .tableView__cardSlot {
   position: absolute;
   left: 0;

--- a/src/ui/TableView.tsx
+++ b/src/ui/TableView.tsx
@@ -49,6 +49,11 @@ export interface TableViewProps {
    * (e.g. Skyjo `grid`, Go Fish `hand`). Omit when the game has no per-player turn UI.
    */
   activeTurnHighlight?: ActiveTurnHighlight | null
+  /**
+   * Optional: mark grid/spread card slots that are legal prep targets (hover/focus scale).
+   * Shell derives indices from legal actions (e.g. Skyjo swap / dump / opening flip).
+   */
+  prepTarget?: { zoneId: string; indices: ReadonlySet<number> } | null
 }
 
 function zoneAllowsIntent(zoneId: string, allowlist: readonly string[] | undefined): boolean {
@@ -138,6 +143,7 @@ export function TableView({
   intentZoneAllowlist,
   pendingStacksColumn,
   activeTurnHighlight,
+  prepTarget,
 }: TableViewProps) {
   const order = table.zoneOrder.length ? table.zoneOrder : Object.keys(table.zones)
   const layoutGroups = useMemo(() => buildLayoutGroups(order, table.zones), [order, table.zones])
@@ -261,6 +267,8 @@ export function TableView({
               const showFace = shouldShowFaceForViewer(zone, card, idx, humanPlayerIndex)
               const tmpl = table.templates[card.templateId]
               const cardInteractive = zoneInteractive && zone.kind !== 'stack'
+              const isPrepTarget =
+                !!prepTarget && prepTarget.zoneId === zid && prepTarget.indices.has(idx) && cardInteractive
               const inner = (
                 <CardView card={card} template={tmpl} showFace={showFace} presentationOnly={cardInteractive} />
               )
@@ -269,7 +277,10 @@ export function TableView({
                   ? undefined
                   : { transform: `rotate(${-12 + idx * 8}deg) translateY(${idx * 2}px)` }
               return (
-                <div key={card.instanceId} className="tableView__cardSlot tableView__cardSlot--enter">
+                <div
+                  key={card.instanceId}
+                  className={`tableView__cardSlot tableView__cardSlot--enter${isPrepTarget ? ' tableView__cardSlot--prepTarget' : ''}`}
+                >
                   <div className="tableView__cardSlotPose" style={poseStyle}>
                     {cardInteractive ? (
                       <button


### PR DESCRIPTION
## Summary

- **Opening phase:** New rounds start with every grid card face-down. Each player (seat order) flips exactly two of their own cards via `skyjoOpeningFlip`; then play begins. First player is whoever has the highest sum on their two revealed starters (ties → lower seat index).
- **Prep UI:** `TableView` accepts optional `prepTarget` (zone + legal indices). Skyjo passes targets derived from legal actions for opening flips, swap/dump, dump-only flip step, and take-discard. Matching slots get ~10% scale on hover / `:focus-within`, disabled under `prefers-reduced-motion: reduce`.
- **Multiplayer:** Host rejects intents when the sender’s seat is not Skyjo’s `currentPlayer` (including opening).

## Tests / docs

- `src/games/skyjo/skyjo.test.ts`: setup, illegal flip, single-player completion, two-player completion + starter.
- `src/rules/skyjo.md`, `docs/games/skyjo.md`: setup and UI notes updated.

## Note

Branch was created from the previous local branch; if the PR should target a different base, change it in GitHub.