### PR TITLE
terraform(prod): TURN ASG idle scale-to-zero

### DIFF
--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,6 +1,7 @@
 turn_compute_mode           = "asg"
 turn_instance_type          = "t3.micro"
-turn_asg_min_size           = 1
-turn_asg_desired_capacity   = 1
+# Idle scale-to-zero (min/desired 0); Lambdas only adjust desired capacity. CPU target disabled to avoid ASG scaling in an idle coturn instance.
+turn_asg_min_size           = 0
+turn_asg_desired_capacity   = 0
 turn_asg_max_size           = 3
-turn_asg_cpu_target_percent = 60
+turn_asg_cpu_target_percent = 0


### PR DESCRIPTION
## Summary

Updates `terraform/prod.tfvars` so the production coturn **Auto Scaling Group** idles at **no instances**: `turn_asg_min_size` and `turn_asg_desired_capacity` are **0**, `turn_asg_max_size` stays **3**.

Existing Lambda behavior already matches this model:

- **Start Relay** (`/turn/start`) calls `startTurnCapacity()` → `SetDesiredCapacity` to at least **1** (`lambda/src/turnEc2Ops.ts`).
- **Scheduled idle** Lambda calls `stopTurnCapacity()` → `SetDesiredCapacity(turnAsgMinSize)` from env `TURN_ASG_MIN_SIZE` (mirrors Terraform `turn_asg_min_size`), after the 4h uptime and usage-grace checks in `turnScheduled.ts`.

After **terraform apply** (e.g. via Deploy), HTTP and scheduled Lambdas pick up `TURN_ASG_MIN_SIZE=0` from Terraform.

## Plan challenge (why not toggle min/max in code?)

1. **Do not set `MaxSize` to 0 when idle** — an ASG must keep `MaxSize >= 1` (or you cannot launch). **Max capacity does not cost money**; it is only an upper bound. The right idle shape is **min 0, max 3, desired 0** — only **desired capacity** moves.

2. **Turn off CPU target tracking** (`turn_asg_cpu_target_percent = 0`) — with `min_size = 0`, the previous **60%** target-tracking policy can **scale in** when average CPU is low, tearing down a running coturn that is simply waiting for TURN traffic. Idle shutdown should be driven only by **Start /turn/start** and **turn-scheduled**, not by CloudWatch CPU.

## Deploy note

Applying this will set ASG desired to **0** and terminate the warm instance when Terraform reconciles (expected once).