### PR TITLE
Omit moveLedger from multiplayer peer snapshots

### DIFF
--- a/docs/features/table-ai-llm.md
+++ b/docs/features/table-ai-llm.md
@@ -32,8 +32,9 @@ The Lambda assembles the user prompt in [`buildTableAiUserPrompt`](../../lambda/
 
 ## Move ledger
 
-- On each successful **local** apply (human or AI), the shell appends one ledger row (`human`, `heuristic`, or `llm`).
-- This lets the model notice patterns (e.g. another seat consistently using LLM vs human timing).
+- On each successful apply on the **authoritative browser** (solo table, or multiplayer **host** applying local + remote intents), the shell appends one ledger row (`human`, `heuristic`, or `llm`).
+- **Multiplayer clients** never receive `moveLedger` on viewer snapshots—we trust the host only; history exists for host-side LLM context and solo `localStorage` resume (full snapshot serialization).
+- This lets the solo/host LLM notice patterns when `moveHistory` is populated.
 - Optional module hook **`summarizeLedgerAction`** shortens the stored line; otherwise a type + payload snippet is used.
 
 ## Per-game overrides

--- a/src/net/sessionSnapshot.test.ts
+++ b/src/net/sessionSnapshot.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import '../games/blackjack'
 import { createSession } from '../session'
-import { parseLocalSessionSnapshot, parseSessionSnapshot, serializeSessionSnapshot } from './sessionSnapshot'
+import {
+  parseLocalSessionSnapshot,
+  parseSessionSnapshot,
+  serializeSessionSnapshot,
+  serializeSessionSnapshotForViewer,
+} from './sessionSnapshot'
+
+describe('serializeSessionSnapshotForViewer', () => {
+  it('omits moveLedger so peers trust host table state only', () => {
+    const sess = createSession('blackjack', () => 0.5)
+    sess.moveLedger = [{ seq: 0, seat: 0, policy: 'human', summary: 'bj:hit' }]
+    const full = serializeSessionSnapshot(sess)
+    expect(full?.moveLedger).toHaveLength(1)
+    const peer = serializeSessionSnapshotForViewer(sess, 0, false)
+    expect(peer?.moveLedger).toBeUndefined()
+  })
+})
 
 describe('parseLocalSessionSnapshot', () => {
   it('restores session without net metadata', () => {

--- a/src/net/sessionSnapshot.ts
+++ b/src/net/sessionSnapshot.ts
@@ -60,7 +60,11 @@ export interface SessionSnapshotWire {
   gameState: unknown
   match?: MatchState
   aiPlayerConfig?: AiPlayerConfig
-  /** Optional move history for LLM / UI (solo resume). */
+  /**
+   * Host-local move history (LLM / solo resume). Present only on **full** snapshots from
+   * {@link serializeSessionSnapshot}; **omitted** from {@link serializeSessionSnapshotForViewer}
+   * so peers never depend on replicated ledger state.
+   */
   moveLedger?: MoveLedgerEntry[]
   /** Host fills per client: network seat index (matches {@link PeerHostSnapshot.seat}). */
   viewerSeat?: number
@@ -194,8 +198,10 @@ export function serializeSessionSnapshotForViewer(
 ): SessionSnapshotWire | null {
   const wire = serializeSessionSnapshot(session)
   if (!wire) return null
+  const peerFields = { ...wire }
+  delete peerFields.moveLedger
   return {
-    ...wire,
+    ...peerFields,
     table: projectTableForViewer(session.table, viewerSeat, spectator),
     gameState: projectGameStateForViewer(session.gameState, viewerSeat, spectator),
     viewerSeat,


### PR DESCRIPTION
## Intent

Multiplayer clients should not depend on replicated `moveLedger`; we trust the host's authoritative state (matches product decision).

## Changes

- `serializeSessionSnapshotForViewer` deletes `moveLedger` from the wire object before projecting table/gameState for each seat.
- Full `serializeSessionSnapshot` still includes `moveLedger` for solo `localStorage` resume and any host-local payloads.
- Doc update in `docs/features/table-ai-llm.md`; JSDoc on `SessionSnapshotWire.moveLedger`.
- Vitest: assert viewer snapshots omit ledger while full snapshots keep it.